### PR TITLE
Show exemption approved when member status is exempt

### DIFF
--- a/reporting-app/app/controllers/dashboard_controller.rb
+++ b/reporting-app/app/controllers/dashboard_controller.rb
@@ -7,6 +7,7 @@ class DashboardController < ApplicationController
   before_action :set_exemption_application_form, if: -> { @certification_case.present? }
   before_action :set_activity_report_application_form, if: -> { @certification_case.present? }
   before_action :set_information_requests, if: -> { @exemption_application_form.present? || @activity_report_application_form.present? }
+  before_action :set_member_status, if: -> { @certification.present? }
 
 
   # TODO: figure out authz
@@ -39,5 +40,9 @@ class DashboardController < ApplicationController
     # There should only be one information request possible for all application forms.
     @information_requests = InformationRequest.for_application_forms([ @exemption_application_form&.id, @activity_report_application_form&.id ].compact)
     @information_request = @information_requests.select { |request| request.member_comment.blank? && request.supporting_documents.empty? }.first
+  end
+
+  def set_member_status
+    @member_status = MemberStatusService.determine(@certification)
   end
 end

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -2,9 +2,9 @@
 
 module DashboardHelper
   def determine_dashboard_view
-    return "exemption_approved" if @member_status&.status == MemberStatus::EXEMPT
-
-    if @certification.nil?
+    if member_status_exempt?
+      "exemption_approved"
+    elsif @certification.nil?
       "no_certification"
     elsif are_activity_report_or_exemption_incomplete?
       "new_certification"
@@ -24,6 +24,11 @@ module DashboardHelper
       # Fallback for unexpected states
       "new_certification"
     end
+  end
+
+  def member_status_exempt?
+    return false if @member_status.blank?
+    @member_status.status == MemberStatus::EXEMPT
   end
 
   def application_exists?

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -2,6 +2,8 @@
 
 module DashboardHelper
   def determine_dashboard_view
+    return "exemption_approved" if @member_status&.status == MemberStatus::EXEMPT
+
     if @certification.nil?
       "no_certification"
     elsif are_activity_report_or_exemption_incomplete?


### PR DESCRIPTION
## Ticket

Resolves #[TSS-498](https://linear.app/nava-platform/issue/TSS-498/demo-fix-must-have-batch-and-api-exempt-users-see-exemption-screen)

## Changes

- added before action on controller to set member status based on certification '
- added logic to render exemption accepted page if status is Exempt

## Context for reviewers

If a member triggers an Exemption based on Ex Parte data, then the member should see exemption accepted page. Examples would be age under 19 or pregnancy. This evaluation is triggered as the first step in the business process on a certification case created. 


## Testing

<img width="1694" height="916" alt="image" src="https://github.com/user-attachments/assets/635b94d2-cadc-4e97-bb1c-878aa1ce3c1e" />


<img width="671" height="198" alt="Screenshot 2025-11-10 at 5 54 07 PM" src="https://github.com/user-attachments/assets/01d4f2ce-fac6-4eed-b92e-48ba336f579f" />
<img width="839" height="192" alt="Screenshot 2025-11-10 at 5 54 45 PM" src="https://github.com/user-attachments/assets/1f43bd90-421b-4a7b-a0f8-b06e38667348" />
![2025-11-10 at 17 51 08 - Determination](https://github.com/user-attachments/assets/0aca90e6-77e1-4909-a92a-b588e34915c9)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->