### PR TITLE
Enable Style/RedundantSelf RuboCop cop

### DIFF
--- a/reporting-app/app/controllers/api_controller.rb
+++ b/reporting-app/app/controllers/api_controller.rb
@@ -26,7 +26,7 @@ class ApiController < ActionController::Metal
     # then handle rendering the errors themselves
     case errors
     when ActiveModel::Errors
-      msgs = self.format_active_model_errors(errors)
+      msgs = format_active_model_errors(errors)
     when Array
       msgs = errors
     when String

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -16,7 +16,7 @@ module Demo
       end
 
       def to_certification
-        certification_requirement_params = ::Certifications::RequirementParams.new_filtered(self.attributes.with_indifferent_access)
+        certification_requirement_params = ::Certifications::RequirementParams.new_filtered(attributes.with_indifferent_access)
         # shouldn't be possible, but we need to ensure the params are valid in
         # order to construct the requirements next
         if certification_requirement_params.invalid?
@@ -32,38 +32,38 @@ module Demo
 
         member_data = {}
 
-        case self.ex_parte_scenario
+        case ex_parte_scenario
         when "Partially met work hours requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :partially_met_work_hours_requirement, cert_date: self.certification_date
+              :certification_member_data, :partially_met_work_hours_requirement, cert_date: certification_date
             ).attributes.compact
           )
         when "Fully met work hours requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :fully_met_work_hours_requirement, cert_date: self.certification_date, num_months: self.number_of_months_to_certify
+              :certification_member_data, :fully_met_work_hours_requirement, cert_date: certification_date, num_months: number_of_months_to_certify
             ).attributes.compact)
         when "Meets age-based exemption requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :meets_age_based_exemption_requirement, cert_date: self.certification_date
+              :certification_member_data, :meets_age_based_exemption_requirement, cert_date: certification_date
             ).attributes.compact
           )
         end
 
         member_data = ::Certifications::MemberData.new(member_data).tap do |md|
-          md.name = self.member_name if self.member_name.present?
-          md.date_of_birth = self.date_of_birth if self.date_of_birth.present?
-          md.pregnancy_status = self.pregnancy_status if self.pregnancy_status.present?
-          md.race_ethnicity = self.race_ethnicity if self.race_ethnicity.present?
+          md.name = member_name if member_name.present?
+          md.date_of_birth = date_of_birth if date_of_birth.present?
+          md.pregnancy_status = pregnancy_status if pregnancy_status.present?
+          md.race_ethnicity = race_ethnicity if race_ethnicity.present?
         end
 
         @certification = FactoryBot.build(
           :certification,
           :connected_to_email,
-          email: self.member_email,
-          case_number: self.case_number,
+          email: member_email,
+          case_number: case_number,
           certification_requirements: certification_requirements,
           member_data: member_data,
         )

--- a/reporting-app/app/models/api/certifications/create_request.rb
+++ b/reporting-app/app/models/api/certifications/create_request.rb
@@ -10,11 +10,11 @@ class Api::Certifications::CreateRequest < ValueObject
   validates :certification_requirements, presence: true
 
   def self.from_request_params(params)
-    self.new_filtered(params)
+    new_filtered(params)
   end
 
   def to_certification
-    case self.certification_requirements
+    case certification_requirements
     when Certifications::Requirements
       # we are good to go
       certification_requirements = self.certification_requirements
@@ -25,7 +25,7 @@ class Api::Certifications::CreateRequest < ValueObject
       raise TypeError
     end
 
-    cert_attrs = self.attributes.merge({ certification_requirements: certification_requirements })
+    cert_attrs = attributes.merge({ certification_requirements: certification_requirements })
     Certification.new(cert_attrs)
   end
 end

--- a/reporting-app/app/models/api/certifications/response.rb
+++ b/reporting-app/app/models/api/certifications/response.rb
@@ -12,6 +12,6 @@ class Api::Certifications::Response < ValueObject
   attribute :updated_at, :datetime
 
   def self.from_certification(certification)
-    self.new_filtered(certification)
+    new_filtered(certification)
   end
 end

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -40,11 +40,11 @@ class Certification < ApplicationRecord
   end
 
   def member_email
-    self.member_account_email || self.member_contact_email
+    member_account_email || member_contact_email
   end
 
   def self.find_by_member_email(email)
-    self.find_by_member_account_email(email).or(self.find_by_member_contact_email(email))
+    find_by_member_account_email(email).or(find_by_member_contact_email(email))
   end
 
   # Check if certification exists with compound key (for duplicate prevention)

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -49,7 +49,7 @@ class CertificationCase < Strata::Case
       self.exemption_request_approval_status_updated_at = Time.current
       close!
 
