### PR TITLE
Add pregnancy_status to Certification create and allow for automated exemption

### DIFF
--- a/reporting-app/app/forms/demo/certifications/base_create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/base_create_form.rb
@@ -15,6 +15,7 @@ module Demo
       strata_attribute :member_name, :name
       strata_attribute :date_of_birth, :us_date
       attribute :case_number, :string
+      attribute :pregnancy_status, :boolean, default: false
 
       # TODO: add validation you can't set both certification_type and the other params?
       attribute :certification_type, :enum, options: ::Certifications::Requirements::CERTIFICATION_TYPE_OPTIONS

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -3,7 +3,10 @@
 module Demo
   module Certifications
     class CreateForm < BaseCreateForm
-      EX_PARTE_SCENARIO_OPTIONS = [ "No data", "Partially met work hours requirement", "Fully met work hours requirement", "Meets age-based exemption requirement" ]
+      EX_PARTE_SCENARIO_OPTIONS = [
+        "No data", "Partially met work hours requirement", "Fully met work hours requirement",
+        "Meets age-based exemption requirement"
+      ].freeze
 
       attribute :ex_parte_scenario, :enum, options: EX_PARTE_SCENARIO_OPTIONS
 
@@ -28,8 +31,9 @@ module Demo
         end
 
         member_data = {
-          "name": self.member_name
-        }
+          "name": self.member_name,
+          "pregnancy_status": self.pregnancy_status
+        }.compact
 
         case self.ex_parte_scenario
         when "Partially met work hours requirement"

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -30,10 +30,7 @@ module Demo
           return false
         end
 
-        member_data = {
-          "name": self.member_name,
-          "pregnancy_status": self.pregnancy_status
-        }.compact
+        member_data = {}
 
         case self.ex_parte_scenario
         when "Partially met work hours requirement"
@@ -56,7 +53,9 @@ module Demo
         end
 
         member_data = ::Certifications::MemberData.new(member_data)
+        member_data.name = self.member_name if self.member_name.present?
         member_data.date_of_birth = self.date_of_birth if self.date_of_birth.present?
