### PR TITLE
Fix authorization for closed certification cases endpoint

### DIFF
--- a/reporting-app/app/policies/staff_policy.rb
+++ b/reporting-app/app/policies/staff_policy.rb
@@ -7,6 +7,10 @@ class StaffPolicy < ApplicationPolicy
     staff?
   end
 
+  def closed?
+    staff?
+  end
+
   def show?
     staff?
   end

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -146,4 +146,48 @@ RSpec.describe "/staff/certification_cases", type: :request do
       expect(response.body).not_to include("closed_case")
     end
   end
+
+  describe "GET /closed" do
+    before do
+      create(
+        :certification_case,
+        :with_closed_status,
+        certification: create(
+          :certification,
+          case_number: "closed_case_1",
+          certification_requirements: build(:certification_certification_requirements, region: "north")
+        )
+      )
+      create(
+        :certification_case,
+        :with_closed_status,
+        certification: create(
+          :certification,
+          case_number: "closed_case_2",
+          certification_requirements: build(:certification_certification_requirements, region: "north")
+        )
+      )
+      create(
+        :certification_case,
+        :actionable,
+        certification: create(
+          :certification,
+          case_number: "open_case",
+          certification_requirements: build(:certification_certification_requirements, region: "north")
+        )
+      )
+    end
+
+    it "returns http success" do
+      get "/staff/certification_cases/closed"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists only closed certification cases" do
+      get "/staff/certification_cases/closed"
+      expect(response.body).to include("closed_case_1")
+      expect(response.body).to include("closed_case_2")
+      expect(response.body).not_to include("open_case")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #129

Add missing closed? method to StaffPolicy to authorize staff access to the /staff/certification_cases/closed page. Includes test coverage verifying the endpoint displays only closed cases.

## Testing
**Before Fix**
![ClosedCaseFix-BeforeFix](https://github.com/user-attachments/assets/b6a3820f-e1df-4844-b44b-e6e6f2bb67b6)

**After Fix**
![ClosedCaseFix-AfterFix](https://github.com/user-attachments/assets/f98e6247-d5a8-40dd-8926-447e92f50fbd)


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->