### PR TITLE
Remove unused staff certifications new and create routes

### DIFF
--- a/reporting-app/app/controllers/certifications_controller.rb
+++ b/reporting-app/app/controllers/certifications_controller.rb
@@ -13,32 +13,6 @@ class CertificationsController < StaffController
   def show
   end
 
-  # GET /certifications/new
-  def new
-    @certification_form = authorize Certification.new
-  end
-
-  # POST /certifications/
-  def create
-    @certification = Certification.new(certification_params.except(:certification_requirements))
-
-    authorize @certification
-
-    requirement_params = certification_params.fetch(:certification_requirements, {})
-    begin
-      @certification.certification_requirements = certification_service.certification_requirements_from_input(requirement_params)
-    rescue ActiveModel::ValidationError => e
-      render json: { certification_requirements: e.model.errors }, status: :unprocessable_content
-      return
-    end
-
-    if @certification.save
-      render :show, status: :created, location: @certification
-    else
-      render json: @certification.errors, status: :unprocessable_content
-    end
-  end
-
   # PATCH/PUT /certifications/1
   # PATCH/PUT /certifications/1.json
   def update
@@ -50,51 +24,48 @@ class CertificationsController < StaffController
   end
 
   private
-    def set_certification
-      @certification = authorize Certification.find(params[:id])
+
+  def set_certification
+    @certification = authorize Certification.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def certification_params
+    # support both top-level params and under a "certification" key (for HTML form)
+    if params&.has_key?(:certification)
+      cert_params = params.fetch(:certification)
+    else
+      cert_params = params
     end
 
-    def certification_service
-      CertificationService.new
-    end
+    cert_params.permit(
+      :member_id,
+      :case_number,
+      :certification_requirements,
+      :member_data,
+      certification_requirements: {},
+      member_data: {}
+    ).tap do |cert_params|
+      begin
+        # handle HTML form input of the JSON blob as a string
+        if cert_params[:certification_requirements].present? && cert_params[:certification_requirements].is_a?(String)
+          parsed_requirements = JSON.parse(cert_params[:certification_requirements])
 
-    # Only allow a list of trusted parameters through.
-    def certification_params
-      # support both top-level params and under a "certification" key (for HTML form)
-      if params&.has_key?(:certification)
-        cert_params = params.fetch(:certification)
-      else
-        cert_params = params
-      end
-
-      cert_params.permit(
-        :member_id,
-        :case_number,
-        :certification_requirements,
-        :member_data,
-        certification_requirements: {},
-        member_data: {}
-      ).tap do |cert_params|
-        begin
-          # handle HTML form input of the JSON blob as a string
-          if cert_params[:certification_requirements].present? && cert_params[:certification_requirements].is_a?(String)
-            parsed_requirements = JSON.parse(cert_params[:certification_requirements])
-
-            cert_params[:certification_requirements] =
-              ActionController::Parameters.new(parsed_requirements).permit(
-                *Certifications::Requirements.attribute_names.map(&:to_sym).excluding(:months_that_can_be_certified, :params),
-                months_that_can_be_certified: [],
-                params: Certifications::RequirementParams.attribute_names.map(&:to_sym)
-              )
-          end
-
-          # handle HTML form input of the JSON blob as a string
-          if cert_params[:member_data].present? && cert_params[:member_data].is_a?(String)
-            cert_params[:member_data] = JSON.parse(cert_params[:member_data])
-          end
-        rescue JSON::ParserError => e
-          raise ActionController::BadRequest.new(e.message)
+          cert_params[:certification_requirements] =
+            ActionController::Parameters.new(parsed_requirements).permit(
+              *Certifications::Requirements.attribute_names.map(&:to_sym).excluding(:months_that_can_be_certified, :params),
+              months_that_can_be_certified: [],
+              params: Certifications::RequirementParams.attribute_names.map(&:to_sym)
+            )
         end
+
+        # handle HTML form input of the JSON blob as a string
+        if cert_params[:member_data].present? && cert_params[:member_data].is_a?(String)
+          cert_params[:member_data] = JSON.parse(cert_params[:member_data])
+        end
+      rescue JSON::ParserError => e
+        raise ActionController::BadRequest.new(e.message)
       end
     end
+  end
 end

--- a/reporting-app/app/views/certifications/index.html.erb
+++ b/reporting-app/app/views/certifications/index.html.erb
@@ -2,8 +2,6 @@
 
 <h1><%= t(".title") %></h1>
 
