### PR TITLE
Update README.md Getting Started/Documentation Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ The platform consists of:
 - **Testing**: RSpec, Playwright (E2E)
 - **CI/CD**: GitHub Actions
 
-## Getting Started
+## Getting Started  
+
+If you are interested in:  
+- Getting OSCER set up locally, see instructions below or go to our [Getting Started guide](docs/how-to-guides/getting-started).
 
 ### Prerequisites
 
@@ -161,6 +164,7 @@ This is the administrative interface where staff can review and process member c
 
 ## Documentation
 
+- **[Getting Started](docs/how-to-guides/)** - Instructuctions for getting started
 - **[System Architecture](docs/system-architecture.md)** - High-level system overview
 - **[Reporting App Documentation](docs/reporting-app/)** - Detailed application documentation
 - **[Infrastructure Guide](docs/infra/)** - Deployment and infrastructure management


### PR DESCRIPTION
- Updated the Getting Started section of the README
- Added a link in the documentation section. 

Open question: should/can we remove the "getting started" instructions in the README as it will be in the "Getting Started" guide in the docs section of the repo?



<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->