### PR TITLE
fix update on certification request page

### DIFF
--- a/reporting-app/app/controllers/certifications_controller.rb
+++ b/reporting-app/app/controllers/certifications_controller.rb
@@ -80,9 +80,6 @@ class CertificationsController < StaffController
           if cert_params[:certification_requirements].present? && cert_params[:certification_requirements].is_a?(String)
             parsed_requirements = JSON.parse(cert_params[:certification_requirements])
 
-            # Permit all Requirements and RequirementParams attributes, plus nested params hash
-            permitted_keys = (Certifications::Requirements.attribute_names | Certifications::RequirementParams.attribute_names).map(&:to_sym)
-
             cert_params[:certification_requirements] =
               ActionController::Parameters.new(parsed_requirements).permit(
                 *Certifications::Requirements.attribute_names.map(&:to_sym).excluding(:months_that_can_be_certified, :params),


### PR DESCRIPTION
## Ticket

Resolves # [TSS-442/](https://linear.app/nava-platform/issue/TSS-442/bug-activity-report-flow-breaks-if-update-is-clicked-on-certification)
## Changes

- update the certification controller PATCH method to pull the nested params for certification requirements on updates. 

## Context for reviewers

When creating a new certification under demo, if a user updates the certification, the certification requirments get lost. this ultimately breaks the certification and will not work on other functions in the app. The change can been seen after update on the form, the requirements lose some values . 

## Testing
When clicking on update the values in the form fields all stay the same, nothing is lost.

<img width="966" height="1532" alt="image" src="https://github.com/user-attachments/assets/62122d30-13c9-47ee-a4b3-57b06ac16796" />



<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->