### PR TITLE
Add optimized member status for batch lookups

### DIFF
--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -50,6 +50,18 @@ class Determination < Strata::Determination
 
   default_scope { order(created_at: :desc) }
 
+  # Batch query scopes
+  scope :for_certifications, ->(certification_ids) {
+    where(subject_type: "Certification", subject_id: certification_ids)
+  }
+
+  scope :latest_per_subject, -> {
+    # Override default_scope ordering for DISTINCT ON to work correctly
+    unscope(:order)
+      .select("DISTINCT ON (subject_id) strata_determinations.*")
+      .order("subject_id, created_at DESC")
+  }
+
   def self.to_reason_codes(eligibility_fact)
     eligibility_fact_reasons = eligibility_fact.reasons.select { |reason| reason.value }.map(&:name).map(&:to_sym)
     eligibility_fact_reasons.map { |reason| REASON_CODE_MAPPING[reason] }

--- a/reporting-app/app/services/member_status_service.rb
+++ b/reporting-app/app/services/member_status_service.rb
@@ -143,7 +143,6 @@ class MemberStatusService
     end
 
     def human_readable_reason_codes(reasons)
-      @translation_cache ||= {}
       reasons.map do |reason|
         @translation_cache[reason] ||= I18n.t("services.member_status_service.reason_codes.#{reason}", default: reason)
       end

--- a/reporting-app/app/services/member_status_service.rb
+++ b/reporting-app/app/services/member_status_service.rb
@@ -23,38 +23,79 @@ class MemberStatusService
     # @return [MemberStatus] The member's current status with optional determination details
     # @raise [ArgumentError] If record is neither Certification nor CertificationCase
     def determine(record)
-      certification, certification_case = get_certification_and_case_from(record)
+      determine_many([ record ]).values.first
+    end
 
-      determination = latest_determination_for(certification)
+    # Determines member statuses for multiple records in batch (O(1) queries)
+    #
+    # @param records [Array, ActiveRecord::Relation] Array or relation of Certification and/or CertificationCase records
+    # @return [Hash] Hash keyed by [record.class.name, record.id] with MemberStatus values
+    # @raise [ArgumentError] If records contain types other than Certification or CertificationCase
+    def determine_many(records)
+      records_array = records.is_a?(ActiveRecord::Relation) ? records.to_a : Array(records)
+      return {} if records_array.empty?
+
+      # Validate all records are correct type
+      records_array.each do |record|
+        raise ArgumentError, "Record must be a Certification or CertificationCase, got #{record.class}" unless valid_record_type?(record)
+      end
+
+      # Group by type
+      certifications = records_array.select { |r| r.is_a?(Certification) }
+      cases = records_array.select { |r| r.is_a?(CertificationCase) }
+
+      # Collect all certification IDs we need
+      cert_ids = certifications.map(&:id) + cases.map(&:certification_id).compact
+      cert_ids = cert_ids.uniq
+
+      # Bulk load cross-references
+      cases_by_cert_id = CertificationCase.where(certification_id: cert_ids).index_by(&:certification_id)
+      certs_by_id = Certification.where(id: cert_ids).index_by(&:id)
+
+      # Bulk load latest determinations
+      latest_dets = Determination.for_certifications(cert_ids).latest_per_subject.index_by(&:subject_id)
+
+      # Memoize human-readable translations
+      @translation_cache = {}
+
+      # Build results
+      results = {}
+      records_array.each do |record|
+        cert, case_record = build_pair(record, certs_by_id, cases_by_cert_id)
+        status = compute_status(cert, case_record, latest_dets)
+        results[[ record.class.name, record.id ]] = status
+      end
+
+      results
+    end
+
+    private
+
+    def valid_record_type?(record)
+      record.is_a?(Certification) || record.is_a?(CertificationCase)
+    end
+
+    def build_pair(record, certs_by_id, cases_by_cert_id)
+      case record
+      when Certification
+        certification = record
+        certification_case = cases_by_cert_id[certification.id]
+      when CertificationCase
+        certification_case = record
+        certification = certs_by_id[record.certification_id]
+      end
+
+      [ certification, certification_case ]
+    end
+
+    def compute_status(certification, certification_case, latest_dets)
+      determination = latest_dets[certification&.id]
 
       if determination.present?
         status_from_determination(determination)
       else
         status_from_case_step(certification_case)
       end