+        member_data.pregnancy_status = self.pregnancy_status if self.pregnancy_status.present?
 
         @certification = FactoryBot.build(
           :certification,

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -75,7 +75,8 @@ class CertificationCase < Strata::Case
 
         reasons = {
           age_under_19: :age_under_19_exempt,
-          age_over_65: :age_over_65_exempt
+          age_over_65: :age_over_65_exempt,
+          pregnant: :pregnancy_exempt
         }
 
         # TODO: Extract to Fact class that inherits from Strata::RulesEngine::Fact

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -37,4 +37,5 @@ class Certifications::MemberData < ValueObject
   attribute :date_of_birth, :date
 
   attribute :payroll_accounts, :array, of: PayrollAccount.to_type
+  attribute :pregnancy_status, :boolean, default: false
 end

--- a/reporting-app/app/models/rules/exemption_ruleset.rb
+++ b/reporting-app/app/models/rules/exemption_ruleset.rb
@@ -10,16 +10,16 @@ module Rules
       age < 19
     end
 
-    def pregnant(pregnancy_status)
+    def is_pregnant(pregnancy_status)
       return if pregnancy_status.nil?
 
       pregnancy_status
     end
 
-    def eligible_for_exemption(age_under_19, age_over_65, pregnant)
-      return if [ age_under_19, age_over_65, pregnant ].all?(&:nil?)
+    def eligible_for_exemption(age_under_19, age_over_65, is_pregnant)
+      return if [ age_under_19, age_over_65, is_pregnant ].all?(&:nil?)
 
-      [ age_under_19, age_over_65, pregnant ].any?
+      [ age_under_19, age_over_65, is_pregnant ].any?
     end
   end
 end

--- a/reporting-app/app/models/rules/exemption_ruleset.rb
+++ b/reporting-app/app/models/rules/exemption_ruleset.rb
@@ -10,10 +10,16 @@ module Rules
       age < 19
     end
 
-    def eligible_for_age_exemption(age_under_19, age_over_65)
-      return if age_under_19.nil? && age_over_65.nil?
+    def pregnant(pregnancy_status)
+      return if pregnancy_status.nil?
 
-      [ age_under_19, age_over_65 ].any?
+      pregnancy_status
+    end
+
+    def eligible_for_exemption(age_under_19, age_over_65, pregnant)
+      return if [ age_under_19, age_over_65, pregnant ].all?(&:nil?)
+
+      [ age_under_19, age_over_65, pregnant ].any?
     end
   end
 end

--- a/reporting-app/app/services/exemption_determination_service.rb
+++ b/reporting-app/app/services/exemption_determination_service.rb
@@ -4,33 +4,46 @@ class ExemptionDeterminationService
   class << self
     def determine(kase)
       certification = Certification.find(kase.certification_id)
-      evaluation_date = certification.certification_requirements.certification_date
-      date_of_birth = extract_date_of_birth(certification)
-      eligibility_fact = evaluate_exemption_eligibility(date_of_birth, evaluation_date)
+      eligibility_fact = evaluate_exemption_eligibility(certification)
 
       kase.determine_ex_parte_exemption(eligibility_fact)
     end
 
     private
 
-    def evaluate_exemption_eligibility(date_of_birth, evaluation_date)
-      return Strata::RulesEngine::Fact.new("no-op", false) unless date_of_birth
-
+    def evaluate_exemption_eligibility(certification)
       ruleset = Rules::ExemptionRuleset.new
       engine = Strata::RulesEngine.new(ruleset)
 
+      evaluation_date = extract_evaluation_date(certification)
+      date_of_birth = extract_date_of_birth(certification)
+      pregnancy_status = extract_pregnancy_status(certification)
+
       engine.set_facts(
         date_of_birth: date_of_birth,
-        evaluated_on: evaluation_date
+        evaluated_on: evaluation_date,
+        pregnancy_status: pregnancy_status
       )
 
-      engine.evaluate(:eligible_for_age_exemption)
+      engine.evaluate(:eligible_for_exemption)
+    end
+
+    def extract_evaluation_date(certification)
+      return nil unless certification.certification_requirements
+
+      certification.certification_requirements.certification_date
     end
 
     def extract_date_of_birth(certification)
       return nil unless certification.member_data
 
       certification.member_data.date_of_birth
+    end
+
+    def extract_pregnancy_status(certification)
+      return nil unless certification.member_data
+
+      certification.member_data.pregnancy_status
     end
   end
 end

--- a/reporting-app/app/views/demo/certifications/new.html.erb
+++ b/reporting-app/app/views/demo/certifications/new.html.erb
@@ -26,6 +26,8 @@
   <%= f.select :number_of_months_to_certify, Demo::Certifications::CreateForm::NUMBER_OF_MONTHS_TO_CERTIFY_OPTIONS.map { |i| [ t("certifications.demo_create.number_of_months_to_certify_options.#{i}"), i ] }, {}, disabled: @form.locked_type_params? %>
   <%= f.select :due_period_days, Demo::Certifications::CreateForm::DUE_PERIOD_OPTIONS.map { |i| [ t("certifications.demo_create.due_period_options.#{i}"), i ] }, {}, disabled: @form.locked_type_params? %>
 
+  <%= f.check_box :pregnancy_status %>
+
   <%= f.select :ex_parte_scenario, Demo::Certifications::CreateForm::EX_PARTE_SCENARIO_OPTIONS %>
 
   <%= f.submit t("certifications.demo_create.submit") %>

--- a/reporting-app/config/locales/views/certifications/en.yml
+++ b/reporting-app/config/locales/views/certifications/en.yml
@@ -46,3 +46,4 @@ en:
       certification_type_options:
         new_application: "New application"
         recertification: "Recertification"
+      pregnancy_status: "Pregnancy Status"

--- a/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
@@ -30,50 +30,72 @@ RSpec.describe Rules::ExemptionRuleset do
     end
   end
 
-  describe '#eligible_for_age_exemption' do
-    context 'when both parameters are nil' do
+  describe '#pregnant' do
+    context 'when pregnancy_status is nil' do
       it 'returns nil' do
-        expect(ruleset.eligible_for_age_exemption(nil, nil)).to be_nil
+        expect(ruleset.pregnant(nil)).to be_nil
       end
     end
 
-    context 'when age_under_19 is nil and age_over_65 is not nil' do
+    context 'when pregnancy_status is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_age_exemption(nil, true)).to be true
-      end
-
-      it 'returns false' do
-        expect(ruleset.eligible_for_age_exemption(nil, false)).to be false
+        expect(ruleset.pregnant(true)).to be true
       end
     end
 
-    context 'when age_under_19 is not nil and age_over_65 is nil' do
+    context 'when pregnancy_status is false' do
+      it 'returns false' do
+        expect(ruleset.pregnant(false)).to be false
+      end
+    end
+  end
+
+  describe '#eligible_for_exemption' do
+    context 'when all parameters are nil' do
+      it 'returns nil' do
+        expect(ruleset.eligible_for_exemption(nil, nil, nil)).to be_nil
+      end
+    end
+
+    context 'when only pregnant is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_age_exemption(true, nil)).to be true
-      end
-
-      it 'returns false' do
-        expect(ruleset.eligible_for_age_exemption(false, nil)).to be false
+        expect(ruleset.eligible_for_exemption(nil, nil, true)).to be true
       end
     end
 
-    context 'when age_under_19 is true' do
-      it 'returns true (exempt)' do
-        expect(ruleset.eligible_for_age_exemption(true, false)).to be true
-        expect(ruleset.eligible_for_age_exemption(true, true)).to be true
+    context 'when only age_under_19 is true' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_exemption(true, nil, nil)).to be true
       end
     end
 