-<%= link_to t(".create"), new_certification_path(), class: "usa-button" %>
-
 <section class="d-flex flex-column flex-md-row gap-4 align-items-start justify-content-between">
   <table class="usa-table usa-table--borderless width-full">
     <thead>

--- a/reporting-app/app/views/certifications/new.html.erb
+++ b/reporting-app/app/views/certifications/new.html.erb
@@ -1,9 +1,0 @@
-<%= render partial: "application/breadcrumbs", locals: { crumbs: [
-  { name: t("certifications.index.title"), url: certifications_path },
-  ], current_name: t(".title")  } %>
-
-<% content_for :title, t(".title") %>
-
-<h1><%= t(".title") %></h1>
-
-<%= render "form", certification_form: @certification_form, submit_text: t(".submit") %>

--- a/reporting-app/config/locales/views/certifications/en.yml
+++ b/reporting-app/config/locales/views/certifications/en.yml
@@ -6,7 +6,6 @@ en:
     member_data: "Member data"
     index:
       title: "Certifications"
-      create: "Create Certification"
       columns:
         col_certification_id: "Certification ID"
         col_case_number: "Medicaid case number"
@@ -17,9 +16,6 @@ en:
     show:
       title: "Certification"
       submit: "Update"
-    new:
-      title: "New Certification"
-      submit: "Create"
     demo_create:
       title: "Certification Request"
       submit: "Request Certification"

--- a/reporting-app/config/routes.rb
+++ b/reporting-app/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :certifications
+    resources :certifications, only: [ :index, :show, :edit, :update ]
 
     resources :certification_cases, only: [ :index, :show ] do
       collection do

--- a/reporting-app/spec/requests/certifications_spec.rb
+++ b/reporting-app/spec/requests/certifications_spec.rb
@@ -75,53 +75,6 @@ RSpec.describe "/certifications", type: :request do
     end
   end
 
-  describe "POST /create" do
-    context "with valid parameters" do
-      it "creates a new Certification" do
-        expect {
-          post certifications_url,
-               params: { certification: valid_html_request_attributes }, headers: valid_headers
-        }.to change(Certification, :count).by(1)
-      end
-
-      it "renders a HTML response with the new certification" do
-        post certifications_url,
-             params: { certification: valid_html_request_attributes }, headers: valid_headers
-        expect(response).to have_http_status(:created)
-      end
-    end
-
-    context "with no member info" do
-      it "creates a new Certification" do
-        expect {
-          post certifications_url,
-               params: { certification: valid_html_request_attributes.deep_merge({ member_id: "no_user" }) }, headers: valid_headers
-        }.to change(Certification, :count).by(1)
-      end
-
-      it "renders a HTML response with the new certification" do
-        post certifications_url,
-             params: { certification: valid_html_request_attributes.deep_merge({ member_id: "no_user" }) }, headers: valid_headers
-        expect(response).to have_http_status(:created)
-      end
-    end
-
-    context "with invalid parameters" do
-      it "does not create a new Certification" do
-        expect {
-          post certifications_url,
-               params: { certification: invalid_request_attributes }
-        }.not_to change(Certification, :count)
-      end
-
-      it "renders a JSON response with errors for the new certification" do
-        post certifications_url,
-             params: { certification: invalid_request_attributes }, headers: valid_headers
-        expect(response).to be_client_error
-      end
-    end
-  end
-
   describe "PATCH /update" do
     context "with valid parameters" do
       let(:new_attributes) {

--- a/reporting-app/spec/routing/certifications_routing_spec.rb
+++ b/reporting-app/spec/routing/certifications_routing_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe CertificationsController, type: :routing do
       expect(get: "/staff/certifications/1").to route_to("certifications#show", id: "1")
     end
 
-    it "routes to #create" do
-      expect(post: "/staff/certifications").to route_to("certifications#create")
-    end
-
     it "routes to #update via PUT" do
       expect(put: "/staff/certifications/1").to route_to("certifications#update", id: "1")
     end


### PR DESCRIPTION
The new and create actions in the staff certifications controller were not being used. Staff certifications are created through the API and demo endpoints and batch upload process, not through the staff UI.

Removed:
- CertificationsController#new and #create actions
- app/views/certifications/new.html.erb view
- Related route definitions, tests, and locale keys
- Unused certification_service helper method
- Fixed indentation in Certifications controller

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->