### PR TITLE
Add activities attribute to certifications API member_data

### DIFF
--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -24,6 +24,28 @@ class Certifications::MemberData < ValueObject
     validates :period_end, presence: true
   end
 
+  class Activity < ValueObject
+    include ActiveModel::AsJsonAttributeType
+
+    ACTIVITY_TYPES = %w[hourly income].freeze
+    VERIFICATION_STATUSES = %w[verified self_attested pending].freeze
+
+    attribute :type, :string
+    attribute :category, :string
+    attribute :hours, :decimal
+    attribute :period_start, :date
+    attribute :period_end, :date
+    attribute :employer, :string
+    attribute :verification_status, :string
+
+    validates :type, presence: true, inclusion: { in: ACTIVITY_TYPES }
+    validates :category, presence: true, inclusion: { in: ::Activity::ALLOWED_CATEGORIES }
+    validates :hours, presence: true
+    validates :period_start, presence: true
+    validates :period_end, presence: true
+    validates :verification_status, inclusion: { in: VERIFICATION_STATUSES }, allow_nil: true
+  end
+
   class PayrollAccount < ValueObject
     include ActiveModel::AsJsonAttributeType
 
@@ -38,5 +60,6 @@ class Certifications::MemberData < ValueObject
   attribute :race_ethnicity, :string
 
   attribute :payroll_accounts, :array, of: PayrollAccount.to_type
+  attribute :activities, :array, of: Activity.to_type
   attribute :pregnancy_status, :boolean, default: false
 end

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -57,6 +57,17 @@
                   "last": "Doe",
                   "suffix": "Jr."
                 },
+                "activities": [
+                  {
+                    "type": "hourly",
+                    "category": "community_service",
+                    "hours": "20",
+                    "period_start": "2025-09-01",
+                    "period_end": "2025-09-30",
+                    "employer": "Community Center",
+                    "verification_status": "verified"
+                  }
+                ],
                 "date_of_birth": "1980-01-01",
                 "race_ethnicity": "Hispanic",
                 "pregnancy_status": false
@@ -249,6 +260,13 @@
               "$ref": "#/components/schemas/CertificationMemberDataPayrollAccount"
             }
           },
+          "activities": {
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/CertificationMemberDataActivity"
+            },
+            "description": "Community engagement activities performed by the member"
+          },
           "date_of_birth": {
             "type": ["string", "null"],
             "format": "date",
@@ -305,6 +323,53 @@
           }
         },
         "required": [
+          "period_start",
+          "period_end"
+        ]
+      },
+      "CertificationMemberDataActivity": {
+        "type": "object",
+        "description": "Description of an activity",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["hourly", "income"],
+            "description": "The type of activity (currently only 'hourly' is used)"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["employment", "community_service", "education"],
+            "description": "The category of activity"
+          },
+          "hours": {
+            "type": "string",
+            "format": "decimal",
+            "description": "Number of hours for the activity"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date",
+            "description": "Start date of the activity period"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "description": "End date of the activity period"
+          },
+          "employer": {
+            "type": ["string", "null"],
+            "description": "Employer or organization associated with the activity"
+          },
+          "verification_status": {
+            "type": ["string", "null"],
+            "enum": ["verified", "self_attested", "pending", null],
+            "description": "Verification status of the activity"
+          }
+        },
+        "required": [
+          "type",
+          "category",
+          "hours",
           "period_start",
           "period_end"
         ]
@@ -396,6 +461,17 @@
               "last": "Doe",
               "suffix": "Jr."
             },
+            "activities": [
+              {
+                "type": "hourly",
+                "category": "community_service",
+                "hours": "20",
+                "period_start": "2025-09-01",
+                "period_end": "2025-09-30",
+                "employer": "Community Center",
+                "verification_status": "verified"
+              }
+            ],
             "date_of_birth": "1980-01-01",
             "race_ethnicity": "Hispanic",
             "pregnancy_status": false

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -47,6 +47,14 @@ components:
                 middle: Alfred
                 last: Doe
                 suffix: Jr.
+              activities:
+              - type: hourly
+                category: community_service
+                hours: '20'
+                period_start: '2025-09-01'
+                period_end: '2025-09-30'
+                employer: Community Center
+                verification_status: verified
               date_of_birth: '1980-01-01'
               race_ethnicity: Hispanic
               pregnancy_status: false
@@ -211,6 +219,13 @@ components:
           - 'null'
           items:
             "$ref": "#/components/schemas/CertificationMemberDataPayrollAccount"
+        activities:
+          type:
+          - array
+          - 'null'
+          items:
+            "$ref": "#/components/schemas/CertificationMemberDataActivity"
+          description: Community engagement activities performed by the member
         date_of_birth:
           type:
           - string
