### PR TITLE
Update dashboard for exemption screener

### DIFF
--- a/reporting-app/app/assets/stylesheets/_uswds-theme.scss
+++ b/reporting-app/app/assets/stylesheets/_uswds-theme.scss
@@ -14,6 +14,11 @@ for a full list of available settings.
   // Ensure utility classes always override other styles
   $utilities-use-important: true,
 
+  // For turning columns into rows or vice versa on breakpoints
+  $flex-direction-settings: (
+    responsive: true
+  ),
+
   // Use USWDS defaults for typography
   $theme-style-body-element: true,
   $theme-font-type-sans: "public-sans",

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -24,6 +24,10 @@ module DashboardHelper
     end
   end
 
+  def application_exists?
+    @activity_report_application_form.present? || @exemption_application_form.present?
+  end
+
   def are_activity_report_or_exemption_incomplete?
     !(@activity_report_application_form&.submitted? || @exemption_application_form&.submitted?)
   end

--- a/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
@@ -1,4 +1,4 @@
-<p class="usa-intro">
-  <%= t(".intro") %>
-</p>
-<%= link_to t(".view_completed_certification_button"), certification_path(certification), class: "usa-button" %>
+<div class="grid-container">
+  <p class="usa-intro"><%= t(".intro") %></p>
+  <%= link_to t(".view_completed_certification_button"), certification_path(certification), class: "usa-button" %>
+</div>

--- a/reporting-app/app/views/dashboard/_activity_report_denied.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_denied.html.erb
@@ -1,11 +1,13 @@
-<div class="usa-alert usa-alert--error" role="alert">
-  <div class="usa-alert__body">
-    <h3 class="usa-alert__heading"><%= t(".heading") %></h3>
-    <p class="usa-alert__text">
-      <%= t(".intro") %>
-    </p>
+<div class="grid-container">
+  <div class="usa-alert usa-alert--error" role="alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading"><%= t(".heading") %></h3>
+      <p class="usa-alert__text">
+        <%= t(".intro") %>
+      </p>
+    </div>
   </div>
-</div>
-<div class="margin-top-3">
-  <%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
+  <div class="margin-top-3">
+    <%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
+  </div>
 </div>

--- a/reporting-app/app/views/dashboard/_activity_report_submitted.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_submitted.html.erb
@@ -1,4 +1,4 @@
-<p class="usa-intro">
-  <%= t(".intro") %>
-</p>
-<%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
+<div class="grid-container">
+  <p class="usa-intro"><%= t(".intro") %></p>
+  <%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
+</div>

--- a/reporting-app/app/views/dashboard/_exemption_approved.html.erb
+++ b/reporting-app/app/views/dashboard/_exemption_approved.html.erb
@@ -1,4 +1,4 @@
-<p class="usa-intro">
-  <%= t(".intro") %>
-</p>
-<%= link_to t(".view_certification_button"), certification_path(certification), class: "usa-button" %>
+<div class="grid-container">
+  <p class="usa-intro"><%= t(".intro") %></p>
+  <%= link_to t(".view_certification_button"), certification_path(certification), class: "usa-button" %>
+</div>

--- a/reporting-app/app/views/dashboard/_exemption_denied.html.erb
+++ b/reporting-app/app/views/dashboard/_exemption_denied.html.erb
@@ -1,11 +1,13 @@
-<div class="usa-alert usa-alert--error" role="alert">
-  <div class="usa-alert__body">
-    <h3 class="usa-alert__heading"><%= t(".heading") %></h3>
-    <p class="usa-alert__text">
-      <%= t(".intro") %>
-    </p>
+<div class="grid-container">
+  <div class="usa-alert usa-alert--error" role="alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading"><%= t(".heading") %></h3>
+      <p class="usa-alert__text">
+        <%= t(".intro") %>
+      </p>
+    </div>
   </div>
-</div>
-<div class="margin-top-3">
-  <%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+  <div class="margin-top-3">
+    <%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+  </div>
 </div>

