### PR TITLE
Change the process flow to send insufficient hours instead of action …

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -97,8 +97,12 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   transition(EX_PARTE_EXEMPTION_CHECK_STEP, "DeterminedExempt", SEND_EXEMPT_EMAIL_STEP)
 
   # --- Transitions: Ex parte hours check ---
+  # DeterminedHoursMet: Hours requirement satisfied
+  # DeterminedActionRequired: No ex parte hours found, member needs to report from scratch
+  # DeterminedHoursInsufficient: Has some ex parte hours but needs more
   transition(EX_PARTE_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedHoursMet", SEND_COMPLIANT_EMAIL_STEP)
   transition(EX_PARTE_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedActionRequired", SEND_ACTION_REQUIRED_EMAIL_STEP)
+  transition(EX_PARTE_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedHoursInsufficient", SEND_INSUFFICIENT_HOURS_EMAIL_STEP)
 
   # --- Transitions: Notification steps → next workflow step ---
   transition(SEND_COMPLIANT_EMAIL_STEP, "NotificationSent", END_STEP)


### PR DESCRIPTION
## Ticket
Resolves #119

## Changes
Updates the SEND_ACTION_REQUIRED_EMAIL_STEP to send insufficient hours email when ex parte hours have been submitted, but do not meet the required monthly total. The action required notification will still be sent if no ex parte hours have been submitted.

## Testing
### Test Scenario 1
- Navigate to the /demo/certifications/new path
- Fill out the form with your email address, and select "Partially met work hours requirement" from the "Ex parte scenario" select input.
- Click Request Certification
- Expected: You recieve an insufficent hours email

### Test Scenario 2
- Navigate to the /demo/certifications/new path
- Fill out the form with your email address, and do not select any "Ex parte scenario" options
- Click Request Certification
- Expected: You recieve an action required

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->