### PR TITLE
Add automated age exempt determination

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CertificationBusinessProcess < Strata::BusinessProcess
-  # TODO: system process to do exemption check
   system_process("ex_parte_exemption_check", ->(kase) {
     ExemptionDeterminationService.determine(kase)
   })

--- a/reporting-app/app/forms/demo/certifications/base_create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/base_create_form.rb
@@ -13,6 +13,7 @@ module Demo
 
       attribute :member_email, :string
       strata_attribute :member_name, :name
+      strata_attribute :date_of_birth, :us_date
       attribute :case_number, :string
 
       # TODO: add validation you can't set both certification_type and the other params?
@@ -39,8 +40,20 @@ module Demo
       # message about relationship to number_of_months_to_certify
       validates :lookback_period, numericality: { greater_than_or_equal_to: Proc.new { |record| record.number_of_months_to_certify } }
 
+      validate :date_of_birth_must_be_in_past
+
       def locked_type_params?
         certification_type.present?
+      end
+
+      private
+
+      def date_of_birth_must_be_in_past
+        return unless date_of_birth.present?
+
+        if date_of_birth > Date.current
+          errors.add(:date_of_birth, "must be in the past")
+        end
       end
     end
   end

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -3,7 +3,7 @@
 module Demo
   module Certifications
     class CreateForm < BaseCreateForm
-      EX_PARTE_SCENARIO_OPTIONS = [ "No data", "Partially met work hours requirement", "Fully met work hours requirement" ]
+      EX_PARTE_SCENARIO_OPTIONS = [ "No data", "Partially met work hours requirement", "Fully met work hours requirement", "Meets age-based exemption requirement" ]
 
       attribute :ex_parte_scenario, :enum, options: EX_PARTE_SCENARIO_OPTIONS
 
@@ -33,12 +33,26 @@ module Demo
 
         case self.ex_parte_scenario
         when "Partially met work hours requirement"
-          member_data.merge!(FactoryBot.build(:certification_member_data, :partially_met_work_hours_requirement, cert_date: self.certification_date).attributes.compact)
+          member_data.merge!(
+            FactoryBot.build(
+              :certification_member_data, :partially_met_work_hours_requirement, cert_date: self.certification_date
+            ).attributes.compact
+          )
         when "Fully met work hours requirement"
-          member_data.merge!(FactoryBot.build(:certification_member_data, :fully_met_work_hours_requirement, cert_date: self.certification_date, num_months: self.number_of_months_to_certify).attributes.compact)
-        else
-          # nothing
+          member_data.merge!(
+            FactoryBot.build(
+              :certification_member_data, :fully_met_work_hours_requirement, cert_date: self.certification_date, num_months: self.number_of_months_to_certify
+            ).attributes.compact)
+        when "Meets age-based exemption requirement"
+          member_data.merge!(
+            FactoryBot.build(
+              :certification_member_data, :meets_age_based_exemption_requirement, cert_date: self.certification_date
+            ).attributes.compact
+          )
         end
+
+        member_data = ::Certifications::MemberData.new(member_data)
+        member_data.date_of_birth = self.date_of_birth if self.date_of_birth.present?
 
         @certification = FactoryBot.build(
           :certification,
@@ -46,7 +60,7 @@ module Demo
           email: self.member_email,
           case_number: self.case_number,
           certification_requirements: certification_requirements,
-          member_data: ::Certifications::MemberData.new(member_data),
+          member_data: member_data,
         )
       end
     end

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -4,6 +4,8 @@ require_relative "certifications/member_data"
 require_relative "certifications/requirements"
 
 class Certification < ApplicationRecord
+  include Determinable
+
   attribute :member_id, :string
   attribute :case_number, :string
 

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -2,6 +2,7 @@
 
 class Certifications::MemberData < ValueObject
   include ActiveModel::AsJsonAttributeType
+  include Strata::Attributes
 
   class ContactData < ValueObject
     include ActiveModel::AsJsonAttributeType
