### PR TITLE
reporting-app: Set APP_HOST env var in cloud environment

### DIFF
--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -3,10 +3,7 @@ locals {
   # This is a map rather than a list so that variables can be easily
   # overridden per environment using terraform's `merge` function
   default_extra_environment_variables = {
-    # Example environment variables
-    # WORKER_THREADS_COUNT    = 4
-    # LOG_LEVEL               = "info"
-    # DB_CONNECTION_POOL_SIZE = 5
+    APP_HOST = var.domain_name
   }
 
   # Configuration for secrets


### PR DESCRIPTION
Backend/non-web code may need to know what URL the public service is exposed as, so provide it at the app code expected `APP_HOST` env var.

The upstream infrastructure template could provide this at some point[1], but don't wait on it.

[1] https://github.com/navapbc/template-infra/issues/974

## Testing

Tested on https://github.com/navapbc/oscer/pull/10

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->