@@ -265,6 +280,56 @@ components:
           - 'null'
           format: decimal
       required:
+      - period_start
+      - period_end
+    CertificationMemberDataActivity:
+      type: object
+      description: Description of an activity
+      properties:
+        type:
+          type: string
+          enum:
+          - hourly
+          - income
+          description: The type of activity (currently only 'hourly' is used)
+        category:
+          type: string
+          enum:
+          - employment
+          - community_service
+          - education
+          description: The category of activity
+        hours:
+          type: string
+          format: decimal
+          description: Number of hours for the activity
+        period_start:
+          type: string
+          format: date
+          description: Start date of the activity period
+        period_end:
+          type: string
+          format: date
+          description: End date of the activity period
+        employer:
+          type:
+          - string
+          - 'null'
+          description: Employer or organization associated with the activity
+        verification_status:
+          type:
+          - string
+          - 'null'
+          enum:
+          - verified
+          - self_attested
+          - pending
+          -
+          description: Verification status of the activity
+      required:
+      - type
+      - category
+      - hours
       - period_start
       - period_end
     CertificationResponseBody:
@@ -335,6 +400,14 @@ components:
             middle: Alfred
             last: Doe
             suffix: Jr.
+          activities:
+          - type: hourly
+            category: community_service
+            hours: '20'
+            period_start: '2025-09-01'
+            period_end: '2025-09-30'
+            employer: Community Center
+            verification_status: verified
           date_of_birth: '1980-01-01'
           race_ethnicity: Hispanic
           pregnancy_status: false
@@ -360,43 +433,43 @@ components:
       required:
       - status
   responses:
-    5649fe1af2ba1b2387d50bc57793d2c4:
+    e85a7efe856f3b4a33e16865be21f15d:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    7393ad9cb4433f13e8400556d66b8cc7:
+    6125a62221e212bb815526051661dbdc:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    9e226226d647cdd2b2f9de2f1e6820a0:
+    2e75eacc71eb2f0502fa228d762d5a55:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    63af00b74faf68e65aea0823fd314b1e:
+    90dc71790b26f81c5e56146f6d9f5018:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    312d6e66dd34f4cc44652c73271b12fd:
+    f03eaaaf493bc30b5c43df958dbb7e8e:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    481f92c30a59b9144510e9a4caaf9f07:
+    d490eeb4ff1770bf36c95bf8931bb69e:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    751fcb3d29beebba44f8d6b6a496945f:
+    4a0c71781938225c26730e68f030c36c:
       description: Response
       content:
         application/json:
@@ -412,7 +485,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    1c0c4e36f0e0064bc5da62d78a57a273:
+    3ac5de20e865f14a0346ef405d86aca7:
       description: The Certification data.
       content:
         application/json:
@@ -467,14 +540,14 @@ paths:
       description: "#"
       operationId: POST__api_certifications
       requestBody:
-        "$ref": "#/components/requestBodies/1c0c4e36f0e0064bc5da62d78a57a273"
+        "$ref": "#/components/requestBodies/3ac5de20e865f14a0346ef405d86aca7"
       responses:
         '201':
-          "$ref": "#/components/responses/5649fe1af2ba1b2387d50bc57793d2c4"
+          "$ref": "#/components/responses/e85a7efe856f3b4a33e16865be21f15d"
         '400':
-          "$ref": "#/components/responses/7393ad9cb4433f13e8400556d66b8cc7"
+          "$ref": "#/components/responses/6125a62221e212bb815526051661dbdc"
         '422':
-          "$ref": "#/components/responses/9e226226d647cdd2b2f9de2f1e6820a0"
+          "$ref": "#/components/responses/2e75eacc71eb2f0502fa228d762d5a55"
   "/api/certifications/{id}":
     get:
       tags:
@@ -486,9 +559,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/63af00b74faf68e65aea0823fd314b1e"
+          "$ref": "#/components/responses/90dc71790b26f81c5e56146f6d9f5018"
         '404':
-          "$ref": "#/components/responses/312d6e66dd34f4cc44652c73271b12fd"
+          "$ref": "#/components/responses/f03eaaaf493bc30b5c43df958dbb7e8e"
   "/api/health":
     get:
       tags:
@@ -498,6 +571,6 @@ paths:
       operationId: GET__api_health
       responses:
         '200':
-          "$ref": "#/components/responses/481f92c30a59b9144510e9a4caaf9f07"
+          "$ref": "#/components/responses/d490eeb4ff1770bf36c95bf8931bb69e"
         '503':