@@ -33,6 +34,7 @@ class Certifications::MemberData < ValueObject
   attribute :account_email, :string
   attribute :contact, ContactData.to_type
   attribute :name, ActiveModel::Type::Json.new(Strata::Name)
+  attribute :date_of_birth, :date
 
   attribute :payroll_accounts, :array, of: PayrollAccount.to_type
 end

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -31,5 +31,12 @@
 # @see Strata::Determinable for the +record_determination!+ method to use in models
 #
 class Determination < Strata::Determination
-  # Add custom enums, validations, scopes, and callbacks here
+  enum :decision_method, { automated: "automated", manual: "manual" }
+  enum :reason, {
+    age_under_19_exempt: "age_under_19_exempt",
+    age_over_65_exempt: "age_over_65_exempt",
+    pregnancy_exempt: "pregnancy_exempt",
+    american_indian_alaska_native_exempt: "american_indian_alaska_native_exempt"
+  }
+  enum :outcome, { compliant: "compliant", exempt: "exempt" }
 end

--- a/reporting-app/app/models/rules/exemption_ruleset.rb
+++ b/reporting-app/app/models/rules/exemption_ruleset.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Rules
+  # Implements eligibility rules for age-based Medicaid exemptions.
+  # Inherits from Strata::Rules::MedicaidRuleset and adds exemption-specific logic.
+  class ExemptionRuleset < Strata::Rules::MedicaidRuleset
+    def age_under_19(age)
+      return if age.nil?
+
+      age < 19
+    end
+
+    def eligible_for_age_exemption(age_under_19, age_over_65)
+      return if age_under_19.nil? && age_over_65.nil?
+
+      [ age_under_19, age_over_65 ].any?
+    end
+  end
+end

--- a/reporting-app/app/services/exemption_determination_service.rb
+++ b/reporting-app/app/services/exemption_determination_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ExemptionDeterminationService
+  class << self
+    def determine(kase)
+      certification = Certification.find(kase.certification_id)
+      evaluation_date = certification.certification_requirements.certification_date
+      date_of_birth = extract_date_of_birth(certification)
+      eligibility_fact = evaluate_exemption_eligibility(date_of_birth, evaluation_date)
+
+      kase.determine_ex_parte_exemption(eligibility_fact)
+    end
+
+    private
+
+    def evaluate_exemption_eligibility(date_of_birth, evaluation_date)
+      return Strata::RulesEngine::Fact.new("no-op", false) unless date_of_birth
+
+      ruleset = Rules::ExemptionRuleset.new
+      engine = Strata::RulesEngine.new(ruleset)
+
+      engine.set_facts(
+        date_of_birth: date_of_birth,
+        evaluated_on: evaluation_date
+      )
+
+      engine.evaluate(:eligible_for_age_exemption)
+    end
+
+    def extract_date_of_birth(certification)
+      return nil unless certification.member_data
+
+      certification.member_data.date_of_birth
+    end
+  end
+end

--- a/reporting-app/app/views/demo/certifications/new.html.erb
+++ b/reporting-app/app/views/demo/certifications/new.html.erb
@@ -15,6 +15,7 @@
 <%= strata_form_with model: @form, url: demo_certifications_path do |f| %>
   <%= f.text_field :member_email %>
   <%= f.name :member_name %>
+  <%= f.date_picker :date_of_birth %>
   <%= f.text_field :case_number, label: t("certifications.case_number") %>
 
   <%= f.hidden_field :certification_type, value: @form.certification_type %>

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -11,6 +11,64 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
     allow(Strata::EventManager).to receive(:publish).and_call_original
   end
 