-    context 'when age_over_65 is true' do
-      it 'returns true (exempt)' do
-        expect(ruleset.eligible_for_age_exemption(false, true)).to be true
-        expect(ruleset.eligible_for_age_exemption(true, true)).to be true
+    context 'when only age_over_65 is true' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_exemption(nil, true, nil)).to be true
       end
     end
 
-    context 'when both are false' do
-      it 'returns false (not exempt)' do
-        expect(ruleset.eligible_for_age_exemption(false, false)).to be false
+    context 'when age_under_19 and pregnant are both true' do
+      it 'returns true (multiple reasons)' do
+        expect(ruleset.eligible_for_exemption(true, nil, true)).to be true
+      end
+    end
+
+    context 'when all are true' do
+      it 'returns true (all reasons)' do
+        expect(ruleset.eligible_for_exemption(true, true, true)).to be true
+      end
+    end
+
+    context 'when all are false' do
+      it 'returns false (no exemption)' do
+        expect(ruleset.eligible_for_exemption(false, false, false)).to be false
+      end
+    end
+
+    context 'when age-based exemption is false but pregnant is true' do
+      it 'returns true (pregnant exemption)' do
+        expect(ruleset.eligible_for_exemption(false, false, true)).to be true
       end
     end
   end

--- a/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exemption_ruleset_spec.rb
@@ -30,22 +30,22 @@ RSpec.describe Rules::ExemptionRuleset do
     end
   end
 
-  describe '#pregnant' do
+  describe '#is_pregnant' do
     context 'when pregnancy_status is nil' do
       it 'returns nil' do
-        expect(ruleset.pregnant(nil)).to be_nil
+        expect(ruleset.is_pregnant(nil)).to be_nil
       end
     end
 
     context 'when pregnancy_status is true' do
       it 'returns true' do
-        expect(ruleset.pregnant(true)).to be true
+        expect(ruleset.is_pregnant(true)).to be true
       end
     end
 
     context 'when pregnancy_status is false' do
       it 'returns false' do
-        expect(ruleset.pregnant(false)).to be false
+        expect(ruleset.is_pregnant(false)).to be false
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe Rules::ExemptionRuleset do
       end
     end
 
-    context 'when only pregnant is true' do
+    context 'when only is_pregnant is true' do
       it 'returns true' do
         expect(ruleset.eligible_for_exemption(nil, nil, true)).to be true
       end
@@ -75,7 +75,7 @@ RSpec.describe Rules::ExemptionRuleset do
       end
     end
 
-    context 'when age_under_19 and pregnant are both true' do
+    context 'when age_under_19 and is_pregnant are both true' do
       it 'returns true (multiple reasons)' do
         expect(ruleset.eligible_for_exemption(true, nil, true)).to be true
       end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -171,6 +171,18 @@ RSpec.describe "/demo/certifications", type: :request do
         }))
         expect(cert.member_data.date_of_birth).to eq(Date.new(1990, 1, 15))
       end
+
+      it "creates a new Certification with pregnancy_status checkbox selected" do
+        create_attrs = valid_request_attributes.merge({ pregnancy_status: "1", ex_parte_scenario: "No data" })
+
+        expect {
+          post demo_certifications_url,
+               params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.member_data.pregnancy_status).to be true
+      end
     end
 
     context "with validation errors" do


### PR DESCRIPTION
## Ticket

Resolves [TSS-421](https://linear.app/nava-platform/issue/TSS-421/add-ex-parte-scenario-data-pregnancy)

## Changes

Add prenancy_status to demo certifications create form
Add pregnancy status to automated ex_parte exemption process.


## Testing

Here are examples of how we are storying multiple reasons at the database level.
<img width="629" height="214" alt="Screenshot 2025-11-03 at 1 34 34 PM" src="https://github.com/user-attachments/assets/1cafb721-7152-448f-bad6-34ae84363f29" />
<img width="590" height="333" alt="Screenshot 2025-11-03 at 1 34 42 PM" src="https://github.com/user-attachments/assets/50184ef6-5742-47a7-9ae0-6d3b2f1056fb" />



> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->