### PR TITLE
Update codeowners to only have navapbc/oscer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # More generic / higher level paths should be listed first.
 
-* @navapbc/platform-admins @navapbc/sdk
+* @navapbc/oscer


### PR DESCRIPTION
update code owners with new navapbc/oscer. This is inline with the new team structure. 

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->