### PR TITLE
fix item icons on certification screener page

### DIFF
--- a/reporting-app/app/views/exemption_screener/index.html.erb
+++ b/reporting-app/app/views/exemption_screener/index.html.erb
@@ -3,7 +3,7 @@
 <div class="border-bottom padding-bottom-1">
 <%= link_to(dashboard_path) do %>
   <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-    <use href="/assets/img/sprite.svg#navigate_before"></use>
+    <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#navigate_before"></use>
   </svg>
   <%= t(".back") %>
 <% end %>
@@ -21,7 +21,7 @@
     <li class="usa-icon-list__item">
       <div class="usa-icon-list__icon">
         <svg class="usa-icon" aria-hidden="true" role="img">
-          <use href="/assets/img/sprite.svg#arrow_forward"></use>
+          <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#arrow_forward"></use>
         </svg>
       </div>
 


### PR DESCRIPTION
## Ticket

Resolves #{[TSS-494](TSS-494/demo-fix-nice-to-have-add-item-icons-on-the-tell-us-about-your)}

## Changes

> use path helper for icons on screener page.

## Context for reviewers

This was a simple fix to user the path helper in rails vs hardcoded paths. The icons will show locally on dev but when deployed, rails will fingerprint all images to bust cache. To fix we use the rails path helper that adds the fingerprinted path. 

## Testing
cant really test this locally, but local box still works 

<img width="570" height="589" alt="image" src="https://github.com/user-attachments/assets/7bc6c1ac-10fa-4a31-ba2e-c49596f08fb0" />



<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->