### PR TITLE
Fix unprocessable_entity deprecation warning

### DIFF
--- a/reporting-app/app/controllers/activities_controller.rb
+++ b/reporting-app/app/controllers/activities_controller.rb
@@ -43,8 +43,8 @@ class ActivitiesController < ApplicationController
         format.html { redirect_to documents_activity_report_application_form_activity_path(@activity_report_application_form, @activity) }
         format.json { render :show, status: :ok, location: @activity.becomes(Activity) }
       else
-        format.html { render :documents, status: :unprocessable_entity }
-        format.json { render json: @activity.errors, status: :unprocessable_entity }
+        format.html { render :documents, status: :unprocessable_content }
+        format.json { render json: @activity.errors, status: :unprocessable_content }
       end
     end
   end
@@ -65,8 +65,8 @@ class ActivitiesController < ApplicationController
         format.html { redirect_to documents_activity_report_application_form_activity_path(@activity_report_application_form, @activity) }
         format.json { render :documents, status: :created, location: @activity.becomes(Activity) }
       else
-        format.html { render :new_activity, status: :unprocessable_entity }
-        format.json { render json: @activity.errors, status: :unprocessable_entity }
+        format.html { render :new_activity, status: :unprocessable_content }
+        format.json { render json: @activity.errors, status: :unprocessable_content }
       end
     end
   end
@@ -84,8 +84,8 @@ class ActivitiesController < ApplicationController
         format.html { redirect_to documents_activity_report_application_form_activity_path(@activity_report_application_form, @activity.becomes(Activity)) }
         format.json { render :show, status: :ok, location: @activity.becomes(Activity) }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @activity.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @activity.errors, status: :unprocessable_content }
       end
     end
   end

--- a/reporting-app/app/controllers/activity_report_application_forms_controller.rb
+++ b/reporting-app/app/controllers/activity_report_application_forms_controller.rb
@@ -38,7 +38,7 @@ class ActivityReportApplicationFormsController < ApplicationController
       else
         flash[:errors] = @activity_report_application_form.errors.full_messages
         format.html { redirect_to dashboard_path }
-        format.json { render json: @activity_report_application_form.errors, status: :unprocessable_entity }
+        format.json { render json: @activity_report_application_form.errors, status: :unprocessable_content }
       end
     end
   end
@@ -72,8 +72,8 @@ class ActivityReportApplicationFormsController < ApplicationController
         format.html { redirect_to @activity_report_application_form, notice: "Activity report application form was successfully updated." }
         format.json { render :show, status: :ok, location: review_activity_report_application_form_path(@activity_report_application_form) }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @activity_report_application_form.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @activity_report_application_form.errors, status: :unprocessable_content }
       end
     end
   end

--- a/reporting-app/app/controllers/activity_report_information_requests_controller.rb
+++ b/reporting-app/app/controllers/activity_report_information_requests_controller.rb
@@ -13,8 +13,8 @@ class ActivityReportInformationRequestsController < ApplicationController
         format.html { redirect_to dashboard_path, notice: "Information request fulfilled" }
         format.json { render :show, status: :ok, location: @information_request }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @information_request.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @information_request.errors, status: :unprocessable_content }
       end
     end
   end

--- a/reporting-app/app/controllers/api_controller.rb
+++ b/reporting-app/app/controllers/api_controller.rb
@@ -12,7 +12,7 @@ class ApiController < ActionController::Metal
 
   include Pundit::Authorization
 
-  def render_errors(errors, status = :unprocessable_entity)
+  def render_errors(errors, status = :unprocessable_content)
     # handle being given an ActiveModel (or any object) with an errors method
     if errors.respond_to?(:errors) && errors.errors.any?
       errors = errors.errors

--- a/reporting-app/app/controllers/certifications_controller.rb
+++ b/reporting-app/app/controllers/certifications_controller.rb
@@ -28,14 +28,14 @@ class CertificationsController < StaffController
     begin
       @certification.certification_requirements = certification_service.certification_requirements_from_input(requirement_params)
     rescue ActiveModel::ValidationError => e
-      render json: { certification_requirements: e.model.errors }, status: :unprocessable_entity
+      render json: { certification_requirements: e.model.errors }, status: :unprocessable_content
       return
     end
 
     if @certification.save
       render :show, status: :created, location: @certification
     else
-      render json: @certification.errors, status: :unprocessable_entity
+      render json: @certification.errors, status: :unprocessable_content
     end
   end
 
