### PR TITLE
Add rubocop-rspec_rails gem and fix RSpec lint violations

### DIFF
--- a/reporting-app/.rubocop.yml
+++ b/reporting-app/.rubocop.yml
@@ -23,7 +23,13 @@ RSpec/NoExpectationExample:
     - assert_
     - is_expected_in_block
 
+RSpecRails/HaveHttpStatus:
+  Enabled: true
 RSpecRails/HttpStatusNameConsistency:
+  Enabled: true
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/NegationBeValid:
   Enabled: true
 
 Style/FrozenStringLiteralComment:

--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -635,9 +635,9 @@ DEPENDENCIES
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
   rubocop-rspec
+  rubocop-rspec_rails
   ruby-lsp
   ruby-lsp-rails
-  rubocop-rspec_rails
   selenium-webdriver
   simplecov
   sprockets-rails

--- a/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
+++ b/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
@@ -38,7 +38,7 @@ module Staff
         else
           message = "Failed to upload file: #{@batch_upload.errors.full_messages.join(', ')}"
           format.html { redirect_to new_certification_batch_upload_path, alert: message }
-          format.json { render json: { error: message }, status: :unprocessable_entity }
+          format.json { render json: { error: message }, status: :unprocessable_content }
         end
       end
     end
@@ -74,7 +74,7 @@ module Staff
         if @batch_upload.processable? == false
           message = "This batch cannot be processed. Current status: #{@batch_upload.status}."
           format.html { redirect_to certification_batch_upload_path(@batch_upload), alert: message }
-          format.json { render json: { error: message }, status: :unprocessable_entity }
+          format.json { render json: { error: message }, status: :unprocessable_content }
         elsif ProcessCertificationBatchUploadJob.perform_later(@batch_upload.id)
           format.html { redirect_to certification_batch_uploads_path, notice: "Processing started for #{@batch_upload.filename}. Results will be available shortly." }
           format.json { head :accepted }

--- a/reporting-app/spec/controllers/staff/certification_batch_uploads_controller_spec.rb
+++ b/reporting-app/spec/controllers/staff/certification_batch_uploads_controller_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe Staff::CertificationBatchUploadsController, type: :controller do
         expect(flash[:alert]).to eq("Failed to upload file: Filename can't be blank, File must be attached")
       end
 
-      it "returns unprocessable_entity status for JSON requests" do
+      it "returns unprocessable_content status for JSON requests" do
         post :create, params: { csv_file: csv_file, locale: "en", format: :json }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns error message in JSON for JSON requests" do
@@ -363,7 +363,7 @@ RSpec.describe Staff::CertificationBatchUploadsController, type: :controller do
         it "returns unprocessable entity status" do
           post :process_batch, params: { id: batch_upload.id, locale: "en", format: :json }
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns error message in JSON" do

--- a/reporting-app/spec/controllers/users/accounts_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/accounts_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Users::AccountsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 end

--- a/reporting-app/spec/controllers/users/passwords_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/passwords_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles auth provider errors" do
@@ -44,7 +44,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles submission by bots" do
@@ -53,7 +53,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles auth provider errors" do
@@ -104,7 +104,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles submission by bots" do
@@ -118,7 +118,7 @@ RSpec.describe Users::PasswordsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 end

--- a/reporting-app/spec/controllers/users/registrations_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/registrations_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Users::RegistrationsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles auth provider errors" do
@@ -57,7 +57,7 @@ RSpec.describe Users::RegistrationsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles submission by bots" do
@@ -73,7 +73,7 @@ RSpec.describe Users::RegistrationsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -107,7 +107,7 @@ RSpec.describe Users::RegistrationsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "handles auth provider errors" do
@@ -119,7 +119,7 @@ RSpec.describe Users::RegistrationsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 end

--- a/reporting-app/spec/controllers/users/sessions_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/sessions_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Users::SessionsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to have_selector("h1", text: /sign in/i)
       expect(response.body).to have_selector(".usa-alert--error")
     end
@@ -108,7 +108,7 @@ RSpec.describe Users::SessionsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -141,7 +141,7 @@ RSpec.describe Users::SessionsController do
         locale: "en"
       }
 
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to have_selector(".usa-alert--error")
     end
 

--- a/reporting-app/spec/forms/users/verify_account_form_spec.rb
+++ b/reporting-app/spec/forms/users/verify_account_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Users::VerifyAccountForm do
   it "requires email and code" do
     form = described_class.new(email: nil, code: nil)
 
-    expect(form).to be_invalid
+    expect(form).not_to be_valid
     expect(form.errors).to be_of_kind(:email, :blank)
     expect(form.errors).to be_of_kind(:code, :blank)
   end
@@ -20,14 +20,14 @@ RSpec.describe Users::VerifyAccountForm do
   it "requires email to be a valid email" do
     form = described_class.new(email: "invalid-email", code: "123456")
 
-    expect(form).to be_invalid
+    expect(form).not_to be_valid
     expect(form.errors).to be_of_kind(:email, :invalid)
   end
 
   it "requires code to be 6 characters" do
     form = described_class.new(email: "test@example.com", code: "12345")
 
-    expect(form).to be_invalid
+    expect(form).not_to be_valid
     expect(form.errors).to be_of_kind(:code, :wrong_length)
   end
 end


### PR DESCRIPTION
## Changes
  - Add rubocop-rspec_rails gem and configure in .rubocop.yml
  - Enable RSpecRails cops for HTTP status and validation matchers
  - Update HTTP status codes from :unprocessable_entity to :unprocessable_content
  - Replace numeric status checks (422) with semantic matcher have_http_status
  - Replace be_invalid with not_to be_valid for better RSpec idioms

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->