+  describe 'ex_parte_exemption_check' do
+    before do
+      certification_case.update!(
+        business_process_current_step: "ex_parte_exemption_check"
+      )
+    end
+
+    context 'when applicant is eligible for exemption' do
+      let(:eligibility_fact) do
+        Strata::RulesEngine::Fact.new(
+          "no-op",
+          true,
+          reasons: [ { rule_name: "eligible_for_age_exemption", reason: "age_under_19", rule_result: true } ]
+        )
+      end
+
+      it 'transitions to end' do
+        # Step 1: Case has been created and is on ex_parte_exemption_check step
+        expect(certification_case.business_process_instance.current_step).to eq("ex_parte_exemption_check")
+        expect(certification_case.member_status).to eq(CertificationCase::MEMBER_STATUS_AWAITING_REPORT)
+        expect(certification_case).to be_open
+
+        # Step 2: System process determines applicant is eligible for exemption
+        certification_case.determine_ex_parte_exemption(eligibility_fact)
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq("end")
+        expect(certification_case.member_status).to eq(CertificationCase::MEMBER_STATUS_EXEMPT)
+        expect(certification_case).to be_closed
+      end
+    end
+
+    context 'when applicant is not eligible for exemption' do
+      let(:eligibility_fact) do
+        Strata::RulesEngine::Fact.new(
+          "no-op",
+          false
+        )
+      end
+
+      it 'transitions to ex_parte_community_engagement_check' do
+        # Step 1: Case has been created and is on ex_parte_exemption_check step
+        expect(certification_case.business_process_instance.current_step).to eq("ex_parte_exemption_check")
+        expect(certification_case.member_status).to eq(CertificationCase::MEMBER_STATUS_AWAITING_REPORT)
+        expect(certification_case).to be_open
+
+        # Step 2: System process determines applicant is not eligible for exemption
+        certification_case.determine_ex_parte_exemption(eligibility_fact)
+        certification_case.reload
+
+        # Case transitions to report_activities step is hardcoded in the business process
+        expect(certification_case.business_process_instance.current_step).to eq("report_activities")
+        expect(certification_case.member_status).to eq(CertificationCase::MEMBER_STATUS_AWAITING_REPORT)
+        expect(certification_case).to be_open
+      end
+    end
+  end
+
   describe 'activity report workflow' do
     it 'transitions through the full workflow and updates member status correctly' do
       # Step 1: Case starts on report_activities

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -19,11 +19,21 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
     end
 
     context 'when applicant is eligible for exemption' do
+      let(:age_fact) do
+        Strata::RulesEngine::Fact.new(
+          :age_under_19, true, reasons: []
+        )
+      end
+      let(:other_age_fact) do
+        Strata::RulesEngine::Fact.new(
+          :age_over_65, false, reasons: []
+        )
+      end
       let(:eligibility_fact) do
         Strata::RulesEngine::Fact.new(
-          "no-op",
+          :age_eligibility,
           true,
-          reasons: [ { rule_name: "eligible_for_age_exemption", reason: "age_under_19", rule_result: true } ]
+          reasons: [ age_fact, other_age_fact ]
         )
       end
 

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     end
 
     trait :partially_met_work_hours_requirement do
