### PR TITLE
TSS-497 add order by create date on certification queue

### DIFF
--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -19,6 +19,7 @@ class CertificationCasesController < StaffController
     @information_requests = InformationRequest.for_application_forms(application_form_ids)
     @activity_report = ActivityReportApplicationForm.find_by(certification_case_id: @case.id)
     @member_status = MemberStatusService.determine(@case)
+    @tasks = @case.tasks.order(created_at: :desc)
   end
 
   private

--- a/reporting-app/app/views/certification_cases/show.html.erb
+++ b/reporting-app/app/views/certification_cases/show.html.erb
@@ -82,7 +82,7 @@
 
   <% component.with_heading { t(".tasks") } %>
   <% component.with_body do %>
-    <%= render partial: 'tasks_section', locals: { tasks: @case.tasks } %>
+    <%= render partial: 'tasks_section', locals: { tasks: @tasks } %>
   <% end %>
 
   <% component.with_heading { t(".information_requests") } %>


### PR DESCRIPTION
## Ticket

Resolves [TSS-497](https://linear.app/nava-platform/issue/TSS-497/demo-fix-nice-to-have-certification-case-queue-view-order-by-created)

## Changes

-  on the staff certification queue, the list is not sorted by create date 

## Context for reviewers

- simple addition of sorting for the staff view of certification cases . 

## Testing


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->