-    end
-
-    private
-
-    def get_certification_and_case_from(record)
-      case record
-      when Certification
-        certification = record
-        certification_case = CertificationCase.find_by(certification_id: certification.id)
-      when CertificationCase
-        certification_case = record
-        certification = Certification.find_by(id: certification_case.certification_id)
-      else
-        raise ArgumentError, "Record must be a Certification or CertificationCase, got #{record.class}"
-      end
-
-      [ certification, certification_case ]
-    end
-
-    def latest_determination_for(certification)
-      return nil if certification.blank?
-
-      Determination.for_subject(certification).first
     end
 
     def status_from_determination(determination)
@@ -94,7 +135,10 @@ class MemberStatusService
     end
 
     def human_readable_reason_codes(reasons)
-      reasons.map { |reason| I18n.t("services.member_status_service.reason_codes.#{reason}", default: reason) }
+      @translation_cache ||= {}
+      reasons.map do |reason|
+        @translation_cache[reason] ||= I18n.t("services.member_status_service.reason_codes.#{reason}", default: reason)
+      end
     end
   end
 end

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -67,4 +67,175 @@ RSpec.describe Determination, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.for_certifications' do
+      let(:compliant_cert) { create(:certification) }
+      let(:exempt_cert) { create(:certification) }
+
+      before do
+        create(:determination, subject: compliant_cert, outcome: 'compliant', reasons: [ 'hours_reported_compliant' ])
+        create(:determination, subject: exempt_cert, outcome: 'exempt', reasons: [ 'age_under_19_exempt' ])
+      end
+
+      it 'returns determinations for specified certification IDs' do
+        determinations = described_class.for_certifications([ compliant_cert.id, exempt_cert.id ])
+        expect(determinations.pluck(:subject_id)).to contain_exactly(compliant_cert.id, exempt_cert.id)
+      end
+
+      it 'returns empty result when no matching certification IDs' do
+        determinations = described_class.for_certifications([ SecureRandom.uuid ])
+        expect(determinations).to be_empty
+      end
+
+      it 'filters by subject_type of Certification' do
+        # This scope is designed specifically for Certifications
+        determinations = described_class.for_certifications([ compliant_cert.id ])
+        expect(determinations.all? { |d| d.subject_type == 'Certification' }).to be true
+      end
+
+      it 'chains with other scopes' do
+        determinations = described_class.for_certifications([ compliant_cert.id, exempt_cert.id ]).where(outcome: 'exempt')
+        expect(determinations.count).to eq(1)
+        expect(determinations.first.outcome).to eq('exempt')
+      end
+    end
+
+    describe '.latest_per_subject' do
+      let(:compliant_cert) { create(:certification) }
+      let(:exempt_cert) { create(:certification) }
+
+      before do
+        # Create multiple determinations for compliant_cert
+        create(:determination,
+               subject: compliant_cert,
+               outcome: 'exempt',
+               reasons: [ 'hours_reported_compliant' ],
+               created_at: 3.days.ago)
+        create(:determination,
+               subject: compliant_cert,
+               outcome: 'compliant',
+               reasons: [ 'age_under_19_exempt' ],
+               created_at: 2.days.ago)
+
+        # Create multiple determinations for exempt_cert
+        create(:determination,
+               subject: exempt_cert,
+               outcome: 'compliant',
+               reasons: [ 'income_reported_compliant' ],
+               created_at: 2.days.ago)
+        create(:determination,
+               subject: exempt_cert,
+               outcome: 'exempt',
+               reasons: [ 'pregnancy_exempt' ],
+               created_at: 1.day.ago)
+      end
+
+      it 'returns only the most recent determination per subject' do
+        determinations = described_class.latest_per_subject.to_a
+        expect(determinations.size).to eq(2)
+      end
+
+      it 'returns the most recent determination for each subject' do
+        determinations = described_class.latest_per_subject.index_by(&:subject_id)
+
+        # compliant_cert should have the not_compliant determination (most recent)
+        compliant_cert_det = determinations[compliant_cert.id]
+        expect(compliant_cert_det.outcome).to eq('compliant')
+        expect(compliant_cert_det.created_at).to be_within(1.second).of(2.days.ago)
+
+        # exempt_cert should have the exempt determination (most recent)
+        exempt_cert_det = determinations[exempt_cert.id]
+        expect(exempt_cert_det.outcome).to eq('exempt')
+        expect(exempt_cert_det.created_at).to be_within(1.second).of(1.day.ago)
+      end
+
+      it 'works with a single subject' do
+        determinations = described_class.where(subject_id: compliant_cert.id).latest_per_subject.to_a
+        expect(determinations.size).to eq(1)
+        expect(determinations.first.outcome).to eq('compliant')
+      end
+
+      it 'chains with for_certifications scope' do
+        determinations = described_class.for_certifications([ compliant_cert.id, exempt_cert.id ]).latest_per_subject.to_a
+        expect(determinations.size).to eq(2)
+        expect(determinations.map(&:outcome)).to contain_exactly('compliant', 'exempt')
+      end
+
+      it 'maintains correct ordering when multiple subjects exist' do
+        # Ensure all results have expected structure and no duplicates per subject
+        determinations = described_class.latest_per_subject.group_by(&:subject_id)
+        expect(determinations.values.all? { |dets| dets.size == 1 }).to be true
+      end
+    end
+
+    describe '.for_certifications and .latest_per_subject together' do
+      let(:compliant_cert) { create(:certification) }
+      let(:exempt_cert) { create(:certification) }
+      let(:cert3) { create(:certification) }
+
+      before do
+        # compliant_cert: 3 determinations (oldest to newest: compliant, exempt, not_compliant)
+        create(:determination,
+               subject: compliant_cert,
+               outcome: 'compliant',
+               reasons: [ 'hours_reported_compliant' ],
+               created_at: 3.days.ago)
+        create(:determination,
+               subject: compliant_cert,
+               outcome: 'exempt',
+               reasons: [ 'age_under_19_exempt' ],
+               created_at: 2.days.ago)
+        create(:determination,
+               subject: compliant_cert,
+               outcome: 'not_compliant',
+               reasons: [ 'hours_reported_compliant' ],
+               created_at: 1.day.ago)
+
+        # exempt_cert: 2 determinations
+        create(:determination,
+               subject: exempt_cert,
+               outcome: 'compliant',
+               reasons: [ 'income_reported_compliant' ],
+               created_at: 2.days.ago)
+        create(:determination,
+               subject: exempt_cert,
+               outcome: 'exempt',
+               reasons: [ 'pregnancy_exempt' ],
+               created_at: 1.day.ago)
+
+        # cert3: 1 determination
+        create(:determination,
+               subject: cert3,
+               outcome: 'compliant',
+               reasons: [ 'hours_reported_compliant' ],
+               created_at: 1.day.ago)
+      end
+
+      it 'returns latest determination for only specified certifications' do
+        determinations = described_class.for_certifications([ compliant_cert.id, exempt_cert.id ]).latest_per_subject.to_a
+        expect(determinations.size).to eq(2)
+        expect(determinations.map(&:subject_id)).to contain_exactly(compliant_cert.id, exempt_cert.id)
+      end
+
+      it 'returns latest determinations with correct outcomes' do
+        determinations = described_class.for_certifications([ compliant_cert.id, exempt_cert.id, cert3.id ]).latest_per_subject
+        outcomes_by_subject = determinations.index_by(&:subject_id).transform_values(&:outcome)
+
+        expect(outcomes_by_subject[compliant_cert.id]).to eq('not_compliant')
+        expect(outcomes_by_subject[exempt_cert.id]).to eq('exempt')
+        expect(outcomes_by_subject[cert3.id]).to eq('compliant')
+      end
+
+      it 'can be used for efficient batch status determination' do
+        cert_ids = [ compliant_cert.id, exempt_cert.id ]
+        determinations = described_class.for_certifications(cert_ids).latest_per_subject.index_by(&:subject_id)
+
+        # Simulate looking up latest determination for a batch
+        expect(determinations[compliant_cert.id].outcome).to eq('not_compliant')
+        expect(determinations[exempt_cert.id].outcome).to eq('exempt')
+        expect(determinations[cert3.id]).to be_nil
+      end
+    end
+  end
 end

