### PR TITLE
Resolve form_with deprecation warning

### DIFF
--- a/reporting-app/app/controllers/users/accounts_controller.rb
+++ b/reporting-app/app/controllers/users/accounts_controller.rb
@@ -2,11 +2,11 @@
 
 class Users::AccountsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_email_form, only: %i[ edit ]
+  before_action :set_password_form
   skip_after_action :verify_authorized
 
   def edit
-    @email_form = Users::UpdateEmailForm.new({ email: current_user.email })
-    @password_form = Users::ForgotPasswordForm.new({ email: current_user.email })
   end
 
   def update_email
@@ -28,6 +28,15 @@ class Users::AccountsController < ApplicationController
   end
 
   private
+
+    def set_email_form
+      @email_form = Users::UpdateEmailForm.new({ email: current_user.email })
+    end
+
+    def set_password_form
+      @password_form = Users::ForgotPasswordForm.new({ email: current_user.email })
+    end
+
     def auth_service
       AuthService.new
     end


### PR DESCRIPTION
Passing `nil` to the `:model` argument in `form_with` has been deprecated and will raise an exception in later versions of Rails. https://github.com/rails/rails/pull/50931

This work resolves the deprecation warning when a user attempts to update their email address with one that is invalid. Previously, this would re-render the edit view without setting @password_form causing the warning to be displayed. Now, the Users::Accounts controller has a `set_password_form` callback to ensure the password_form is set and the edit view renders correctly.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->