### PR TITLE
Clean up test setup by using factory defaults

### DIFF
--- a/reporting-app/spec/factories/users_factory.rb
+++ b/reporting-app/spec/factories/users_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     uid { Faker::Internet.uuid }
-    provider { "factory_bot" }
+    provider { "login.gov" }
     mfa_preference { "opt_out" }
     full_name { nil }
     role { nil }

--- a/reporting-app/spec/models/activity_report_application_form_spec.rb
+++ b/reporting-app/spec/models/activity_report_application_form_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ActivityReportApplicationForm, type: :model do
     describe "certification_case_id uniqueness" do
       let(:certification) { create(:certification) }
       let(:certification_case) { create(:certification_case, certification: certification) }
-      let(:user) { create(:user) }
 
       it "requires unique certification_case_id" do
         create(:activity_report_application_form, certification_case_id: certification_case.id)

--- a/reporting-app/spec/requests/activities_spec.rb
+++ b/reporting-app/spec/requests/activities_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe "/activities", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: Faker::Internet.email, uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:other_user) { create(:user, email: Faker::Internet.email, uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:activity_report_application_form) do
     create(
       :activity_report_application_form,

--- a/reporting-app/spec/requests/activity_report_application_forms_spec.rb
+++ b/reporting-app/spec/requests/activity_report_application_forms_spec.rb
@@ -17,8 +17,8 @@ require 'rails_helper'
 RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:other_user) { create(:user, email: "test-other@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:certification_requirements) do
     build(
       :certification_certification_requirements,

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/api/certifications", type: :request do
   include Warden::Test::Helpers
 
-  let(:member_user) { create(:user, email: "member@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:member_user) { create(:user) }
 
   let(:valid_json_request_attributes) {
     {

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/staff/certification_cases", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "staff@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification_case) { create(:certification_case) }
 
   before do

--- a/reporting-app/spec/requests/certifications_spec.rb
+++ b/reporting-app/spec/requests/certifications_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe "/certifications", type: :request do
   include Warden::Test::Helpers
 
-  let(:staff_user) { create(:user, email: "staff@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:member_user) { create(:user, email: "member@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:staff_user) { create(:user) }
+  let(:member_user) { create(:user) }
 
   let(:valid_html_request_attributes) {
     {

--- a/reporting-app/spec/requests/dashboard_spec.rb
+++ b/reporting-app/spec/requests/dashboard_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe "/dashboard", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:other_user) { create(:user, email: "test-other@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
 
   before do
     login_as user

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/demo/certifications", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "foo@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user, email: "foo@example.com") }
 
   let(:valid_request_attributes) {
     {

--- a/reporting-app/spec/requests/exemption_application_forms_spec.rb
+++ b/reporting-app/spec/requests/exemption_application_forms_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/exemption_application_forms", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification) { create(:certification) }
   let(:certification_case) { create(:certification_case, certification: certification) }
   let(:valid_attributes) {

--- a/reporting-app/spec/requests/exemption_screener_spec.rb
+++ b/reporting-app/spec/requests/exemption_screener_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "ExemptionScreeners", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification) { create(:certification, :connected_to_email, email: user.email) }
   let(:certification_case) { create(:certification_case, certification: certification) }
 

--- a/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/review_activity_report_tasks", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:kase) { create(:certification_case, business_process_current_step: "review_activity_report") }
   let(:task) { create(:review_activity_report_task, case: kase) }
 

--- a/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/review_exemption_claim_tasks", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification_case) { create(:certification_case, business_process_current_step: "review_exemption_claim") }
   let(:task) { create(:review_exemption_claim_task, case: certification_case) }
 

--- a/reporting-app/spec/requests/staff/users_spec.rb
+++ b/reporting-app/spec/requests/staff/users_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe "/staff/users", type: :request do
   include Warden::Test::Helpers
 
-  let(:staff_user) { User.create!(email: "staff@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:other_user) { User.create!(email: "other@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:staff_user) { create(:user) }
 
   before do
     login_as staff_user

--- a/reporting-app/spec/requests/staff_spec.rb
+++ b/reporting-app/spec/requests/staff_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe "/staff", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
-  let(:other_user) { create(:user, email: "other@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:certification_case) { create(:certification_case) }
 
   before do

--- a/reporting-app/spec/requests/tasks_spec.rb
+++ b/reporting-app/spec/requests/tasks_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "/staff/tasks", type: :request do
   include Warden::Test::Helpers
 
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification) { create(:certification) }
   let(:certification_case) { create(:certification_case, certification_id: certification.id) }
 

--- a/reporting-app/spec/views/exemption_screener/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/exemption_screener/index.html.erb_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe "exemption_screener/index", type: :view do
-  let(:user) { create(:user, email: "test@example.com", uid: SecureRandom.uuid, provider: "login.gov") }
+  let(:user) { create(:user) }
   let(:certification) { create(:certification, :connected_to_email, email: user.email) }
   let(:certification_case) { create(:certification_case, certification: certification) }
 


### PR DESCRIPTION
Simplify test setup by removing redundant attribute overrides and relying on factory defaults for user creation. This makes tests cleaner, faster, and more maintainable.

Changes:
- Remove explicit uid: SecureRandom.uuid from 15 test files Factory now uses Faker::Internet.uuid (faster, seedable)

- Remove explicit email addresses from 8 test files where email isn't tested Factory default Faker::Internet.email is sufficient

- Remove 4 unused user let statements:
  - spec/models/activity_report_application_form_spec.rb
  - spec/requests/dashboard_spec.rb
  - spec/requests/activities_spec.rb
  - spec/requests/staff/users_spec.rb

- Remove explicit provider: "login.gov" from 15 test files Update factory default from "factory_bot" to "login.gov"

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->