### PR TITLE
Add step indicator to exemption screener workflow

### DIFF
--- a/reporting-app/app/controllers/exemption_screener_controller.rb
+++ b/reporting-app/app/controllers/exemption_screener_controller.rb
@@ -16,6 +16,7 @@ class ExemptionScreenerController < ApplicationController
   # Entry point - displays introductory landing page
   def index
     @first_exemption_type = Exemption.first_type
+    @current_step = :start
   end
 
   # GET /exemption-screener/question/:exemption_type
@@ -23,6 +24,7 @@ class ExemptionScreenerController < ApplicationController
   def show
     @current_question = @navigator.current_question
     @previous_exemption_type = @navigator.previous_location
+    @current_step = @current_exemption_type.to_sym
   end
 
   # POST /exemption-screener/question/:exemption_type
@@ -54,6 +56,7 @@ class ExemptionScreenerController < ApplicationController
     @exemption_name = Exemption.title_for(@current_exemption_type)
     @exemption_description = Exemption.description_for(@current_exemption_type)
     @required_documents = Exemption.supporting_documents_for(@current_exemption_type)
+    @current_step = :result
   end
 
   # POST /exemption-screener/may-qualify/:exemption_type
@@ -66,6 +69,7 @@ class ExemptionScreenerController < ApplicationController
   # Shown when user answers "No" to all questions
   def complete
     # Renders the "you likely need to report activities" page
+    @current_step = :result
   end
 
   private

--- a/reporting-app/app/helpers/exemption_screener_helper.rb
+++ b/reporting-app/app/helpers/exemption_screener_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ExemptionScreenerHelper
+  # Generates array of step symbols dynamically based on enabled exemptions
+  # Returns: [:start, :caregiver_child, :medical_condition, ..., :result]
+  def exemption_screener_steps
+    @exemption_screener_steps ||= [ :start ] + Exemption.enabled.map { |t| t[:id] } + [ :result ]
+  end
+
+  # Returns the display label for a given step symbol
+  def exemption_screener_step_label(step)
+    case step
+    when :start, :result
+      t("exemption_screener.steps.#{step}")
+    else
+      Exemption.title_for(step)
+    end
+  end
+end

--- a/reporting-app/app/views/exemption_screener/_step_indicator.html.erb
+++ b/reporting-app/app/views/exemption_screener/_step_indicator.html.erb
@@ -1,0 +1,43 @@
+<%
+# Exemption Screener step indicator with counter
+# @param current_step [Symbol] The current step
+%>
+<%
+  current_index = exemption_screener_steps.index(current_step)
+  total_steps = exemption_screener_steps.length
+  current_step_number = current_index + 1
+  current_step_label = exemption_screener_step_label(current_step)
+%>
+
+<div class="usa-step-indicator" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <% exemption_screener_steps.each_with_index do |step, index| %>
+      <%
+        status = if index < current_index
+          "complete"
+        elsif index == current_index
+          "current"
+        else
+          "incomplete"
+        end
+      %>
+
+      <li class="usa-step-indicator__segment usa-step-indicator__segment--<%= status %>"
+          aria-current="<%= status == 'current' ? 'true' : 'false' %>">
+        <span class="usa-step-indicator__segment-label">
+          <span class="usa-sr-only"><%= exemption_screener_step_label(step) %></span>
+        </span>
+      </li>
+    <% end %>
+  </ol>
+  <div class="usa-step-indicator__header">
+    <h2 class="usa-step-indicator__heading">
+      <span class="usa-step-indicator__heading-counter">
+        <span class="usa-sr-only">Step</span>
+        <span class="usa-step-indicator__current-step"><%= current_step_number %></span>
+        <span class="usa-step-indicator__total-steps">of <%= total_steps %></span>
+      </span>
+      <span class="usa-step-indicator__heading-text"><%= current_step_label %></span>
+    </h2>
+  </div>
+</div>

--- a/reporting-app/app/views/exemption_screener/complete.html.erb
+++ b/reporting-app/app/views/exemption_screener/complete.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="grid-container">
-  <div class="border-bottom padding-bottom-1 margin-bottom-4">
+  <div class="padding-bottom-1 margin-bottom-4">
     <%= link_to(dashboard_path, class: "usa-link") do %>
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
         <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#navigate_before"></use>
@@ -9,6 +9,8 @@
       <%= t(".back_to_dashboard") %>
     <% end %>
   </div>