--- a/reporting-app/app/views/dashboard/_exemption_submitted.html.erb
+++ b/reporting-app/app/views/dashboard/_exemption_submitted.html.erb
@@ -1,4 +1,4 @@
-<p class="usa-intro">
-  <%= t(".intro") %>
-</p>
-<%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+<div class="grid-container">
+  <p class="usa-intro"><%= t(".intro") %></p>
+  <%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+</div>

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -4,8 +4,8 @@
     <div class="grid-row flex-column tablet:flex-row gap-4">
       <div class="usa-hero__callout grid-col">
         <h2 class="usa-hero__heading font-heading-xl">
-          <!-- TODO: handle this formatting stuff in the content so can pass the date -->
-          <!-- TODO: also '%b %d, %Y' doesn't correspond to a defined date format for locales, most similar to :short, but that doesn't have the year -->
+          <%# TODO: handle this formatting stuff in the content so can pass the date %>
+          <%# TODO: also '%b %d, %Y' doesn't correspond to a defined date format for locales, most similar to :short, but that doesn't have the year %>
           <span class="usa-hero__heading--alt"><%= t(".get_started.header") %></span> <%= certification.certification_requirements.due_date&.strftime('%b %d, %Y') %>
         </h2>
         <p class="text-base-lightest">

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -1,4 +1,4 @@
-<% if !activity_report&.in_progress? %>
+<% if !application_exists? %>
 <section class="usa-section usa-section--light padding-y-3 margin-bottom-4" aria-label="Get started">
   <div class="grid-container">
     <div class="grid-row flex-column tablet:flex-row gap-4">

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -5,6 +5,7 @@
       <div class="usa-hero__callout grid-col">
         <h2 class="usa-hero__heading font-heading-xl">
           <!-- TODO: handle this formatting stuff in the content so can pass the date -->
+          <!-- TODO: also '%b %d, %Y' doesn't correspond to a defined date format for locales, most similar to :short, but that doesn't have the year -->
           <span class="usa-hero__heading--alt"><%= t(".get_started.header") %></span> <%= certification.certification_requirements.due_date&.strftime('%b %d, %Y') %>
         </h2>
         <p class="text-base-lightest">

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -11,8 +11,7 @@
         <p class="text-base-lightest">
          <%= t(".get_started.prompt") %>
         </p>
-        <!-- TODO: link to screener -->
-        <a class="usa-button" href=""><%= t(".get_started.button") %></a>
+        <%= link_to t(".get_started.button"), exemption_screener_path(certification_case_id: @certification_case.id), class: "usa-button" %>
       </div>
 
       <div class="grid-col display-flex flex-align-center">

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -1,48 +1,80 @@
-<ul class="usa-card-group">
-  <li class="usa-card tablet:grid-col-6">
-    <div class="usa-card__container">
-      <div class="usa-card__header">
-        <h2 class="usa-card__heading"><%= t(".activity_report.title") %></h2>
+<% if !activity_report&.in_progress? %>
+<section class="usa-section usa-section--light padding-y-3 margin-bottom-4" aria-label="Get started">
+  <div class="grid-container">
+    <div class="grid-row grid-gap grid-gap-6 margin-x-0">
+      <div class="usa-hero__callout tablet:grid-col">
+        <h2 class="usa-hero__heading font-heading-xl">
+          <!-- TODO: handle this formatting stuff in the content so can pass the date -->
+          <span class="usa-hero__heading--alt"><%= t(".get_started.header") %></span> <%= certification.certification_requirements.due_date&.strftime('%b %d, %Y') %>
+        </h2>
+        <p class="text-base-lightest">
+         <%= t(".get_started.prompt") %>
+        </p>
+        <!-- TODO: link to screener -->
+        <a class="usa-button" href=""><%= t(".get_started.button") %></a>
       </div>
-      <div class="usa-card__body">
+
+      <div class="tablet:grid-col display-flex flex-align-center">
         <p class="font-serif-md">
-          <%= t(".activity_report.intro") %>
+          <%= t(".get_started.info") %>
         </p>
       </div>