-      certification = Certification.find(self.certification_id)
+      certification = Certification.find(certification_id)
       certification.record_determination!(
         decision_method: :manual,
         reasons: [ Determination::REASON_CODE_MAPPING[:exemption_request_compliant] ],
@@ -76,7 +76,7 @@ class CertificationCase < Strata::Case
   # Model only handles state changes - service handles events
   # @param eligibility_fact [Strata::RulesEngine::Fact] the evaluation result
   def record_exemption_determination(eligibility_fact)
-    certification = Certification.find(self.certification_id)
+    certification = Certification.find(certification_id)
 
     transaction do
       self.exemption_request_approval_status = "approved"
@@ -98,7 +98,7 @@ class CertificationCase < Strata::Case
   # @param outcome [Symbol] :compliant or :not_compliant
   # @param hours_data [Hash] aggregated hours data
   def record_hours_compliance(outcome, hours_data)
-    certification = Certification.find(self.certification_id)
+    certification = Certification.find(certification_id)
     reason_code = outcome == :compliant ? :hours_reported_compliant : :hours_reported_insufficient
 
     transaction do

--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -19,36 +19,36 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   before_validation :set_type_params
 
   def set_type_params
-    if self.certification_type.blank? || !Certifications::Requirements::CERTIFICATION_TYPE_OPTIONS.include?(self.certification_type)
+    if certification_type.blank? || !Certifications::Requirements::CERTIFICATION_TYPE_OPTIONS.include?(certification_type)
       return
     end
 
-    self.set_params_for_type(certification_type)
+    set_params_for_type(certification_type)
     # unset any existing explicit due_date
     self.due_date = nil
   end
 
   def to_requirements
     Certifications::Requirements.new({
-      "certification_date": self.certification_date,
-      "certification_type": self.certification_type,
-      "months_that_can_be_certified": self.months_that_can_be_certified,
-      "number_of_months_to_certify": self.number_of_months_to_certify,
-      "due_date": self.due_date,
-      "region": self.region,
-      "params": self.as_json
+      "certification_date": certification_date,
+      "certification_type": certification_type,
+      "months_that_can_be_certified": months_that_can_be_certified,
+      "number_of_months_to_certify": number_of_months_to_certify,
+      "due_date": due_date,
+      "region": region,
+      "params": as_json
     })
   end
 
   def months_that_can_be_certified
-    self.lookback_period.times.map { |i| self.certification_date.beginning_of_month << i }
+    lookback_period.times.map { |i| certification_date.beginning_of_month << i }
   end
 
   private
 
   def set_due_date_from_period
-    if self.due_period_days
-      self.due_date ||= self.certification_date + self.due_period_days.days
+    if due_period_days
+      self.due_date ||= certification_date + due_period_days.days
     end
   end
 end

--- a/reporting-app/app/models/certifications/requirement_type_params.rb
+++ b/reporting-app/app/models/certifications/requirement_type_params.rb
@@ -24,13 +24,13 @@ class Certifications::RequirementTypeParams < ValueObject
     # TODO: can be updated to load from some config, the DB, etc.
     case certification_type
     when "new_application"
-      self.new({
+      new({
         lookback_period: 1,
         number_of_months_to_certify: 1,
         due_period_days: 30
       })
     when "recertification"
-      self.new({
+      new({
         lookback_period: 6,
         number_of_months_to_certify: 3,
         due_period_days: 30

--- a/reporting-app/app/models/certifications/requirements.rb
+++ b/reporting-app/app/models/certifications/requirements.rb
@@ -32,7 +32,7 @@ class Certifications::Requirements < ValueObject
 
   def continuous_lookback_period?
     months_that_can_be_certified = self.months_that_can_be_certified
-    range = self.certification_lookback_date_range
+    range = certification_lookback_date_range
 
     num_months_that_can_be_certified = months_that_can_be_certified.length
     # +1 to the difference since this list is inclusive
@@ -42,9 +42,9 @@ class Certifications::Requirements < ValueObject
   end
 
   def continuous_lookback_period
-    return nil unless self.continuous_lookback_period?
+    return nil unless continuous_lookback_period?
 
-    self.certification_lookback_date_range
+    certification_lookback_date_range
   end
 
   private

--- a/reporting-app/lib/active_model/new_filtered.rb
+++ b/reporting-app/lib/active_model/new_filtered.rb
@@ -8,7 +8,7 @@ module ActiveModel
 
     module ClassMethods
       def attr_syms
-        self.attribute_names.map(&:to_sym)
+        attribute_names.map(&:to_sym)
       end
 
       def new_filtered(sliceable)
@@ -19,7 +19,7 @@ module ActiveModel
           obj = sliceable
         end
 
-        self.new(obj.slice(*self.attr_syms))
+        new(obj.slice(*attr_syms))
       end
     end
   end

--- a/reporting-app/lib/active_model/type/json.rb
+++ b/reporting-app/lib/active_model/type/json.rb
@@ -33,7 +33,7 @@ module ActiveModel
       end
 
       def deserialize(value)
-        self.cast(super(value))
+        cast(super(value))
       end
 
       def ==(other)

--- a/reporting-app/lib/union_object.rb
+++ b/reporting-app/lib/union_object.rb
@@ -12,13 +12,13 @@ class UnionObject
   end
 
   def self.attribute_names
-    self.union_types.flat_map { |t| t.attribute_names }
+    union_types.flat_map { |t| t.attribute_names }
   end
 
   def self.new(attributes = {})
     objs = []
 
-    for t in self.union_types
+    for t in union_types
       obj = t.new_filtered(attributes)
       if obj.valid?
         return obj

--- a/reporting-app/lib/value_object.rb
+++ b/reporting-app/lib/value_object.rb
@@ -13,6 +13,6 @@ class ValueObject
 
   def ==(other)
     return false if self.class != other.class
-    self.as_json == other.as_json
+    as_json == other.as_json
   end
 end


### PR DESCRIPTION
**Proposed Change:**
Removes unnecessary self. prefixes throughout the codebase to align with Ruby style conventions and improve code readability.

**Reference:**
https://docs.rubocop.org/rubocop/cops_style.html#styleredundantself
https://rubystyle.guide/#no-self-unless-required


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->