--- a/reporting-app/spec/services/member_status_service_spec.rb
+++ b/reporting-app/spec/services/member_status_service_spec.rb
@@ -263,15 +263,6 @@ RSpec.describe MemberStatusService do
       end
     end
 
-    context 'with ActiveRecord::Relation' do
-      it 'accepts relations and converts to array' do
-        relation = Certification.where(id: certification.id)
-        expect { service.determine_many(relation) }.not_to raise_error
-        result = service.determine_many(relation)
-        expect(result).to have_key([ "Certification", certification.id ])
-      end
-    end
-
     context 'with invalid input types' do
       it 'raises ArgumentError for mixed valid/invalid records' do
         expect { service.determine_many([ certification, "invalid" ]) }.to raise_error(ArgumentError)

--- a/reporting-app/spec/services/member_status_service_spec.rb
+++ b/reporting-app/spec/services/member_status_service_spec.rb
@@ -222,4 +222,185 @@ RSpec.describe MemberStatusService do
       end
     end
   end
+
+  describe '#determine_many' do
+    context 'with empty array' do
+      it 'returns empty hash' do
+        result = service.determine_many([])
+        expect(result).to eq({})
+      end
+    end
+
+    context 'with single Certification' do
+      it 'returns hash with single result keyed by [class_name, id]' do
+        result = service.determine_many([ certification ])
+        key = [ "Certification", certification.id ]
+        expect(result).to have_key(key)
+        expect(result[key]).to be_a(MemberStatus)
+      end
+    end
+
+    context 'with single CertificationCase' do
+      it 'returns hash with single result keyed by [class_name, id]' do
+        result = service.determine_many([ certification_case ])
+        key = [ "CertificationCase", certification_case.id ]
+        expect(result).to have_key(key)
+        expect(result[key]).to be_a(MemberStatus)
+      end
+    end
+
+    context 'with mixed Certification and CertificationCase inputs' do
+      let(:cert2) { create(:certification) }
+      let(:case2) { create(:certification_case, certification_id: cert2.id) }
+
+      it 'returns results for all records' do
+        result = service.determine_many([ certification, certification_case, cert2, case2 ])
+        expect(result.size).to eq(4)
+        expect(result).to have_key([ "Certification", certification.id ])
+        expect(result).to have_key([ "CertificationCase", certification_case.id ])
+        expect(result).to have_key([ "Certification", cert2.id ])
+        expect(result).to have_key([ "CertificationCase", case2.id ])
+      end
+    end
+
+    context 'with ActiveRecord::Relation' do
+      it 'accepts relations and converts to array' do
+        relation = Certification.where(id: certification.id)
+        expect { service.determine_many(relation) }.not_to raise_error
+        result = service.determine_many(relation)
+        expect(result).to have_key([ "Certification", certification.id ])
+      end
+    end
+
+    context 'with invalid input types' do
+      it 'raises ArgumentError for mixed valid/invalid records' do
+        expect { service.determine_many([ certification, "invalid" ]) }.to raise_error(ArgumentError)
+      end
+
+      it 'includes class name in error message' do
+        expect { service.determine_many([ certification, "invalid" ]) }.to raise_error(/String/)
+      end
+    end
+
+    context 'when Determinations exist' do
+      before do
+        create(:determination,
+               subject: certification,
+               outcome: "exempt",
+               decision_method: "automated",
+               reasons: [ "age_over_65_exempt" ])
+        create(:determination,
+               subject: create(:certification),
+               outcome: "compliant",
+               decision_method: "manual",
+               reasons: [ "hours_reported_compliant" ])
+      end
+
+      it 'returns correct statuses for records with determinations' do
+        certs = Certification.all
+        result = service.determine_many(certs)
+
+        # Fetch determinations separately to avoid lazy loading issues
+        exempt_dets = Determination.where(outcome: "exempt")
+        compliant_dets = Determination.where(outcome: "compliant")
+
+        first_cert_id = exempt_dets.first.subject_id
+        second_cert_id = compliant_dets.first.subject_id
+
+        expect(result[[ "Certification", first_cert_id ]].status).to eq("exempt")
+        expect(result[[ "Certification", second_cert_id ]].status).to eq("compliant")
+      end
+
+      it 'uses the most recent determination when multiple exist' do
+        cert = certification
+        create(:determination,
+               subject: cert,
+               outcome: "compliant",
+               decision_method: "automated",
+               reasons: [ "pregnancy_exempt" ],
+               created_at: 1.hour.ago)
+        create(:determination,
+               subject: cert,
+               outcome: "compliant",
+               decision_method: "manual",
+               reasons: [ "hours_reported_compliant" ],
+               created_at: Time.current)
+
+        result = service.determine_many([ cert ])
+        expect(result[[ "Certification", cert.id ]].determination_method).to eq("manual")
+        expect(result[[ "Certification", cert.id ]].reason_codes).to eq([ "hours_reported_compliant" ])
+      end
+
+      it 'includes human_readable_reason_codes' do
+        result = service.determine_many([ certification ])
+        status = result[[ "Certification", certification.id ]]
+        expect(status.human_readable_reason_codes).to eq([ "Age over 65" ])
+      end
+    end
+
+    context 'when no Determinations exist' do
+      it 'returns awaiting_report status for unreviewed cases' do
+        result = service.determine_many([ certification_case ])
+        expect(result[[ "CertificationCase", certification_case.id ]].status).to eq("awaiting_report")
+      end
+
+      it 'returns pending_review status when in review step' do
+        certification_case.update(business_process_current_step: CertificationBusinessProcess::REVIEW_ACTIVITY_REPORT_STEP)
+        result = service.determine_many([ certification_case ])
+        expect(result[[ "CertificationCase", certification_case.id ]].status).to eq("pending_review")
+      end
+
+      it 'returns not_compliant status when in end step without approval' do
+        certification_case.update(business_process_current_step: CertificationBusinessProcess::END_STEP)
+        result = service.determine_many([ certification_case ])
+        expect(result[[ "CertificationCase", certification_case.id ]].status).to eq("not_compliant")
+      end
+    end
+
+    context 'with large batch of records' do
+      let(:certs) { create_list(:certification, 50) }
+      let(:cases_with_det) do
+        certs.first(25).map { |cert| create(:certification_case, certification_id: cert.id) }
+      end
+      let(:cases_without_det) do
+        certs.last(25).map { |cert| create(:certification_case, certification_id: cert.id) }
+      end
+
+      before do
+        # Create determinations for first 25 certs only
+        certs.first(25).each do |cert|
+          create(:determination,
+                 subject: cert,
+                 outcome: "compliant",
+                 decision_method: "automated",
+                 reasons: [ "hours_reported_compliant" ])
+        end
+      end
+
+      it 'computes status for all records' do
+        mixed = (cases_with_det + cases_without_det).shuffle
+        result = service.determine_many(mixed)
+        expect(result.size).to eq(50)
+      end
+
+      it 'returns correct statuses for records with and without determinations' do
+        mixed = cases_with_det + cases_without_det
+        result = service.determine_many(mixed)
+
+        # Cases with determinations should show compliant status
+        cases_with_det.each do |case_record|
+          status = result[[ "CertificationCase", case_record.id ]]
+          expect(status).to be_present
+          expect(status.status).to eq("compliant")
+        end
+
+        # Cases without determinations should show awaiting_report status
+        cases_without_det.each do |case_record|
+          status = result[[ "CertificationCase", case_record.id ]]
+          expect(status).to be_present
+          expect(status.status).to eq("awaiting_report")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Add `determine_many` to MemberStatusService. This will call bulk queries so we load all Certification, CertificationCase, and Determination objects at once in memory. This allows us to create a member status object for many Certifications with only three queries at most.

Add for_certifications scope

Add latest_per_subject scope - Grabs the latest determination per subject_id, selected on the most recent determination by created_at.

## Context for reviewers

Member Status was recently introduced. It performs two queries, one to retrieve either Certification or Certification Case, and another to retrieve the latest determination for that query. This is inefficient if we call MemberStatusService.determine within a mapping function as it results in an N+1 query.

## Testing

Would need to verify with testing with batch upload.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->