### PR TITLE
Fix link to Getting Started guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The platform consists of:
 ## Getting Started  
 
 If you are interested in:  
-- Getting OSCER set up locally, see instructions below or go to our [Getting Started guide](docs/how-to-guides/getting-started).
+- Getting OSCER set up locally, see instructions below or go to our [Getting Started guide](docs/how-to-guides/getting-started.md).
 
 ### Prerequisites
 


### PR DESCRIPTION
## Changes

Fixes the URL to the getting started guide in the readme

## Testing

Tested by previewing the branch on github on our fork.

Happy Friday!