-          "$ref": "#/components/responses/751fcb3d29beebba44f8d6b6a496945f"
+          "$ref": "#/components/responses/4a0c71781938225c26730e68f030c36c"

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -37,20 +37,16 @@ FactoryBot.define do
 
     trait :partially_met_work_hours_requirement do
       with_no_exemptions
-      payroll_accounts {
+      activities {
         [
           {
-            "company_name": "Acme",
-            "paychecks":
-              [
-                {
-                  "period_start": cert_date.beginning_of_month,
-                  "period_end": cert_date.end_of_month,
-                  "gross": 123.45,
-                  "net": 50.00,
-                  "hours_worked": 10
-                }
-              ]
+            "type": "hourly",
+            "category": "employment",
+            "hours": 10,
+            "period_start": cert_date.beginning_of_month,
+            "period_end": cert_date.end_of_month,
+            "employer": "Acme",
+            "verification_status": "verified"
           }
         ]
       }
@@ -58,27 +54,40 @@ FactoryBot.define do
 
     trait :fully_met_work_hours_requirement do
       with_no_exemptions
-      payroll_accounts {
-        [
+      activities {
+        num_months.times.map { |i|
           {
-            "company_name": "Acme",
-            "paychecks": num_months.times.map { |i|
-              {
-                "period_start": cert_date.beginning_of_month << i,
-                "period_end": cert_date.end_of_month << i,
-                "gross": 2000.00,
-                "net": 1000.00,
-                "hours_worked": 80
-              }
-            }
+            "type": "hourly",
+            "category": "employment",
+            "hours": 80,
+            "period_start": cert_date.beginning_of_month << i,
+            "period_end": cert_date.end_of_month << i,
+            "employer": "Acme",
+            "verification_status": "verified"
           }
-        ]
+        }
       }
     end
 
     trait :meets_age_based_exemption_requirement do
       with_no_exemptions
       date_of_birth { cert_date - rand(1..18).years } # random age between 1 and 18 years old (eligible for age exemption)
+    end
+
+    trait :with_activities do
+      activities {
+        [
+          {
+            "type": "hourly",
+            "category": "community_service",
+            "hours": 20,
+            "period_start": cert_date.beginning_of_month,
+            "period_end": cert_date.end_of_month,
+            "employer": "Community Center",
+            "verification_status": "verified"
+          }
+        ]
+      }
     end
   end
 end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -115,6 +115,9 @@ RSpec.describe "/demo/certifications", type: :request do
           "first": create_attrs[:member_name_first],
           "last": create_attrs[:member_name_last]
         }))
+        expect(cert.member_data.activities).not_to be_nil
+        expect(cert.member_data.activities.length).to eq(1)
+        expect(cert.member_data.activities.first.hours).to eq(10)
       end
 
       it "creates Certification with 'Fully met work hours requirement'" do
@@ -133,6 +136,8 @@ RSpec.describe "/demo/certifications", type: :request do
           "first": create_attrs[:member_name_first],
           "last": create_attrs[:member_name_last]
         }))
+        expect(cert.member_data.activities).not_to be_nil
+        expect(cert.member_data.activities.sum(&:hours)).to eq(80)
       end
 
       it "creates a new Certification with 'Meets age-based exemption requirement' scenario and uses scenario DOB" do


### PR DESCRIPTION
Part of #78

Add support for tracking member activities in the certifications API. The new activities attribute is optional and allows recording hourly work and other activities with proper validation and verification status.

This work only includes saving the activities in the memeber_data attribute on a Certification record. Future work will add logic to store the activities data as ExParteActivity records and determine compliance.

Changes:
- Add Certifications::MemberData::Activity value object with attributes:
  - type: enum ["hourly", "income"] (required)
  - category: enum from Activity::ALLOWED_CATEGORIES (required)
  - hours: decimal (required)
  - period_start/period_end: dates (required)
  - employer: string (optional)
  - verification_status: enum ["verified", "self_attested", "pending"] (optional)
- Add activities array attribute to Certifications::MemberData
- Update OAS JSON schema with CertificationMemberDataActivity definition
- Update API request/response examples to include activities
- Add comprehensive test coverage for valid and invalid activities
- Update factory traits to use activities instead of payroll_accounts for exparte scenarios from demo crertification creation

## Testing

Creating a certification with activities via API
![cert-activities-api](https://github.com/user-attachments/assets/f3f101a6-94b5-409b-9564-7ba2a840341e)


Creating a certification with activities via demo/certifications form
![cert-demo-form](https://github.com/user-attachments/assets/8167ddcb-3b91-4e08-9b0e-ce84c8c821e6)


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->