+
+  <%= render "step_indicator", current_step: @current_step %>
 
   <main id="main-content">
     <h1 class="margin-bottom-2">

--- a/reporting-app/app/views/exemption_screener/index.html.erb
+++ b/reporting-app/app/views/exemption_screener/index.html.erb
@@ -1,14 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="grid-container">
-  <div class="border-bottom padding-bottom-1 margin-bottom-4">
-    <%= link_to(dashboard_path, class: "usa-link") do %>
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#navigate_before"></use>
-      </svg>
-      <%= t(".back_to_dashboard") %>
-    <% end %>
-  </div>
+  <%= render "step_indicator", current_step: @current_step %>
 
   <main id="main-content">
     <h1 class="font-heading-2xl margin-bottom-2">

--- a/reporting-app/app/views/exemption_screener/may_qualify.html.erb
+++ b/reporting-app/app/views/exemption_screener/may_qualify.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="grid-container">
-  <div class="border-bottom padding-bottom-1 margin-bottom-4">
+  <div class="padding-bottom-1 margin-bottom-4">
     <%= link_to(dashboard_path, class: "usa-link") do %>
       <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
         <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#navigate_before"></use>
@@ -9,6 +9,8 @@
       <%= t(".back_to_dashboard") %>
     <% end %>
   </div>
+
+  <%= render "step_indicator", current_step: @current_step %>
 
   <main id="main-content">
     <h1 class="margin-bottom-2">

--- a/reporting-app/app/views/exemption_screener/show.html.erb
+++ b/reporting-app/app/views/exemption_screener/show.html.erb
@@ -1,14 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="grid-container">
-  <div class="border-bottom padding-bottom-1 margin-bottom-4">
-    <%= link_to(dashboard_path, class: "usa-link") do %>
-      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="<%= asset_path '@uswds/uswds/dist/img/sprite.svg' %>#navigate_before"></use>
-      </svg>
-      <%= t(".back_to_dashboard") %>
-    <% end %>
-  </div>
+  <%= render "step_indicator", current_step: @current_step %>
 
   <main id="main-content">
     <h1 class="margin-bottom-2">

--- a/reporting-app/config/locales/views/exemption_screener/en.yml
+++ b/reporting-app/config/locales/views/exemption_screener/en.yml
@@ -1,5 +1,9 @@
 en:
   exemption_screener:
+    steps:
+      start: "Start"
+      result: "Result"
+
     index:
       title: "Tell us about your situation"
       back_to_dashboard: "Back to Dashboard"

--- a/reporting-app/spec/helpers/exemption_screener_helper_spec.rb
+++ b/reporting-app/spec/helpers/exemption_screener_helper_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExemptionScreenerHelper, type: :helper do
+  describe "#exemption_screener_steps" do
+    it "returns array starting with :start" do
+      expect(helper.exemption_screener_steps.first).to eq(:start)
+    end
+
+    it "ends with :result" do
+      expect(helper.exemption_screener_steps.last).to eq(:result)
+    end
+
+    it "includes all enabled exemption type IDs" do
+      enabled_ids = Exemption.enabled.map { |t| t[:id] }
+      steps = helper.exemption_screener_steps
+      enabled_ids.each do |id|
+        expect(steps).to include(id)
+      end
+    end
+
+    it "has length of enabled types + 2" do
+      expected_length = Exemption.enabled.count + 2
+      expect(helper.exemption_screener_steps.length).to eq(expected_length)
+    end
+
+    it "maintains order of enabled exemption types" do
+      enabled_ids = Exemption.enabled.map { |t| t[:id] }
+      steps = helper.exemption_screener_steps[1..-2] # exclude :start and :result
+      expect(steps).to eq(enabled_ids)
+    end
+
+    it "memoizes the result" do
+      first_call = helper.exemption_screener_steps
+      second_call = helper.exemption_screener_steps
+      expect(first_call.object_id).to eq(second_call.object_id)
+    end
+  end
+
+  describe "#exemption_screener_step_label" do
+    it "returns translation for :start" do
+      expect(helper.exemption_screener_step_label(:start)).to eq(I18n.t("exemption_screener.steps.start"))
+    end
+
+    it "returns translation for :result" do
+      expect(helper.exemption_screener_step_label(:result)).to eq(I18n.t("exemption_screener.steps.result"))
+    end
+
+    it "returns exemption title for exemption type steps" do
+      exemption_type = Exemption.enabled.first[:id]
+      expected = Exemption.title_for(exemption_type)
+      expect(helper.exemption_screener_step_label(exemption_type)).to eq(expected)
+    end
+
+    it "returns correct labels for all enabled exemption types" do
+      Exemption.enabled.each do |exemption|
+        id = exemption[:id]
+        expected_title = Exemption.title_for(id)
+        expect(helper.exemption_screener_step_label(id)).to eq(expected_title)
+      end
+    end
+  end
+end