@@ -45,7 +45,7 @@ class CertificationsController < StaffController
     if @certification.update(certification_params)
       render :show, status: :ok, location: @certification
     else
-      render json: @certification.errors, status: :unprocessable_entity
+      render json: @certification.errors, status: :unprocessable_content
     end
   end
 

--- a/reporting-app/app/controllers/demo/certifications_controller.rb
+++ b/reporting-app/app/controllers/demo/certifications_controller.rb
@@ -17,21 +17,21 @@ class Demo::CertificationsController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :new, status: :unprocessable_entity
+      return render :new, status: :unprocessable_content
     end
 
     @certification = @form.to_certification
 
     if !@certification
       flash.now[:errors] = @form.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
 
     if @certification.save
       redirect_to certification_path(@certification)
     else
       flash.now[:errors] = @certification.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/reporting-app/app/controllers/exemption_application_forms_controller.rb
+++ b/reporting-app/app/controllers/exemption_application_forms_controller.rb
@@ -28,8 +28,8 @@ class ExemptionApplicationFormsController < ApplicationController
         format.html { redirect_to edit_exemption_application_form_path(@exemption_application_form) }
         format.json { render :show, status: :created, location: @exemption_application_form }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @exemption_application_form.errors, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @exemption_application_form.errors, status: :unprocessable_content }
       end
     end
   end
@@ -41,8 +41,8 @@ class ExemptionApplicationFormsController < ApplicationController
         format.html { redirect_to documents_exemption_application_form_path(@exemption_application_form) }
         format.json { render :show, status: :ok, location: @exemption_application_form }
       else
-        format.html { render :exemption_type, status: :unprocessable_entity }
-        format.json { render json: @exemption_application_form.errors, status: :unprocessable_entity }
+        format.html { render :exemption_type, status: :unprocessable_content }
+        format.json { render json: @exemption_application_form.errors, status: :unprocessable_content }
       end
     end
   end
@@ -85,8 +85,8 @@ class ExemptionApplicationFormsController < ApplicationController
         format.html { redirect_to documents_exemption_application_form_path(@exemption_application_form) }
         format.json { render :show, status: :ok, location: @exemption_application_form }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @exemption_application_form.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @exemption_application_form.errors, status: :unprocessable_content }
       end
     end
   end

--- a/reporting-app/app/controllers/exemption_information_requests_controller.rb
+++ b/reporting-app/app/controllers/exemption_information_requests_controller.rb
@@ -13,8 +13,8 @@ class ExemptionInformationRequestsController < ApplicationController
         format.html { redirect_to dashboard_path, notice: "Information request fulfilled" }
         format.json { render :show, status: :ok, location: @information_request }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @information_request.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @information_request.errors, status: :unprocessable_content }
       end
     end
   end

--- a/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
+++ b/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
@@ -21,7 +21,7 @@ module Staff
       if uploaded_file.blank?
         flash[:alert] = "Please select a CSV file to upload"
         @batch_upload = CertificationBatchUpload.new
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
         return
       end
 
@@ -36,7 +36,7 @@ module Staff
         redirect_to certification_batch_uploads_path
       else
         flash[:alert] = "Failed to upload file: #{@batch_upload.errors.full_messages.join(', ')}"
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/reporting-app/app/controllers/tasks_controller.rb
+++ b/reporting-app/app/controllers/tasks_controller.rb
@@ -32,7 +32,7 @@ class TasksController < Strata::TasksController
     else
       @information_request = result[:information_request_record]
       set_create_path
-      render "tasks/request_information", status: :unprocessable_entity
+      render "tasks/request_information", status: :unprocessable_content
     end
   end
 

--- a/reporting-app/app/controllers/users/accounts_controller.rb
+++ b/reporting-app/app/controllers/users/accounts_controller.rb
@@ -14,14 +14,14 @@ class Users::AccountsController < ApplicationController
 
     if @email_form.invalid?
       flash.now[:errors] = @email_form.errors.full_messages
-      return render :edit, status: :unprocessable_entity
+      return render :edit, status: :unprocessable_content
     end
 
     begin
       auth_service.change_email(current_user.uid, @email_form.email)
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :edit, status: :unprocessable_entity
+      return render :edit, status: :unprocessable_content
     end
 
     redirect_to({ action: :edit }, notice: "Account updated successfully.")