+      date_of_birth { cert_date - 35.years } # 35 years old (ineligible for age exemption)
       payroll_accounts {
         [
           {
@@ -46,6 +47,7 @@ FactoryBot.define do
     end
 
     trait :fully_met_work_hours_requirement do
+      date_of_birth { cert_date - 35.years }
       payroll_accounts {
         [
           {
@@ -62,6 +64,10 @@ FactoryBot.define do
           }
         ]
       }
+    end
+
+    trait :meets_age_based_exemption_requirement do
+      date_of_birth { cert_date - 18.years } # 18 years old (eligible for age exemption)
     end
   end
 end

--- a/reporting-app/spec/factories/determination_factory.rb
+++ b/reporting-app/spec/factories/determination_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :determination do
+    subject { association :certification }
+    decision_method { 'automated' }
+    reason { 'age_under_19_exempt' }
+    outcome { 'exempt' }
+    determination_data { { reasons: { rule: 'passed' } } }
+    determined_at { Time.current }
+  end
+end

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#accept_activity_report' do
-    it 'sets approval status and closes case' do
-      allow(Strata::EventManager).to receive(:publish)
+    before { allow(Strata::EventManager).to receive(:publish) }
 
+    it 'sets approval status and closes case' do
       certification_case.accept_activity_report
       certification_case.reload
 
@@ -110,8 +110,6 @@ RSpec.describe CertificationCase, type: :model do
     end
 
     it 'publishes DeterminedRequirementsMet event' do
-      allow(Strata::EventManager).to receive(:publish)
-
       certification_case.accept_activity_report
 
       expect(Strata::EventManager).to have_received(:publish).with(
@@ -122,9 +120,9 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#deny_activity_report' do
-    it 'sets denial status' do
-      allow(Strata::EventManager).to receive(:publish)
+    before { allow(Strata::EventManager).to receive(:publish) }
 
+    it 'sets denial status' do
       certification_case.deny_activity_report
       certification_case.reload
 
@@ -133,8 +131,6 @@ RSpec.describe CertificationCase, type: :model do
     end
 
     it 'publishes DeterminedRequirementsNotMet event' do
-      allow(Strata::EventManager).to receive(:publish)
-
       certification_case.deny_activity_report
 
       expect(Strata::EventManager).to have_received(:publish).with(
@@ -145,9 +141,9 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#accept_exemption_request' do
-    it 'sets approval status and closes case' do
-      allow(Strata::EventManager).to receive(:publish)
+    before { allow(Strata::EventManager).to receive(:publish) }
 
+    it 'sets approval status and closes case' do
       certification_case.accept_exemption_request
       certification_case.reload
 
@@ -157,8 +153,6 @@ RSpec.describe CertificationCase, type: :model do
     end
 
     it 'publishes DeterminedExempt event' do
-      allow(Strata::EventManager).to receive(:publish)
-
       certification_case.accept_exemption_request
 
       expect(Strata::EventManager).to have_received(:publish).with(
@@ -169,9 +163,9 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#deny_exemption_request' do
-    it 'sets denial status' do
-      allow(Strata::EventManager).to receive(:publish)
+    before { allow(Strata::EventManager).to receive(:publish) }
 
+    it 'sets denial status' do
       certification_case.deny_exemption_request
       certification_case.reload
 
@@ -180,14 +174,62 @@ RSpec.describe CertificationCase, type: :model do
     end
 
     it 'publishes DeterminedNotExempt event' do
-      allow(Strata::EventManager).to receive(:publish)
-
       certification_case.deny_exemption_request
 
       expect(Strata::EventManager).to have_received(:publish).with(
         "DeterminedNotExempt",
         { case_id: certification_case.id }
       )
+    end
+  end
+
+  describe '#determine_ex_parte_exemption' do
+    before { allow(Strata::EventManager).to receive(:publish) }
+
+    context 'when applicant is eligible for exemption' do
+      it 'sets approval status and closes case' do
+        eligibility_fact = Strata::RulesEngine::Fact.new(
+          "no-op", true, reasons: [ { rule_name: "eligible_for_age_exemption", reason: "age_under_19", rule_result: true } ]
+        )
+        certification_case.determine_ex_parte_exemption(eligibility_fact)
+        certification_case.reload
+
+        expect(certification_case.exemption_request_approval_status).to eq("approved")
+        expect(certification_case.exemption_request_approval_status_updated_at).to be_present
+        expect(certification_case).to be_closed
+
+        determination = Determination.first
+
+        expect(determination.decision_method).to eq("automated")
+        expect(determination.reason).not_to be_nil
+        expect(determination.outcome).to eq("exempt")
+        expect(determination.determined_at).to be_present
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedExempt",
+          { case_id: certification_case.id }
+        )
+      end
+    end
+
+
+    context 'when applicant is not eligible for exemption' do
+      it 'publishes DeterminedNotExempt event' do
+        eligibility_fact = Strata::RulesEngine::Fact.new(
+          "no-op", false
+        )
+        certification_case.determine_ex_parte_exemption(eligibility_fact)
+        certification_case.reload
+
+        expect(certification_case.exemption_request_approval_status).to be_nil
+        expect(certification_case.exemption_request_approval_status_updated_at).to be_nil
+        expect(Determination.count).to be_zero
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedNotExempt",
+          { case_id: certification_case.id }
+        )
+      end
     end
   end
 end

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -3,19 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Determination, type: :model do
-  describe 'inheritance' do
-    it { expect(described_class.superclass).to eq(Strata::Determination) }
-  end
+  describe 'enums' do
+    describe 'decision_method' do
+      it 'defines the decision_method enum with correct values' do
+        expect(described_class.decision_methods.keys).to contain_exactly('automated', 'manual')
+      end
+    end
 
-  describe 'validations' do
-    pending 'Add domain-specific validations for your business rules'
-  end
+    describe 'reason' do
+      it 'defines the reason enum with correct values' do
+        expected_reasons = %w[
+          age_under_19_exempt
+          age_over_65_exempt
+          pregnancy_exempt
+          american_indian_alaska_native_exempt
+        ]
+        expect(described_class.reasons.keys).to match_array(expected_reasons)
+      end
+    end
 
-  describe 'scopes' do
-    pending 'Add domain-specific scopes for filtering determinations'
-  end
-
-  describe 'custom behavior' do
-    pending 'Add custom enums, callbacks, or methods specific to your domain'
+    describe 'outcome' do
+      it 'defines the outcome enum with correct values' do
+        expect(described_class.outcomes.keys).to contain_exactly('compliant', 'exempt')
+      end
+    end
   end
 end

--- a/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rules::ExemptionRuleset do
+  let(:ruleset) { described_class.new }
+
+  describe '#age_under_19' do
+    context 'when age is nil' do
+      it 'returns nil' do
+        expect(ruleset.age_under_19(nil)).to be_nil
+      end
+    end
+
+    context 'when age is less than 19' do
+      it 'returns true' do
+        expect(ruleset.age_under_19(18)).to be true
+        expect(ruleset.age_under_19(0)).to be true
+        expect(ruleset.age_under_19(1)).to be true
+      end
+    end
+
+    context 'when age is 19 or greater' do
+      it 'returns false' do
+        expect(ruleset.age_under_19(19)).to be false
+        expect(ruleset.age_under_19(64)).to be false
+        expect(ruleset.age_under_19(65)).to be false
+        expect(ruleset.age_under_19(100)).to be false
+      end
+    end
+  end
+
+  describe '#eligible_for_age_exemption' do
+    context 'when both parameters are nil' do
+      it 'returns nil' do
+        expect(ruleset.eligible_for_age_exemption(nil, nil)).to be_nil
+      end
+    end
+
+    context 'when age_under_19 is nil and age_over_65 is not nil' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_age_exemption(nil, true)).to be true
+      end
+
+      it 'returns false' do
+        expect(ruleset.eligible_for_age_exemption(nil, false)).to be false
+      end
+    end
+
+    context 'when age_under_19 is not nil and age_over_65 is nil' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_age_exemption(true, nil)).to be true
+      end
+
+      it 'returns false' do
+        expect(ruleset.eligible_for_age_exemption(false, nil)).to be false
+      end
+    end
+
+    context 'when age_under_19 is true' do
+      it 'returns true (exempt)' do
+        expect(ruleset.eligible_for_age_exemption(true, false)).to be true
+        expect(ruleset.eligible_for_age_exemption(true, true)).to be true
+      end
+    end
+
+    context 'when age_over_65 is true' do
+      it 'returns true (exempt)' do
+        expect(ruleset.eligible_for_age_exemption(false, true)).to be true
+        expect(ruleset.eligible_for_age_exemption(true, true)).to be true
+      end
+    end
+
+    context 'when both are false' do
+      it 'returns false (not exempt)' do
+        expect(ruleset.eligible_for_age_exemption(false, false)).to be false
+      end
+    end
+  end
+end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "/demo/certifications", type: :request do
       member_name_first: "Jane",
       member_name_last: "Doe",
       case_number: "C-123",
-      certification_date: "09/25/2025"
+      certification_date: "09/25/2025",
+      date_of_birth: "01/15/1990"
     }
   }
 