-      <div class="usa-card__footer">
-        <% if activity_report&.in_progress? %>
-          <p class="font-serif-md">
-            <strong><%= t(".activity_report.in_progress_status") %></strong><br />
-            <%= t(".activity_report.in_progress_message") %>
-          </p>
-          <%= link_to t(".activity_report.continue_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %><br />
-        <% else %>
-          <%= link_to t(".activity_report.report_activities_button"), new_activity_report_application_form_path(certification_case_id: @certification_case.id), class: "usa-button" %><br />
-        <% end %>
-      </div>
     </div>
-  </li>
-  <li class="usa-card tablet:grid-col-6">
-    <div class="usa-card__container">
-      <div class="usa-card__header">
-        <h2 class="usa-card__heading"><%= t(".exemption_request.title") %></h2>
-      </div>
-      <div class="usa-card__body">
-        <p class="font-serif-md">
-          <%= t(".exemption_request.intro") %>
-        </p>
-      </div>
-      <div class="usa-card__footer">
-        <% if exemption_application&.in_progress? %>
-          <p class="font-serif-md">
-            <strong><%= t(".exemption_request.in_progress_status") %></strong><br />
-            <%= t(".exemption_request.in_progress_message") %>
-          </p>
-          <%= link_to t(".exemption_request.continue_request_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
-        <% else %>
-          <%= link_to t(".exemption_request.request_exemption_button"), new_exemption_application_form_path(certification_case_id: @certification_case.id), class: "usa-button usa-button--outline" %>
-        <% end %>
-      </div>
-    </div>
-  </li>
-</ul>
+  </div>
+</section>
+<% end %>
+
+<div class="grid-container">
+  <div class="grid-row grid-gap">
+    <h2 class="font-heading-xl margin-bottom-4"><%= t(".activities.header") %></h2>
+
+    <ul class="usa-card-group">
+      <li class="usa-card tablet:grid-col-6">
+        <div class="usa-card__container">
+          <div class="usa-card__header">
+            <h2 class="usa-card__heading"><%= t(".activity_report.title") %></h2>
+          </div>
+          <div class="usa-card__body">
+            <p class="font-serif-md">
+              <%= t(".activity_report.intro") %>
+            </p>
+          </div>
+          <div class="usa-card__footer">
+            <% if activity_report&.in_progress? %>
+              <p class="font-serif-md">
+                <strong><%= t(".activity_report.in_progress_status") %></strong><br />
+                <%= t(".activity_report.in_progress_message") %>
+              </p>
+              <%= link_to t(".activity_report.continue_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %><br />
+            <% else %>
+              <%= link_to t(".activity_report.report_activities_button"), new_activity_report_application_form_path(certification_case_id: @certification_case.id), class: "usa-button usa-button--outline" %><br />
+            <% end %>
+          </div>
+        </div>
+      </li>
+      <li class="usa-card tablet:grid-col-6">
+        <div class="usa-card__container">
+          <div class="usa-card__header">
+            <h2 class="usa-card__heading"><%= t(".exemption_request.title") %></h2>
+          </div>
+          <div class="usa-card__body">
+            <p class="font-serif-md">
+              <%= t(".exemption_request.intro") %>
+            </p>
+          </div>
+          <div class="usa-card__footer">
+            <% if exemption_application&.in_progress? %>
+              <p class="font-serif-md">
+                <strong><%= t(".exemption_request.in_progress_status") %></strong><br />
+                <%= t(".exemption_request.in_progress_message") %>
+              </p>
+              <%= link_to t(".exemption_request.continue_request_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+            <% else %>
+              <%= link_to t(".exemption_request.request_exemption_button"), new_exemption_application_form_path(certification_case_id: @certification_case.id), class: "usa-button usa-button--outline" %>
+            <% end %>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -1,8 +1,8 @@
 <% if !activity_report&.in_progress? %>
 <section class="usa-section usa-section--light padding-y-3 margin-bottom-4" aria-label="Get started">
   <div class="grid-container">
-    <div class="grid-row grid-gap grid-gap-6 margin-x-0">
-      <div class="usa-hero__callout tablet:grid-col">
+    <div class="grid-row flex-column tablet:flex-row gap-4">
+      <div class="usa-hero__callout grid-col">
         <h2 class="usa-hero__heading font-heading-xl">
           <!-- TODO: handle this formatting stuff in the content so can pass the date -->
           <span class="usa-hero__heading--alt"><%= t(".get_started.header") %></span> <%= certification.certification_requirements.due_date&.strftime('%b %d, %Y') %>
@@ -14,7 +14,7 @@
         <a class="usa-button" href=""><%= t(".get_started.button") %></a>
       </div>
 
-      <div class="tablet:grid-col display-flex flex-align-center">
+      <div class="grid-col display-flex flex-align-center">
         <p class="font-serif-md">
           <%= t(".get_started.info") %>
         </p>

--- a/reporting-app/app/views/dashboard/_no_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_no_certification.html.erb
@@ -1,2 +1,4 @@
 <!-- TODO: determine the no certification UX -->
+<div class="grid-container">
 No pending certifications.
+</div>

--- a/reporting-app/app/views/dashboard/_request_for_information.html.erb
+++ b/reporting-app/app/views/dashboard/_request_for_information.html.erb
@@ -1,15 +1,17 @@
-<div class="usa-alert usa-alert--warning margin-bottom-3" role="status">
-  <div class="usa-alert__body">
-    <h3 class="usa-alert__heading"><%= t('.heading') %></h3>
-    <p class="usa-alert__text">
-      <%= t('.intro_html', due_date: information_request.due_date&.strftime('%B %d, %Y') || '<date due>') %>
-    </p>
-    <div class="margin-top-2">
-      <% if information_request.application_form_type.constantize == ActivityReportApplicationForm %>
-        <%= link_to t('.cta_button'), edit_activity_report_information_request_path(information_request), class: 'usa-button display-inline-block' %>
-      <% elsif information_request.application_form_type.constantize == ExemptionApplicationForm %>
-        <%= link_to t('.cta_button'), edit_exemption_information_request_path(information_request), class: 'usa-button display-inline-block' %>
-      <% end %>
+<div class="grid-container">
+  <div class="usa-alert usa-alert--warning margin-bottom-3" role="status">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading"><%= t('.heading') %></h3>
+      <p class="usa-alert__text">
+        <%= t('.intro_html', due_date: information_request.due_date&.strftime('%B %d, %Y') || '<date due>') %>
+      </p>
+      <div class="margin-top-2">
+        <% if information_request.application_form_type.constantize == ActivityReportApplicationForm %>
+          <%= link_to t('.cta_button'), edit_activity_report_information_request_path(information_request), class: 'usa-button display-inline-block' %>
+        <% elsif information_request.application_form_type.constantize == ExemptionApplicationForm %>
+          <%= link_to t('.cta_button'), edit_exemption_information_request_path(information_request), class: 'usa-button display-inline-block' %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/reporting-app/app/views/dashboard/index.html.erb
+++ b/reporting-app/app/views/dashboard/index.html.erb
@@ -9,11 +9,11 @@
 <%= render determine_dashboard_view, activity_report: @activity_report_application_form, exemption_application: @exemption_application_form, certification_case: @certification_case, certification: @certification %>
 <!-- Previous Certifications -->
 <% if @all_certifications.length > 1 %>
-  <div class="grid-container">
+  <section class="grid-container usa-section">
     <h2><%= t(".previous_certifications.title") %></h2>
     <p class="font-serif-md">
       <%= t(".previous_certifications.intro") %>
     </p>
     <%= link_to t(".previous_certifications.review_previous_certifications_button"), certifications_path, class: "usa-button usa-button--outline" %>
-  </div>
+  </section>
 <% end %>

--- a/reporting-app/app/views/dashboard/index.html.erb
+++ b/reporting-app/app/views/dashboard/index.html.erb
@@ -1,13 +1,19 @@
-<h1><%= t(".title") %></h1>
+<div class="grid-container">
+  <h1 class="margin-bottom-2"><%= t(".title") %></h1>
+</div>
 <% if @information_request %>
-  <%= render "dashboard/request_for_information", information_request: @information_request %>
+  <div class="grid-container">
+    <%= render "dashboard/request_for_information", information_request: @information_request %>
+  </div>
 <% end %>
 <%= render determine_dashboard_view, activity_report: @activity_report_application_form, exemption_application: @exemption_application_form, certification_case: @certification_case, certification: @certification %>
 <!-- Previous Certifications -->
 <% if @all_certifications.length > 1 %>
-  <h2><%= t(".previous_certifications.title") %></h2>
-  <p class="font-serif-md">
-    <%= t(".previous_certifications.intro") %>
-  </p>
-  <%= link_to t(".previous_certifications.review_previous_certifications_button"), certifications_path, class: "usa-button usa-button--outline" %>
+  <div class="grid-container">
+    <h2><%= t(".previous_certifications.title") %></h2>
+    <p class="font-serif-md">
+      <%= t(".previous_certifications.intro") %>
+    </p>
+    <%= link_to t(".previous_certifications.review_previous_certifications_button"), certifications_path, class: "usa-button usa-button--outline" %>
+  </div>
 <% end %>

--- a/reporting-app/app/views/layouts/application.html.erb
+++ b/reporting-app/app/views/layouts/application.html.erb
@@ -1,47 +1,14 @@
-<%# Top-level layout for all pages in the application %>
-<!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
-  <head>
-    <title>
-      <%= content_for?(:title) ? "#{ yield(:title) } | #{ t('header.title') }" : t("header.title") %>
-    </title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-
-    <%= favicon_link_tag asset_path('@uswds/uswds/dist/img/us_flag_small.png') %>
-
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= yield :head %>
-
-    <%= javascript_importmap_tags %>
-    <%= javascript_include_tag '@uswds/uswds/dist/js/uswds-init.min.js' %>
-  </head>
-
-  <body>
-    <div class="display-flex flex-column minh-viewport">
-      <%= render partial: 'application/header' %>
-
-      <main id="main-content" class="grid-col-fill display-flex flex-column">
-        <div class="grid-col-fill <%= yield :main_col_class %>">
-          <section class="usa-section">
-            <div class="grid-container">
-              <%= render partial: 'application/flash' %>
-
-              <div class="grid-row grid-gap">
-                <%= yield :before_content_col %>
-                <div class="grid-col-12 <%= yield :content_col_class %>" id="content">
-                  <%= content_for?(:content) ? yield(:content) : yield %>
-                </div>
-                <%= yield :after_content_col %>
-              </div>
-            </div>
-          </section>
-        </div>
-      </main>
+<%# Typical content-only layout for all pages in the application %>
+<%= content_for :main_content do %>
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <%= yield :before_content_col %>
+      <div class="grid-col-12 <%= yield :content_col_class %>" id="content">
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+      <%= yield :after_content_col %>
     </div>
+  </div>
+<% end %>
 
-    <%= javascript_include_tag '@uswds/uswds/dist/js/uswds.min.js' %>
-    <%= yield :scripts %>
-  </body>
-</html>
+<%= render template: 'layouts/application_base' %>

--- a/reporting-app/app/views/layouts/application_base.html.erb
+++ b/reporting-app/app/views/layouts/application_base.html.erb
@@ -1,0 +1,41 @@
+<%# Top-level layout for all pages in the application %>
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <title>
+      <%= content_for?(:title) ? "#{ yield(:title) } | #{ t('header.title') }" : t("header.title") %>
+    </title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= favicon_link_tag asset_path('@uswds/uswds/dist/img/us_flag_small.png') %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= yield :head %>
+
+    <%= javascript_importmap_tags %>
+    <%= javascript_include_tag '@uswds/uswds/dist/js/uswds-init.min.js' %>
+  </head>
+
+  <body>
+    <div class="display-flex flex-column minh-viewport">
+      <%= render partial: 'application/header' %>
+
+      <main id="main-content" class="grid-col-fill display-flex flex-column">
+        <div class="grid-col-fill <%= yield :main_col_class %>">
+          <section class="usa-section padding-y-4">
+            <div class="grid-container">
+              <%= render partial: 'application/flash' %>
+            </div>
+          </section>
+
+          <%= content_for?(:main_content) ? yield(:main_content) : yield %>
+        </div>
+      </main>
+    </div>
+
+    <%= javascript_include_tag '@uswds/uswds/dist/js/uswds.min.js' %>
+    <%= yield :scripts %>
+  </body>
+</html>

--- a/reporting-app/app/views/layouts/dashboard.html.erb
+++ b/reporting-app/app/views/layouts/dashboard.html.erb
@@ -1,0 +1,1 @@
+<%= render template: 'layouts/application_base' %>

--- a/reporting-app/config/locales/views/dashboard/new_certification.yml
+++ b/reporting-app/config/locales/views/dashboard/new_certification.yml
@@ -1,6 +1,13 @@
 en:
   dashboard:
     new_certification:
+      get_started:
+        header: "Report activities by"
+        prompt: "Begin reporting your Community Engagement activities, or find out if you qualify for an exemption."
+        button: "Get started"
+        info: "Medicaid beneficiaries need to regularly report activities like volunteering, education, and hours worked in order to keep their coverage. Certain life situations may allow you to apply for an exemption so that you don't have to report."
+      activities:
+        header: "Activities & Exemptions"
       activity_report:
         title: "Report activities"
         intro: "Report your activities for the current reporting period."

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe "dashboard/index", type: :view do
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.activity_report.report_activities_button'))
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.exemption_request.request_exemption_button'))
     end
+
+    it 'renders "get started" callout' do
+      render
+      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+    end
   end
 
   context "with an in-progress activity report" do
@@ -42,6 +47,11 @@ RSpec.describe "dashboard/index", type: :view do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.activity_report.continue_report_button'))
     end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+    end
   end
 
   context "with an in-progress exemption request" do
@@ -57,6 +67,11 @@ RSpec.describe "dashboard/index", type: :view do
     it 'renders a button to continue the exemption request' do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.exemption_request.continue_request_button'))
+    end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
     end
   end
 
@@ -77,6 +92,11 @@ RSpec.describe "dashboard/index", type: :view do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_submitted.view_activity_report_button'))
     end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+    end
   end
 
   context "with a submitted exemption request" do
@@ -95,6 +115,11 @@ RSpec.describe "dashboard/index", type: :view do
     it 'has a button to view the submitted exemption request' do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.exemption_submitted.view_exemption_button'))
+    end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
     end
   end
 
@@ -117,6 +142,11 @@ RSpec.describe "dashboard/index", type: :view do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_approved.view_completed_certification_button'))
     end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+    end
   end
 
   context "with an approved exemption request" do
@@ -137,6 +167,11 @@ RSpec.describe "dashboard/index", type: :view do
     it 'has a button to view the certification' do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.exemption_approved.view_certification_button'))
+    end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
     end
   end
 


### PR DESCRIPTION
## Ticket

https://linear.app/nava-platform/issue/TSS-440

## Changes

Design calls for the hero/callout section to have a grey background across the page, which the current `application` layout doesn't really facilitate. Could add a new content section that could be populated outside the main grid container, but what to do about the flash section and given the other potential semantic issues with existing markup, felt best to create an alternate base layout which provides more control over the main content layout when needed.

## Testing

Open case but nothing started yet:
<img width="1281" height="901" alt="image" src="https://github.com/user-attachments/assets/427074fd-cbfc-4507-8b78-cc1b5d89dcec" />

No cases:
<img width="1281" height="901" alt="image" src="https://github.com/user-attachments/assets/a25f99a9-173a-4b1d-a1c4-a73d78001cd2" />

Started activity report:
<img width="1281" height="901" alt="image" src="https://github.com/user-attachments/assets/5a62d43a-571f-4a10-a709-967b83251c09" />

Started exemption:
<img width="1281" height="901" alt="image" src="https://github.com/user-attachments/assets/b5cf5276-e7fb-4a96-8579-83bd11df2a73" />

Exemption submitted/approved:
<img width="1281" height="901" alt="image" src="https://github.com/user-attachments/assets/4c768c9e-bc49-4e09-8325-afe26254acd2" />

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->