### PR TITLE
Fix activity display to show member-reported hours

### DIFF
--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -60,7 +60,6 @@ class CertificationCasesController < StaffController
   def fetch_member_activities
     # Only include activities from approved activity reports to match the totals calculation
     return [] unless @activity_report
-    return [] unless @case.activity_report_approval_status == "approved"
 
     @activity_report.activities.where.not(hours: nil)
   end

--- a/reporting-app/app/services/hours_compliance_determination_service.rb
+++ b/reporting-app/app/services/hours_compliance_determination_service.rb
@@ -95,7 +95,6 @@ class HoursComplianceDeterminationService
       # Only include hours from approved activity reports (member-reported hours)
       certification_case = CertificationCase.find_by(certification_id: certification.id)
       return empty_hours_result unless certification_case
-      return empty_hours_result unless certification_case.activity_report_approval_status == "approved"
 
       form = ActivityReportApplicationForm.find_by(certification_case_id: certification_case.id)
       return empty_hours_result unless form

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe "/staff/certification_cases", type: :request do
                hours: 15,
                period_start: period_start,
                period_end: period_end)
+        create(:ex_parte_activity,
+               member_id: member_id,
+               category: "community_service",
+               hours: 15,
+               period_start: period_start,
+               period_end: period_end)
+        form = create(
+          :activity_report_application_form,
+          certification_case_id: certification_case.id,
+        )
+        form.activities.create(
+          hours: 10,
+          name: "Employer Inc",
+          type: "WorkActivity",
+          month: period_start
+        )
       end
 
       it "displays the hours reported table" do
@@ -77,13 +93,18 @@ RSpec.describe "/staff/certification_cases", type: :request do
         expect(response.body).to include("From the State")
         expect(response.body).to include("Employment")
         expect(response.body).to include("Community Service")
+        expect(response.body).to include("Self-reported")
+        expect(response.body).to include("Employer Inc")
       end
 
       it "displays total and required hours" do
         get "/staff/certification_cases/#{certification_case.id}"
         expect(response.body).to include("Total reported")
+        expect(response.body).to include("60")
         expect(response.body).to include("Required")
+        expect(response.body).to include("80")
         expect(response.body).to include("Additional hours needed")
+        expect(response.body).to include("20")
       end
     end
 


### PR DESCRIPTION
Resolves #120

Remove approval status checks that prevented member activities from appearing in the case view table. This also allows self reported hours to be included in the hours summary displayed on the member dashboard.

Summary of changes:
- Removed the approval status check in certification_cases_controller.rb:63 and hours_compliance_determination_service.rb:98
- This allows staff to view member-reported activities and hours even when the activity report is still pending approval
- Updated tests to verify both ex parte activities and self-reported activities appear correctly with accurate hour totals

## Testing
**Case view before update**
<img width="1055" height="1000" alt="Screenshot 2025-12-17 at 10 10 37 AM" src="https://github.com/user-attachments/assets/5d127435-5695-4509-be29-b188ef4e61ea" />
**Case view after update**
<img width="1031" height="1020" alt="Screenshot 2025-12-17 at 10 10 19 AM" src="https://github.com/user-attachments/assets/3e9d997d-00a0-430a-84a8-8e7a51759598" />

**Member dashboard before update**
<img width="1025" height="842" alt="Screenshot 2025-12-17 at 10 10 48 AM" src="https://github.com/user-attachments/assets/4370cf7c-a533-4072-9e7e-9309497d5106" />
**Member dashboard after update**
<img width="1115" height="830" alt="Screenshot 2025-12-17 at 10 09 41 AM" src="https://github.com/user-attachments/assets/24eb824e-e67e-420c-9f6c-0e1fcc943ab9" />

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->