--- a/reporting-app/app/controllers/users/mfa_controller.rb
+++ b/reporting-app/app/controllers/users/mfa_controller.rb
@@ -15,7 +15,7 @@ class Users::MfaController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :preference, status: :unprocessable_entity
+      return render :preference, status: :unprocessable_content
     end
 
     if @form.mfa_preference == "software_token"

--- a/reporting-app/app/controllers/users/passwords_controller.rb
+++ b/reporting-app/app/controllers/users/passwords_controller.rb
@@ -14,14 +14,14 @@ class Users::PasswordsController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :forgot, status: :unprocessable_entity
+      return render :forgot, status: :unprocessable_content
     end
 
     begin
       auth_service.forgot_password(email)
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :forgot, status: :unprocessable_entity
+      return render :forgot, status: :unprocessable_content
     end
 
     redirect_to users_reset_password_path
@@ -36,7 +36,7 @@ class Users::PasswordsController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :reset, status: :unprocessable_entity
+      return render :reset, status: :unprocessable_content
     end
 
     begin
@@ -47,7 +47,7 @@ class Users::PasswordsController < ApplicationController
       )
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :reset, status: :unprocessable_entity
+      return render :reset, status: :unprocessable_content
     end
 
     redirect_to new_user_session_path, notice: I18n.t("users.passwords.reset.success")

--- a/reporting-app/app/controllers/users/registrations_controller.rb
+++ b/reporting-app/app/controllers/users/registrations_controller.rb
@@ -16,14 +16,14 @@ class Users::RegistrationsController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :new, status: :unprocessable_entity
+      return render :new, status: :unprocessable_content
     end
 
     begin
       auth_service.register(@form.email, @form.password)
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :new, status: :unprocessable_entity
+      return render :new, status: :unprocessable_content
     end
 
     redirect_to users_verify_account_path
@@ -40,14 +40,14 @@ class Users::RegistrationsController < ApplicationController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :new_account_verification, status: :unprocessable_entity
+      return render :new_account_verification, status: :unprocessable_content
     end
 
     begin
       auth_service.verify_account(@form.email, @form.code)
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :new_account_verification, status: :unprocessable_entity
+      return render :new_account_verification, status: :unprocessable_content
     end
 
     redirect_to new_user_session_path
@@ -59,7 +59,7 @@ class Users::RegistrationsController < ApplicationController
 
     if @resend_verification_form.invalid?
       flash.now[:errors] = @resend_verification_form.errors.full_messages
-      return render :new_account_verification, status: :unprocessable_entity
+      return render :new_account_verification, status: :unprocessable_content
     end
 
     auth_service.resend_verification_code(email)

--- a/reporting-app/app/controllers/users/sessions_controller.rb
+++ b/reporting-app/app/controllers/users/sessions_controller.rb
@@ -13,7 +13,7 @@ class Users::SessionsController < Devise::SessionsController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :new, status: :unprocessable_entity
+      return render :new, status: :unprocessable_content
     end
 
     begin
@@ -25,7 +25,7 @@ class Users::SessionsController < Devise::SessionsController
       return redirect_to users_verify_account_path
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :new, status: :unprocessable_entity
+      return render :new, status: :unprocessable_content
     end
 
     unless response[:user].present?
@@ -53,7 +53,7 @@ class Users::SessionsController < Devise::SessionsController
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
-      return render :challenge, status: :unprocessable_entity
+      return render :challenge, status: :unprocessable_content
     end
 
     begin
@@ -65,12 +65,12 @@ class Users::SessionsController < Devise::SessionsController
       )
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
-      return render :challenge, status: :unprocessable_entity
+      return render :challenge, status: :unprocessable_content
     end
 
     unless response[:user].present?
       flash.now[:errors] = [ "Invalid code" ]
-      return render :challenge, status: :unprocessable_entity
+      return render :challenge, status: :unprocessable_content
     end
 
     session[:challenge_session] = nil

--- a/reporting-app/config/initializers/devise.rb
+++ b/reporting-app/config/initializers/devise.rb
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> ORM configuration

--- a/reporting-app/config/initializers/oas_rails.rb
+++ b/reporting-app/config/initializers/oas_rails.rb
@@ -105,7 +105,7 @@ OasRails.configure do |config|
   # Example, if you add forbidden then it will be added only if the endpoint requires authentication.
   # Example: not_found will be setted to the endpoint only if the operation is a show/update/destroy action.
   config.set_default_responses = false
