### PR TITLE
Update CertificationCase index to display all open cases

### DIFF
--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -7,7 +7,7 @@ class CertificationCasesController < StaffController
   before_action :set_certification, only: %i[ show tasks documents notes ]
 
   def index
-    @cases = certification_service.fetch_open_actionable_cases
+    @cases = certification_service.fetch_open_cases
   end
 
   def closed

--- a/reporting-app/app/services/certification_service.rb
+++ b/reporting-app/app/services/certification_service.rb
@@ -22,6 +22,10 @@ class CertificationService
     hydrate_cases_with_certifications!(CertificationCase.open.actionable)
   end
 
+  def fetch_open_cases
+    hydrate_cases_with_certifications!(CertificationCase.open)
+  end
+
   def fetch_closed_cases
     hydrate_cases_with_certifications!(CertificationCase.closed)
   end

--- a/reporting-app/spec/factories/certification_case_factory.rb
+++ b/reporting-app/spec/factories/certification_case_factory.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
       end
     end
 
+    trait :waiting_on_member do
+      business_process_current_step { "report_activities" }
+    end
+
     trait :actionable do
       business_process_current_step { "review_activity_report" }
       after(:create) do |case_obj|

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -37,4 +37,35 @@ RSpec.describe "/staff/certification_cases", type: :request do
       end
     end
   end
+
+  describe "GET /index" do
+    before do
+      create(
+        :certification_case,
+        :actionable,
+        certification: create(:certification, case_number: "actionable_case")
+      )
+      create(
+        :certification_case,
+        :with_closed_status,
+        certification: create(:certification, case_number: "closed_case")
+      )
+      create(
+        :certification_case, :waiting_on_member,
+        certification: create(:certification, case_number: "waiting")
+      )
+    end
+
+    it "returns http success" do
+      get "/staff/certification_cases"
+      expect(response).to have_http_status(:success)
+    end
+
+    it "lists only open certification cases" do
+      get "/staff/certification_cases"
+      expect(response.body).to include("actionable_case")
+      expect(response.body).to include("waiting")
+      expect(response.body).not_to include("closed_case")
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

Resolves TSS-496

## Changes

Adds fetch_open_cases method to CertificationSerivce and updates CertificationCases#index to display all open cases in the "Open" tab, instead of only displaying actionable cases. Future work may add a third tab to separate actionable cases from cases waiting on member action.

## Testing

Before Update:
<img width="1392" height="693" alt="Screenshot 2025-11-10 at 5 26 30 PM" src="https://github.com/user-attachments/assets/128432b6-b523-4408-8511-fb1a310199a1" />

After Update:
<img width="1355" height="699" alt="Screenshot 2025-11-10 at 5 25 56 PM" src="https://github.com/user-attachments/assets/eedf519d-c43e-408c-b683-8332fc05ec57" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->