--- a/reporting-app/spec/requests/exemption_screener_spec.rb
+++ b/reporting-app/spec/requests/exemption_screener_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "ExemptionScreeners", type: :request do
         expect(response.body).to include("Tell us about your situation")
         expect(response.body).to include("Start")
       end
+
+      it "displays step indicator with Start as current step" do
+        get exemption_screener_path(certification_case_id: certification_case.id)
+
+        expect(response.body).to include("usa-step-indicator")
+        expect(response.body).to include("usa-step-indicator__segment--current")
+      end
     end
 
     context "without certification_case_id" do
@@ -64,6 +71,18 @@ RSpec.describe "ExemptionScreeners", type: :request do
       expect(response).to have_http_status(:success)
       # Should include question text from config
       expect(response.body).to include(Exemption.question_for(first_exemption_type))
+    end
+
+    it "displays step indicator with current exemption type highlighted" do
+      get exemption_screener_question_path(
+        exemption_type: first_exemption_type,
+        certification_case_id: certification_case.id
+      )
+
+      expect(response.body).to include("usa-step-indicator")
+      expect(response.body).to include("usa-step-indicator__segment--current")
+      # Should include the exemption type title in the step indicator
+      expect(response.body).to include(Exemption.title_for(first_exemption_type))
     end
 
     context "with invalid exemption_type" do
@@ -176,6 +195,16 @@ RSpec.describe "ExemptionScreeners", type: :request do
 
       expect(response.body).to include(Exemption.title_for(first_exemption_type))
     end
+
+    it "displays step indicator with Result as current step" do
+      get exemption_screener_may_qualify_path(
+        exemption_type: first_exemption_type,
+        certification_case_id: certification_case.id
+      )
+
+      expect(response.body).to include("usa-step-indicator")
+      expect(response.body).to include("usa-step-indicator__segment--current")
+    end
   end
 
   describe "POST /exemption-screener/may-qualify/:exemption_type" do
@@ -237,6 +266,13 @@ RSpec.describe "ExemptionScreeners", type: :request do
       expect(response.body).to include(
         new_activity_report_application_form_path(certification_case_id: certification_case.id)
       )
+    end
+
+    it "displays step indicator with Result as current step" do
+      get exemption_screener_complete_path(certification_case_id: certification_case.id)
+
+      expect(response.body).to include("usa-step-indicator")
+      expect(response.body).to include("usa-step-indicator__segment--current")
     end
   end
 end

--- a/reporting-app/spec/views/exemption_screener/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/exemption_screener/index.html.erb_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "exemption_screener/index", type: :view do
     assign(:certification_case, certification_case)
     assign(:certification, certification)
     assign(:first_exemption_type, first_exemption_type)
+    assign(:current_step, :start)
   end
 
-  it "renders links to dashboard and first exemption question" do
+  it "renders link to first exemption question" do
     render
 
-    expect(rendered).to have_link(href: dashboard_path)
     expect(rendered).to have_link(
       href: exemption_screener_question_path(
         exemption_type: first_exemption_type,


### PR DESCRIPTION
## Ticket

Resolves #170 

## Changes
Displays progress through the exemption screening process using a counter format (e.g., "Step 2 of 8: Caregiver/Child"). The step indicator appears on all pages and dynamically adjusts when exemption types are added or removed from the configuration.

Implementation uses custom USWDS markup instead of the Strata step indicator partial because the Strata component requires all step labels to be defined in I18n translations. This approach needs dynamic labels from Exemption.title_for() to ensure automatic updates when exemption types are modified in the config, without requiring duplicate translations or code changes.

Changes:
- Add ExemptionScreenerHelper with methods to generate steps dynamically
- Create step indicator partial using USWDS counter format
- Set @current_step in controller actions (index, show, may_qualify, complete)
- Add step indicator to all exemption screener views
- Add translations for "Start" and "Result" step labels
- Add comprehensive test coverage for helper and integration tests

## Testing

![ExemptionScreener-StepIndicator](https://github.com/user-attachments/assets/7504937a-362d-4126-a9f2-ec0002c63eab)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->