-  # config.possible_default_responses = [:not_found, :unauthorized, :forbidden, :internal_server_error, :unprocessable_entity]
+  # config.possible_default_responses = [:not_found, :unauthorized, :forbidden, :internal_server_error, :unprocessable_content]
   # config.response_body_of_default = "Hash{ errors: Array<String> }"
   # config.response_body_of_unprocessable_entity= "Hash{ errors: Array<String> }"
 end

--- a/reporting-app/spec/requests/activities_spec.rb
+++ b/reporting-app/spec/requests/activities_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "/activities", type: :request do
 
         it "renders a response with 422 status (unprocessable entity)" do
           post activity_report_application_form_activities_url(activity_report_application_form), params: { activity: invalid_attributes }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders error messages" do
@@ -123,7 +123,7 @@ RSpec.describe "/activities", type: :request do
 
         it "renders a response with 422 status (unprocessable entity)" do
           post activity_report_application_form_activities_url(activity_report_application_form), params: { activity: invalid_attributes }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "renders error messages" do
@@ -179,7 +179,7 @@ RSpec.describe "/activities", type: :request do
 
       it "renders a response with 422 status (unprocessable entity)" do
         post activity_report_application_form_activities_url(activity_report_application_form), params: { activity: invalid_attributes }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders error messages" do
@@ -217,7 +217,7 @@ RSpec.describe "/activities", type: :request do
     context "with invalid parameters" do
       it "renders a response with 422 status (unprocessable entity)" do
         patch activity_report_application_form_activity_url(activity_report_application_form, existing_activity), params: { activity: { activity_type: "not_accurate_type", hours: "Not a number", name: "" } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders an error if the name is blank" do

--- a/reporting-app/spec/requests/activity_report_application_forms_spec.rb
+++ b/reporting-app/spec/requests/activity_report_application_forms_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
       it "renders an unprocessable entity response" do
         activity_report_application_form = ActivityReportApplicationForm.create! valid_db_attributes
         patch activity_report_application_form_url(activity_report_application_form), params: { activity_report_application_form: invalid_attributes }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -231,7 +231,7 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
       it "renders an unprocessable entity response" do
         activity_report_application_form = ActivityReportApplicationForm.create! valid_db_attributes
         patch activity_report_application_form_url(activity_report_application_form), params: { activity_report_application_form: invalid_attributes }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "/demo/certifications", type: :request do
                    member_name_last: "Doe"
                  )
              }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders form with errors when member_name_first is missing" do
@@ -220,7 +220,7 @@ RSpec.describe "/demo/certifications", type: :request do
                    certification_date: "09/25/2025"
                  )
              }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders form with errors when member_name_last is missing" do
@@ -231,7 +231,7 @@ RSpec.describe "/demo/certifications", type: :request do
                    certification_date: "09/25/2025"
                  )
              }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "renders form with errors when date_of_birth is in the future" do
@@ -242,7 +242,7 @@ RSpec.describe "/demo/certifications", type: :request do
                    date_of_birth: (Date.current + 1.day).strftime("%m/%d/%Y")
                  )
              }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
@@ -113,13 +113,13 @@ RSpec.describe "/review_activity_report_tasks", type: :request do
       expect(task).to be_on_hold
     end
 
-    it "renders :unprocessable_entity when staff_comment is blank" do
+    it "renders :unprocessable_content when staff_comment is blank" do
       form_params  =  { activity_report_information_request: { staff_comment: "" } }
       expect {
         post create_information_request_review_activity_report_task_path(task), params: form_params
       }.not_to change(ActivityReportInformationRequest, :count)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
 
       task.reload
       expect(task).to be_pending

--- a/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
@@ -101,13 +101,13 @@ RSpec.describe "/review_exemption_claim_tasks", type: :request do
       expect(task).to be_on_hold
     end
 
-    it "renders :unprocessable_entity when staff_comment is blank" do
+    it "renders :unprocessable_content when staff_comment is blank" do
       form_params  =  { exemption_information_request: { staff_comment: "" } }
       expect {
         post create_information_request_review_exemption_claim_task_path(task), params: form_params
       }.not_to change(ExemptionInformationRequest, :count)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
 
       task.reload
       expect(task).to be_pending

--- a/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
+++ b/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
       it "shows error and re-renders form" do
         post certification_batch_uploads_path, params: { csv_file: nil }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("Upload Certification Roster")
         expect(flash[:alert]).to eq("Please select a CSV file to upload")
       end


### PR DESCRIPTION
Replace `:unprocessable_entity` with `:unprocessable_content` to resolve deprecation waring:
```
warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
```


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->