### PR TITLE
Remove task status enum overrides

### DIFF
--- a/reporting-app/app/models/review_activity_report_task.rb
+++ b/reporting-app/app/models/review_activity_report_task.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ReviewActivityReportTask < Strata::Task
-  # TODO: move :on_hold to Strata::Task
-  enum :status, { pending: 0, completed: 1, on_hold: 2 }
-
   # TODO: Figure out a better way to handle default due dates for tasks
   attribute :due_on, :date, default: -> { 7.days.from_now.to_date }
 

--- a/reporting-app/app/models/review_exemption_claim_task.rb
+++ b/reporting-app/app/models/review_exemption_claim_task.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ReviewExemptionClaimTask < Strata::Task
-  # TODO: move :on_hold to Strata::Task
-  enum :status, { pending: 0, completed: 1, on_hold: 2 }
-
   # TODO: Figure out a better way to handle default due dates for tasks
   attribute :due_on, :date, default: -> { 7.days.from_now.to_date }
 


### PR DESCRIPTION
## Ticket
Related to TSS-416

## Changes
Remove local enum overrides for ReviewActivityReportTask and ReviewExemptionClaimTask since the on_hold status is now available in the upstream Strata SDK. 

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->