@@ -133,6 +134,43 @@ RSpec.describe "/demo/certifications", type: :request do
           "last": create_attrs[:member_name_last]
         }))
       end
+
+      it "creates a new Certification with 'Meets age-based exemption requirement' scenario and uses scenario DOB" do
+        create_attrs = valid_request_attributes.except(:date_of_birth).merge({ ex_parte_scenario: "Meets age-based exemption requirement" })
+
+        expect {
+          post demo_certifications_url,
+               params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.case_number).to eq(create_attrs[:case_number])
+        expect(cert.certification_requirements.certification_date).to eq(Date.new(2025, 9, 25))
+        expect(cert.certification_requirements.due_date).not_to be_nil
+        expect(cert.member_name).to eq(Strata::Name.new({
+          "first": create_attrs[:member_name_first],
+          "last": create_attrs[:member_name_last]
+        }))
+        expect(cert.member_data.date_of_birth).to eq(cert.certification_requirements.certification_date - 18.years)
+      end
+
+      it "creates a new Certification with 'Meets age-based exemption requirement' scenario and uses form DOB over scenario DOB" do
+        create_attrs = valid_request_attributes.merge({ ex_parte_scenario: "Meets age-based exemption requirement" })
+
+        expect {
+          post demo_certifications_url,
+               params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.case_number).to eq(create_attrs[:case_number])
+        expect(cert.certification_requirements.certification_date).to eq(Date.new(2025, 9, 25))
+        expect(cert.certification_requirements.due_date).not_to be_nil
+        expect(cert.member_name).to eq(Strata::Name.new({
+          "first": create_attrs[:member_name_first],
+          "last": create_attrs[:member_name_last]
+        }))
+        expect(cert.member_data.date_of_birth).to eq(Date.new(1990, 1, 15))
+      end
     end
 
     context "with validation errors" do
