### PR TITLE
add API security C4+ADR documentation

### DIFF
--- a/docs/architecture/api-security/api-security.md
+++ b/docs/architecture/api-security/api-security.md
@@ -63,7 +63,7 @@ Content-Type: application/json
 
 | Component     | Value                   |
 | ------------- | ----------------------- |
-| Algorithm     | HMAC-SHA256             |
+| Algorithm     | HMAC-SHA256 (`sha256`)  |
 | Message       | Request body (raw JSON) |
 | Encoding      | Base64 (strict)         |
 | Secret Source | `ENV["API_SECRET_KEY"]` |
@@ -109,7 +109,7 @@ Lightweight object representing an authenticated API caller for Pundit:
 
 ### HMAC-SHA256 over JWT/OAuth
 
-Use symmetric key signatures instead of OAuth or JWT. Simpler than OAuth (no token management), no external dependencies. JWT adds unnecessary complexity for a single trusted client. The SDK's `CognitoAdapter` already demonstrates this pattern. Tradeoff: must securely share and rotate the secret key out-of-band.
+Use symmetric key signatures instead of OAuth or JWT. Simpler than OAuth (no token management), no external dependencies. JWT adds unnecessary complexity for a single trusted client. The app's `CognitoAdapter` already demonstrates this pattern (`app/adapters/auth/cognito_adapter.rb`). Tradeoff: must securely share and rotate the secret key out-of-band.
 
 ### No replay prevention for idempotent sync
 
@@ -163,7 +163,7 @@ State systems must:
 body = { member_id: "123", hours: 80 }.to_json
 
 signature = Base64.strict_encode64(
-  OpenSSL::HMAC.digest("SHA256", ENV["API_SECRET_KEY"], body)
+  OpenSSL::HMAC.digest("sha256", ENV["API_SECRET_KEY"], body)
 )
 
 # Request


### PR DESCRIPTION

## Summary

Adds C4 + ADR architecture documentation for securing the Hours API using HMAC-SHA256 symmetric key authentication.

## What's Included

| File                                             | Purpose                                                   |
| ------------------------------------------------ | --------------------------------------------------------- |
| `docs/architecture/api-security/api-security.md` | Architecture spec with C4 diagrams and decisions          |
| `docs/architecture/api-security/stories.md`      | Implementation stories with acceptance criteria and tests |
| `docs/architecture/api-security/epic.md`         | Epic-level overview for stakeholders                      |

## Key Decisions

| Decision           | Choice                  | Why                                                                                        |
| ------------------ | ----------------------- | ------------------------------------------------------------------------------------------ |
| Auth mechanism     | HMAC-SHA256             | Simpler than OAuth/JWT for single trusted client; pattern exists in app's `CognitoAdapter` |
| Replay prevention  | **None**                | Idempotent data sync over TLS — replays cause no harm; can add later if required           |
| Pundit integration | `ApiClient` model       | Reuses existing policy infrastructure without special-casing                               |
| Secret management  | `ENV["API_SECRET_KEY"]` | Auto-generated via infra templates (SSM Parameter Store)                                   |

## Architecture Highlights

**Authentication Flow:**

1. State system generates HMAC signature from request body
2. `ApiController` calls `ApiAuthenticator.authenticate!(request)`
3. Authenticator verifies signature using constant-time comparison
4. On success: `ApiClient` object created for Pundit authorization
5. On failure: 401 with `{ "errors": ["..."] }`

**Request Format:**

```
POST /api/hours
Authorization: HMAC sig={base64_signature}
Content-Type: application/json
```

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->