@@ -165,6 +203,17 @@ RSpec.describe "/demo/certifications", type: :request do
                demo_certifications_create_form:
                  valid_request_attributes.except(:member_name_last).merge(
                    certification_date: "09/25/2025"
+                 )
+             }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders form with errors when date_of_birth is in the future" do
+        post demo_certifications_url,
+             params: {
+               demo_certifications_create_form:
+                 valid_request_attributes.merge(
+                   date_of_birth: (Date.current + 1.day).strftime("%m/%d/%Y")
                  )
              }
         expect(response).to have_http_status(:unprocessable_entity)

--- a/reporting-app/spec/services/exemption_determination_service_spec.rb
+++ b/reporting-app/spec/services/exemption_determination_service_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExemptionDeterminationService do
+  let(:service) { described_class }
+  let(:cert_date) { Date.new(2025, 7, 1) }
+  let(:member_data) { build(:certification_member_data, date_of_birth: dob, cert_date: cert_date) }
+
+  describe '#determine' do
+    let(:certification) { create(:certification, member_data: member_data) }
+    let(:kase) { create(:certification_case, certification_id: certification.id) }
+
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+    end
+
+    context 'when applicant is under 19 years old' do
+      let(:dob) { cert_date - 18.years }
+
+      it 'publishes DeterminedExempt event' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id })
+      end
+
+      it 'closes the case' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("closed")
+      end
+
+      it 'sets exemption_request_approval_status to approved' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status).to eq("approved")
+      end
+
+      it 'sets exemption_request_approval_status_updated_at' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status_updated_at).to be_present
+      end
+    end
+
+    context 'when applicant is 65 years old or older' do
+      let(:dob) { cert_date - 65.years }
+
+      it 'publishes DeterminedExempt event' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id })
+      end
+
+      it 'closes the case' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("closed")
+      end
+
+      it 'sets exemption_request_approval_status to approved' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status).to eq("approved")
+      end
+
+      it 'sets exemption_request_approval_status_updated_at' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status_updated_at).to be_present
+      end
+    end
+
+    context 'when applicant is 19 years old' do
+      let(:dob) { cert_date - 19.years }
+
+      it 'publishes DeterminedNotExempt event' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id })
+      end
+
+      it 'does not close the case' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("open")
+      end
+
+      it 'does not set exemption_request_approval_status' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status).to be_nil
+      end
+    end
+
+    context 'when applicant is 64 years old' do
+      let(:dob) { cert_date - 64.years }
+
+      it 'publishes DeterminedNotExempt event' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id })
+      end
+
+      it 'does not close the case' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("open")
+      end
+
+      it 'does not set exemption_request_approval_status' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status).to be_nil
+      end
+    end
+
+    context 'when member_data has no date_of_birth' do
+      let(:dob) { nil }
+
+      it 'publishes DeterminedNotExempt event' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id })
+      end
+
+      it 'does not close the case' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("open")
+      end
+
+      it 'does not set exemption_request_approval_status' do
+        service.determine(kase)
+        kase.reload
+        expect(kase.exemption_request_approval_status).to be_nil
+      end
+    end
+
+    context 'when date_of_birth is invalid format' do
+      let(:dob) { "invalid-date-format" }
+
+      it 'publishes DeterminedNotExempt event' do
+        allow(Rails.logger).to receive(:warn)
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id })
+      end
+
+      it 'does not close the case' do
+        allow(Rails.logger).to receive(:warn)
+        service.determine(kase)
+        kase.reload
+        expect(kase.status).to eq("open")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [TSS-348](https://linear.app/nava-platform/issue/TSS-348/add-ex-parte-mock-scenario-data-automated-age-exempt)

## Changes

Add ex parte scenario with an age exempt member.
Add DOB to other scenarios which does not qualify member for exemption.
Add DOB field, to allow overriding a DOB in a scenario or to allow creating a DOB from a blank scenario.

## Context for reviewers + testing

1. Certification created in a typical scenario for someone who is not age exempt. Moves the case to "report_activities"
<img width="571" height="781" alt="Screenshot 2025-10-22 at 3 15 30 PM" src="https://github.com/user-attachments/assets/d6a211ce-8dcc-4079-9c70-4f1501cf6364" />
<img width="527" height="210" alt="Screenshot 2025-10-22 at 3 17 17 PM" src="https://github.com/user-attachments/assets/c46f259e-15f0-487d-bd73-6d47ffed1172" />
<img width="478" height="197" alt="Screenshot 2025-10-22 at 3 18 41 PM" src="https://github.com/user-attachments/assets/fb19531c-a6d2-4418-9b89-91a46530ebcb" />

2. DOB is set, in the same scenario, showing the ability to override the scenario DOB.
<img width="608" height="981" alt="Screenshot 2025-10-22 at 3 25 28 PM" src="https://github.com/user-attachments/assets/044c172f-52ec-413f-b2f4-d2c7c2a85bd5" />
<img width="530" height="208" alt="Screenshot 2025-10-22 at 3 25 52 PM" src="https://github.com/user-attachments/assets/54d8a179-e1eb-4bbb-8d1a-b9a2e9d46c00" />
<img width="464" height="184" alt="Screenshot 2025-10-22 at 3 29 57 PM" src="https://github.com/user-attachments/assets/d016e2c4-2e8a-4df3-b761-baf3e1904f72" />

3. Age exempt scenario, moves the person to exempt status and business process to "end" step.
<img width="844" height="210" alt="Screenshot 2025-10-22 at 3 32 55 PM" src="https://github.com/user-attachments/assets/29023405-fcd1-492a-a7ed-ba70621976ba" />
<img width="533" height="220" alt="Screenshot 2025-10-22 at 3 32 28 PM" src="https://github.com/user-attachments/assets/3966a5cd-89d1-445b-a449-c1b859f7a296" />
<img width="578" height="982" alt="Screenshot 2025-10-22 at 3 32 07 PM" src="https://github.com/user-attachments/assets/907f839f-1f0e-4633-85bb-e7dd6a444b1e" />



<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->