### PR TITLE
Update exemption screener copy and add documentation

### DIFF
--- a/docs/how-to-guides/configuring-exemption-screener.md
+++ b/docs/how-to-guides/configuring-exemption-screener.md
@@ -1,0 +1,110 @@
+# Configuring the Exemption Screener
+
+This guide explains how to configure and manage the exemption types that appear in the member exemption screener.
+
+## Overview
+
+The exemption screener is a dynamic multi-step form that helps members determine if they qualify for an exemption from work requirements. The system is driven by a configuration file, a domain model, and a navigation service.
+
+| Component | Responsibility | Location |
+|-----------|----------------|----------|
+| **Configuration** | Source of truth for exemption data and questions | `config/initializers/exemption_types.rb` |
+| **Domain Model** | Interface for accessing and filtering exemption data | `app/models/exemption.rb` |
+| **Navigator** | Logic for moving between questions and determining outcomes | `app/services/exemption_screener_navigator.rb` |
+
+---
+
+## Step 1: Modifying Exemption Types
+
+All exemption types are defined in `config/initializers/exemption_types.rb`. This file populates `Rails.application.config.exemption_types` at boot time.
+
+### Configuration Fields
+
+Each exemption entry in the array is a hash with the following fields:
+
+- `id`: (Symbol) Unique identifier for the exemption type.
+- `title`: (String) Display name used in the staff portal and summary pages.
+- `description`: (String) Short explanation of the exemption.
+- `supporting_documents`: (Array of Strings) List of documents a member might need to provide.
+- `question`: (String) The actual question shown to the member in the screener.
+- `explanation`: (String) Additional context/help text shown below the question.
+- `yes_answer`: (String) The text for the "Yes" radio button option.
+- `enabled`: (Boolean) Controls whether this type appears in the screener.
+
+### Example Entry
+
+```ruby
+{
+  id: :caregiver_child,
+  title: "Parent or Caregiver of Dependent Age 13 or Younger",
+  description: "Parent or legal guardian of a young child (≤13), living in the same household.",
+  supporting_documents: [
+    "Relationship and co-residence verified via Medicaid/SNAP case",
+    "Child's birth certificate or custody paperwork"
+  ],
+  question: "Are you currently a caregiver for a child 13 years of age or under?",
+  explanation: "You may be eligible for an exemption if you are a parent, guardian...",
+  yes_answer: "I am a caregiver for a child under 13.",
+  enabled: true
+}
+```
+
+### Adding a New Exemption
+1. Add a new hash to the array in `exemption_types.rb`.
+2. Ensure the `id` is unique.
+3. Set `enabled: true`.
+4. **Note:** The order in the array determines the order in which questions are asked in the screener.
+
+---
+
+## Step 2: How the `Exemption` Model Works
+
+The `Exemption` model (`app/models/exemption.rb`) provides a clean API for the rest of the application to interact with the configuration.
+
+Key methods include:
+- `Exemption.all`: Returns all configured types.
+- `Exemption.enabled`: Returns only types where `enabled: true`.
+- `Exemption.next_type(current_id)`: Finds the next enabled exemption in the list.
+- `Exemption.previous_type(current_id)`: Finds the previous enabled exemption.
+- `Exemption.question_data_for(id)`: Fetches the question, explanation, and yes_answer for a specific type.
+
+This abstraction ensures that if we ever move the configuration to a database, the navigation logic won't need to change.
+
+---
+
+## Step 3: Navigation Logic
+
+The `ExemptionScreenerNavigator` (`app/services/exemption_screener_navigator.rb`) uses the `Exemption` model to drive the member's experience.
+
+### How it handles answers:
+
+When a member answers a question in the screener:
+
+1. **If the answer is "Yes"**: 
+   - The navigator returns a `:may_qualify` action.
+   - The member is directed to a page explaining they might qualify for that specific exemption.
+2. **If the answer is "No"**:
+   - The navigator calls `Exemption.next_type(current_type)`.
+   - If a next type exists, it returns a `:question` action with the new location.
+   - If no more types exist, it returns a `:complete` action (meaning the member likely doesn't qualify for any exemptions).
+
+### Direct Dependency Chain
+
+```mermaid
+graph TD
+    Config[config/initializers/exemption_types.rb] -->|Populates| AppConfig[Rails.application.config.exemption_types]
+    AppConfig -->|Read by| Model[app/models/exemption.rb]
+    Model -->|Provides next/prev/data| Navigator[app/services/exemption_screener_navigator.rb]
+    Navigator -->|Determines| UI[Screener UI / Controllers]
+```
+
+## Best Practices
+
+1. **Keep IDs Consistent**: Changing an `id` in the config might break existing records in the database if they refer to that ID (e.g., if exemptions are saved with that type).
+2. **Ordering Matters**: Place the most common or "easiest to verify" exemptions at the top of the list in `exemption_types.rb`. This affects the order of questions presented in the navigator.
+3. **Disabling**: If you need to temporarily/permanently remove an exemption from the screener, set `enabled: false` rather than deleting it. This preserves the metadata for existing database records.
+4. **I18n**: The `Exemption` model checks for translations in `config/locales/` using the key `exemption_types.{id}.{field}`. If a translation exists, it overrides the default text in the initializer.
+
+
+## Future Considerations
+1. In the future, `exemption_types.rb` will support additional exemption types that are not shown in the exemption screener UI. New exemption categories will be created to display these types, along with corresponding text for automated exemptions.

--- a/docs/how-to-guides/configuring-exemption-screener.md
+++ b/docs/how-to-guides/configuring-exemption-screener.md
@@ -8,7 +8,8 @@ The exemption screener is a dynamic multi-step form that helps members determine
 
 | Component | Responsibility | Location |
 |-----------|----------------|----------|
-| **Configuration** | Source of truth for exemption data and questions | `config/initializers/exemption_types.rb` |
+| **Configuration** | Controls which exemptions are active and their order | `config/initializers/exemption_types.rb` |
+| **Content** | Stores all display text for exemptions (I18n) | `config/locales/exemption_types.en.yml` |
 | **Domain Model** | Interface for accessing and filtering exemption data | `app/models/exemption.rb` |
 | **Navigator** | Logic for moving between questions and determining outcomes | `app/services/exemption_screener_navigator.rb` |
 
@@ -16,44 +17,60 @@ The exemption screener is a dynamic multi-step form that helps members determine
 
 ## Step 1: Modifying Exemption Types
 
-All exemption types are defined in `config/initializers/exemption_types.rb`. This file populates `Rails.application.config.exemption_types` at boot time.
+The configuration for exemption types is split between two files to separate system logic from display content:
 
-### Configuration Fields
+1. **`config/initializers/exemption_types.rb`**: Defines the list of active exemptions and their order.
+2. **`config/locales/exemption_types.en.yml`**: Contains all the human-readable text.
 
-Each exemption entry in the array is a hash with the following fields:
+### Configuration Fields (`exemption_types.rb`)
 
-- `id`: (Symbol) Unique identifier for the exemption type.
+Each entry in the initializer array is a hash with:
+
+- `id`: (Symbol) Unique identifier for the exemption type. This MUST match the key in the locale file.
+- `enabled`: (Boolean) Controls whether this type appears in the screener.
+
+### Content Fields (`exemption_types.en.yml`)
+
+The locale file defines the following fields under `en.exemption_types.{id}`:
+
 - `title`: (String) Display name used in the staff portal and summary pages.
 - `description`: (String) Short explanation of the exemption.
 - `supporting_documents`: (Array of Strings) List of documents a member might need to provide.
 - `question`: (String) The actual question shown to the member in the screener.
 - `explanation`: (String) Additional context/help text shown below the question.
 - `yes_answer`: (String) The text for the "Yes" radio button option.
-- `enabled`: (Boolean) Controls whether this type appears in the screener.
 
-### Example Entry
+### Example Configuration
 
+**In `config/initializers/exemption_types.rb`**:
 ```ruby
 {
   id: :caregiver_child,
-  title: "Parent or Caregiver of Dependent Age 13 or Younger",
-  description: "Parent or legal guardian of a young child (≤13), living in the same household.",
-  supporting_documents: [
-    "Relationship and co-residence verified via Medicaid/SNAP case",
-    "Child's birth certificate or custody paperwork"
-  ],
-  question: "Are you currently a caregiver for a child 13 years of age or under?",
-  explanation: "You may be eligible for an exemption if you are a parent, guardian...",
-  yes_answer: "I am a caregiver for a child under 13.",
   enabled: true
 }
 ```
 
+**In `config/locales/exemption_types.en.yml`**:
+```yaml
+en:
+  exemption_types:
+    caregiver_child:
+      title: "Parent or Caregiver of Dependent Age 13 or Younger"
+      description: "Parent or legal guardian of a young child (≤13), living in the same household."
+      supporting_documents:
+        - "Relationship and co-residence verified via Medicaid/SNAP case"
+        - "Child's birth certificate or custody paperwork"
+      question: "Are you currently a caregiver for a child 13 years of age or under?"
+      explanation: "You may be eligible for an exemption if you are a parent, guardian..."
+      yes_answer: "I am a caregiver for a child under 13."
+```
+
 ### Adding a New Exemption
-1. Add a new hash to the array in `exemption_types.rb`.
-2. Ensure the `id` is unique.
-3. Set `enabled: true`.
-4. **Note:** The order in the array determines the order in which questions are asked in the screener.
+1. Add a new hash with a unique `id` to the array in `exemption_types.rb`.
+2. Set `enabled: true`.
+3. Add a corresponding entry in `config/locales/exemption_types.en.yml` with the same `id`.
+4. Define all required text fields (`title`, `description`, etc.) in the locale file.
+5. **Note:** The order in the `exemption_types.rb` array determines the order in which questions are asked in the screener.
 
 ---
 
@@ -93,7 +110,8 @@ When a member answers a question in the screener:
 ```mermaid
 graph TD
     Config[config/initializers/exemption_types.rb] -->|Populates| AppConfig[Rails.application.config.exemption_types]
-    AppConfig -->|Read by| Model[app/models/exemption.rb]
+    Locale[config/locales/exemption_types.en.yml] -->|Provides Text| Model[app/models/exemption.rb]
+    AppConfig -->|Read by| Model
     Model -->|Provides next/prev/data| Navigator[app/services/exemption_screener_navigator.rb]
     Navigator -->|Determines| UI[Screener UI / Controllers]
 ```
@@ -103,7 +121,7 @@ graph TD
 1. **Keep IDs Consistent**: Changing an `id` in the config might break existing records in the database if they refer to that ID (e.g., if exemptions are saved with that type).
 2. **Ordering Matters**: Place the most common or "easiest to verify" exemptions at the top of the list in `exemption_types.rb`. This affects the order of questions presented in the navigator.
 3. **Disabling**: If you need to temporarily/permanently remove an exemption from the screener, set `enabled: false` rather than deleting it. This preserves the metadata for existing database records.
-4. **I18n**: The `Exemption` model checks for translations in `config/locales/` using the key `exemption_types.{id}.{field}`. If a translation exists, it overrides the default text in the initializer.
+4. **I18n by Default**: All display text must be managed in `config/locales/exemption_types.en.yml`. The `Exemption` model automatically looks up translations using the key `exemption_types.{id}.{field}`.
 
 
 ## Future Considerations

--- a/reporting-app/app/models/exemption.rb
+++ b/reporting-app/app/models/exemption.rb
@@ -30,14 +30,14 @@ class Exemption
       exemption_type = find(type)
       return nil unless exemption_type
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.title", default: exemption_type[:title])
+      I18n.t("exemption_types.#{exemption_type[:id]}.title")
     end
 
     def description_for(type)
       exemption_type = find(type)
       return nil unless exemption_type
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.description", default: exemption_type[:description])
+      I18n.t("exemption_types.#{exemption_type[:id]}.description")
     end
 
     def supporting_documents_for(type)
@@ -45,34 +45,28 @@ class Exemption
       return nil unless exemption_type
 
       key = "exemption_types.#{exemption_type[:id]}.supporting_documents"
-      # Check if translation exists; if not, return the array directly
-      # This avoids I18n's inconsistent handling of array defaults
-      if I18n.exists?(key)
-        I18n.t(key)
-      else
-        exemption_type[:supporting_documents]
-      end
+      I18n.t(key)
     end
 
     def question_for(type)
       exemption_type = find(type)
       return nil unless exemption_type
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.question", default: exemption_type[:question])
+      I18n.t("exemption_types.#{exemption_type[:id]}.question")
     end
 
     def explanation_for(type)
       exemption_type = find(type)
       return nil unless exemption_type
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.explanation", default: exemption_type[:explanation])
+      I18n.t("exemption_types.#{exemption_type[:id]}.explanation")
     end
 
     def yes_answer_for(type)
       exemption_type = find(type)
       return nil unless exemption_type
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.yes_answer", default: exemption_type[:yes_answer])
+      I18n.t("exemption_types.#{exemption_type[:id]}.yes_answer")
     end
 
     # Returns a hash with the question data for the given type

--- a/reporting-app/app/models/exemption.rb
+++ b/reporting-app/app/models/exemption.rb
@@ -26,47 +26,17 @@ class Exemption
       all.find { |t| t[:id] == type.to_sym }
     end
 
-    def title_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
+    ATTRIBUTES = %i[title description supporting_documents question explanation yes_answer].freeze
 
-      I18n.t("exemption_types.#{exemption_type[:id]}.title")
-    end
+    # Dynamically define methods that fetch I18n translations for exemption types
+    # Each method follows the pattern: attribute_for(type)
+    ATTRIBUTES.each do |attribute|
+      define_method("#{attribute}_for") do |type|
+        exemption_type = find(type)
+        return nil unless exemption_type
 
-    def description_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
-
-      I18n.t("exemption_types.#{exemption_type[:id]}.description")
-    end
-
-    def supporting_documents_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
-
-      key = "exemption_types.#{exemption_type[:id]}.supporting_documents"
-      I18n.t(key)
-    end
-
-    def question_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
-
-      I18n.t("exemption_types.#{exemption_type[:id]}.question")
-    end
-
-    def explanation_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
-
-      I18n.t("exemption_types.#{exemption_type[:id]}.explanation")
-    end
-
-    def yes_answer_for(type)
-      exemption_type = find(type)
-      return nil unless exemption_type
-
-      I18n.t("exemption_types.#{exemption_type[:id]}.yes_answer")
+        I18n.t("exemption_types.#{exemption_type[:id]}.#{attribute}")
+      end
     end
 
     # Returns a hash with the question data for the given type

--- a/reporting-app/config/initializers/exemption_types.rb
+++ b/reporting-app/config/initializers/exemption_types.rb
@@ -49,10 +49,13 @@ Rails.application.config.exemption_types = [
   },
   {
     id: :substance_treatment,
-    title: "Placeholder",
-    description: "Placeholder",
+    title: "Medically Frail or Special Medical Needs",
+    description: "Individual with serious, chronic, or disabling physical/mental health conditions.",
     supporting_documents: [
-      "Placeholder"
+      "Disability determination (SSA or Medicaid)",
+      "Physician attestation or diagnostic report",
+      "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services",
+      "MMIS data showing chronic or complex conditions"
     ],
     question: "Are you currently in treatment for substance abuse?",
     explanation: "You may be eligible if you are currently in treatment for substance abuse, like drugs or alcohol. " \

--- a/reporting-app/config/initializers/exemption_types.rb
+++ b/reporting-app/config/initializers/exemption_types.rb
@@ -3,110 +3,30 @@
 Rails.application.config.exemption_types = [
   {
     id: :caregiver_disability,
-    title: "Caregiver of Person with Disability or Incapable of Self-Care",
-    description: "Individual who provides daily care to someone with a disability or who cannot care for themselves (child or adult).",
-    supporting_documents: [
-      "Provider attestation or care plan indicating caregiver role",
-      "Documentation of dependent’s disability (e.g., SSA award, IEP, long-term care status)",
-      "Power of attorney, guardianship, or service authorization forms"
-    ],
-    question: "Are you currently a caregiver for someone with a disability or someone who cannot care for themselves without help?",
-    explanation: "You may be eligible for an exemption if you care for an individual of any age who has a disability or who cannot" \
-      " care for themselves without help.",
-    yes_answer: "I am a caregiver for someone who has a disability or who is unable to care for themselves without help.",
     enabled: true
   },
   {
     id: :caregiver_child,
-    title: "Parent or Caregiver of Dependent Age 13 or Younger",
-    description: "Parent or legal guardian of a young child (≤13), living in the same household.",
-    supporting_documents: [
-      "Relationship and co-residence verified via Medicaid/SNAP case",
-      "Child's birth certificate or custody paperwork",
-      "TANF or SNAP eligibility file indicating dependent child"
-    ],
-    question: "Are you currently a caregiver for a child 13 years of age or under?",
-    explanation: "You may be eligible for an exemption if you are a parent, guardian, caretaker relative, " \
-      "or family caregiver of a dependent child 13 years of age and under. ",
-    yes_answer: "I am a caregiver for a child under 13.",
     enabled: true
   },
   {
     id: :medical_condition,
-    title: "Medically Frail or Special Medical Needs",
-    description: "Individual with serious, chronic, or disabling physical/mental health conditions.",
-    supporting_documents: [
-      "Disability determination (SSA or Medicaid)",
-      "Physician attestation or diagnostic report",
-      "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services",
-      "MMIS data showing chronic or complex conditions"
-    ],
-    question: "Do you have a current medical condition that makes it hard for you to work or do daily activities?",
-    explanation: "You may be eligible if you have a physical, intellectual, or developmental disability, a disabling" \
-      " mental disorder, or those with serious or complex medical conditions.",
-    yes_answer: "I have a current medical condition that falls under one of the above categories.",
     enabled: true
   },
   {
     id: :substance_treatment,
-    title: "Medically Frail or Special Medical Needs",
-    description: "Individual with serious, chronic, or disabling physical/mental health conditions.",
-    supporting_documents: [
-      "Disability determination (SSA or Medicaid)",
-      "Physician attestation or diagnostic report",
-      "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services",
-      "MMIS data showing chronic or complex conditions"
-    ],
-    question: "Are you currently in treatment for substance abuse?",
-    explanation: "You may be eligible if you are currently in treatment for substance abuse, like drugs or alcohol. " \
-      "Treatment may include counseling, group sessions, a recover program, and/or medication to help with recovery " \
-      "(like methadone, suboxone, or naltrexone).",
-    yes_answer: "I am currently in treatment for substance abuse.",
     enabled: true
   },
   {
     id: :incarceration,
-    title: "Recently Released from Incarceration (within 90 days)",
-    description: "Released from jail or prison within the past three months.",
-    supporting_documents: [
-      "Release documentation from correctional facility",
-      "Probation or parole status record",
-      "Reentry program enrollment documents"
-    ],
-    question: "Have you been released from jail or prison in the last 90 days?",
-    explanation: "You may be eligible if you have been released from incarceration in the last 90 days.",
-    yes_answer: "I have been released from jail or prison in the last 90 days.",
     enabled: true
   },
   {
     id: :education_and_training,
-    title: "Student Enrolled at Least Half-Time",
-    description: "Actively enrolled in education or job training for at least half of a full-time course load.",
-    supporting_documents: [
-      "Transcript or course schedule showing at least half-time enrollment (typically 6+ credit hours)",
-      "Enrollment verification letter from institution",
-      "FAFSA or Pell Grant records"
-    ],
-    question: "Are you a student in college or vocational training and currently enrolled at least half-time?",
-    explanation: "You may be eligible if you are currently enrolled in a school at least half-time " \
-      "(typicall 6 credits for undergraduate students, but may vary by institution).",
-    yes_answer: "I am a student currently enrolled at least half-time.",
     enabled: true
   },
   {
     id: :received_medical_care,
-    title: "Received High-Acuity Medical Care",
-    description: "Hospitalization or intensive treatment that made work impossible during the month.",
-    supporting_documents: [
-      "Hospital discharge summary",
-      "Inpatient admission records",
-      "Provider statement confirming high-acuity care"
-    ],
-    question: "Have you recently stayed overnight at a medical facility or received intensive medical care?",
-    explanation: "You may be eligible if you recently received intensive medical care such as: staying in a hospital overnight" \
-      ", staying in a psychiatric hospital, staying in a nurshing or rehabilitation facility, or follow-up care related" \
-      " to one of these stays.",
-    yes_answer: "I have recently received overnight or intensive medical care.",
     enabled: true
   }
   # TODO: Add federal disaster declaration and medical care travel

--- a/reporting-app/config/initializers/exemption_types.rb
+++ b/reporting-app/config/initializers/exemption_types.rb
@@ -2,6 +2,21 @@
 
 Rails.application.config.exemption_types = [
   {
+    id: :caregiver_disability,
+    title: "Caregiver of Person with Disability or Incapable of Self-Care",
+    description: "Individual who provides daily care to someone with a disability or who cannot care for themselves (child or adult).",
+    supporting_documents: [
+      "Provider attestation or care plan indicating caregiver role",
+      "Documentation of dependent’s disability (e.g., SSA award, IEP, long-term care status)",
+      "Power of attorney, guardianship, or service authorization forms"
+    ],
+    question: "Are you currently a caregiver for someone with a disability or someone who cannot care for themselves without help?",
+    explanation: "You may be eligible for an exemption if you care for an individual of any age who has a disability or who cannot" \
+      " care for themselves without help.",
+    yes_answer: "I am a caregiver for someone who has a disability or who is unable to care for themselves without help.",
+    enabled: true
+  },
+  {
     id: :caregiver_child,
     title: "Parent or Caregiver of Dependent Age 13 or Younger",
     description: "Parent or legal guardian of a young child (≤13), living in the same household.",
@@ -10,12 +25,10 @@ Rails.application.config.exemption_types = [
       "Child's birth certificate or custody paperwork",
       "TANF or SNAP eligibility file indicating dependent child"
     ],
-    question: "Are you currently a caregiver for someone with a disability or a child 13 years of age or younger?",
-    explanation: "You may be eligible if you are a parent, guardian, caretaker relative, or family caregiver of a" \
-      " dependent child 13 years of age or under. You may also be eligible if you care for an individual of" \
-      " any age who has a disablility or who cannot care for themselves without help.",
-    yes_answer: "I am a caregiver for someone who has a disability (or who is unable to care for themselves without help)" \
-      " or a child under 13.",
+    question: "Are you currently a caregiver for a child 13 years of age or under?",
+    explanation: "You may be eligible for an exemption if you are a parent, guardian, caretaker relative, " \
+      "or family caregiver of a dependent child 13 years of age and under. ",
+    yes_answer: "I am a caregiver for a child under 13.",
     enabled: true
   },
   {

--- a/reporting-app/config/locales/exemption_types.en.yml
+++ b/reporting-app/config/locales/exemption_types.en.yml
@@ -1,0 +1,74 @@
+en:
+  exemption_types:
+    caregiver_disability:
+      title: "Caregiver of Person with Disability or Incapable of Self-Care"
+      description: "Individual who provides daily care to someone with a disability or who cannot care for themselves (child or adult)."
+      supporting_documents:
+        - "Provider attestation or care plan indicating caregiver role"
+        - "Documentation of dependent’s disability (e.g., SSA award, IEP, long-term care status)"
+        - "Power of attorney, guardianship, or service authorization forms"
+      question: "Are you currently a caregiver for someone with a disability or someone who cannot care for themselves without help?"
+      explanation: "You may be eligible for an exemption if you care for an individual of any age who has a disability or who cannot care for themselves without help."
+      yes_answer: "I am a caregiver for someone who has a disability or who is unable to care for themselves without help."
+    caregiver_child:
+      title: "Parent or Caregiver of Dependent Age 13 or Younger"
+      description: "Parent or legal guardian of a young child (≤13), living in the same household."
+      supporting_documents:
+        - "Relationship and co-residence verified via Medicaid/SNAP case"
+        - "Child's birth certificate or custody paperwork"
+        - "TANF or SNAP eligibility file indicating dependent child"
+      question: "Are you currently a caregiver for a child 13 years of age or under?"
+      explanation: "You may be eligible for an exemption if you are a parent, guardian, caretaker relative, or family caregiver of a dependent child 13 years of age and under. "
+      yes_answer: "I am a caregiver for a child under 13."
+    medical_condition:
+      title: "Medically Frail or Special Medical Needs"
+      description: "Individual with serious, chronic, or disabling physical/mental health conditions."
+      supporting_documents:
+        - "Disability determination (SSA or Medicaid)"
+        - "Physician attestation or diagnostic report"
+        - "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services"
+        - "MMIS data showing chronic or complex conditions"
+      question: "Do you have a current medical condition that makes it hard for you to work or do daily activities?"
+      explanation: "You may be eligible if you have a physical, intellectual, or developmental disability, a disabling mental disorder, or those with serious or complex medical conditions."
+      yes_answer: "I have a current medical condition that falls under one of the above categories."
+    substance_treatment:
+      title: "Medically Frail or Special Medical Needs"
+      description: "Individual with serious, chronic, or disabling physical/mental health conditions."
+      supporting_documents:
+        - "Disability determination (SSA or Medicaid)"
+        - "Physician attestation or diagnostic report"
+        - "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services"
+        - "MMIS data showing chronic or complex conditions"
+      question: "Are you currently in treatment for substance abuse?"
+      explanation: "You may be eligible if you are currently in treatment for substance abuse, like drugs or alcohol. Treatment may include counseling, group sessions, a recover program, and/or medication to help with recovery (like methadone, suboxone, or naltrexone)."
+      yes_answer: "I am currently in treatment for substance abuse."
+    incarceration:
+      title: "Recently Released from Incarceration (within 90 days)"
+      description: "Released from jail or prison within the past three months."
+      supporting_documents:
+        - "Release documentation from correctional facility"
+        - "Probation or parole status record"
+        - "Reentry program enrollment documents"
+      question: "Have you been released from jail or prison in the last 90 days?"
+      explanation: "You may be eligible if you have been released from incarceration in the last 90 days."
+      yes_answer: "I have been released from jail or prison in the last 90 days."
+    education_and_training:
+      title: "Student Enrolled at Least Half-Time"
+      description: "Actively enrolled in education or job training for at least half of a full-time course load."
+      supporting_documents:
+        - "Transcript or course schedule showing at least half-time enrollment (typically 6+ credit hours)"
+        - "Enrollment verification letter from institution"
+        - "FAFSA or Pell Grant records"
+      question: "Are you a student in college or vocational training and currently enrolled at least half-time?"
+      explanation: "You may be eligible if you are currently enrolled in a school at least half-time (typicall 6 credits for undergraduate students, but may vary by institution)."
+      yes_answer: "I am a student currently enrolled at least half-time."
+    received_medical_care:
+      title: "Received High-Acuity Medical Care"
+      description: "Hospitalization or intensive treatment that made work impossible during the month."
+      supporting_documents:
+        - "Hospital discharge summary"
+        - "Inpatient admission records"
+        - "Provider statement confirming high-acuity care"
+      question: "Have you recently stayed overnight at a medical facility or received intensive medical care?"
+      explanation: "You may be eligible if you recently received intensive medical care such as: staying in a hospital overnight, staying in a psychiatric hospital, staying in a nurshing or rehabilitation facility, or follow-up care related to one of these stays."
+      yes_answer: "I have recently received overnight or intensive medical care."

--- a/reporting-app/config/locales/exemption_types.en.yml
+++ b/reporting-app/config/locales/exemption_types.en.yml
@@ -18,7 +18,7 @@ en:
         - "Child's birth certificate or custody paperwork"
         - "TANF or SNAP eligibility file indicating dependent child"
       question: "Are you currently a caregiver for a child 13 years of age or under?"
-      explanation: "You may be eligible for an exemption if you are a parent, guardian, caretaker relative, or family caregiver of a dependent child 13 years of age and under. "
+      explanation: "You may be eligible for an exemption if you are a parent, guardian, caretaker relative, or family caregiver of a dependent child 13 years of age and under."
       yes_answer: "I am a caregiver for a child under 13."
     medical_condition:
       title: "Medically Frail or Special Medical Needs"
@@ -40,7 +40,7 @@ en:
         - "Enrollment in long-term services and supports (LTSS), SUD treatment, or home- and community-based services"
         - "MMIS data showing chronic or complex conditions"
       question: "Are you currently in treatment for substance abuse?"
-      explanation: "You may be eligible if you are currently in treatment for substance abuse, like drugs or alcohol. Treatment may include counseling, group sessions, a recover program, and/or medication to help with recovery (like methadone, suboxone, or naltrexone)."
+      explanation: "You may be eligible if you are currently in treatment for substance abuse, like drugs or alcohol. Treatment may include counseling, group sessions, a recovery program, and/or medication to help with recovery (like methadone, suboxone, or naltrexone)."
       yes_answer: "I am currently in treatment for substance abuse."
     incarceration:
       title: "Recently Released from Incarceration (within 90 days)"
@@ -60,7 +60,7 @@ en:
         - "Enrollment verification letter from institution"
         - "FAFSA or Pell Grant records"
       question: "Are you a student in college or vocational training and currently enrolled at least half-time?"
-      explanation: "You may be eligible if you are currently enrolled in a school at least half-time (typicall 6 credits for undergraduate students, but may vary by institution)."
+      explanation: "You may be eligible if you are currently enrolled in a school at least half-time (typically 6 credits for undergraduate students, but may vary by institution)."
       yes_answer: "I am a student currently enrolled at least half-time."
     received_medical_care:
       title: "Received High-Acuity Medical Care"
@@ -70,5 +70,5 @@ en:
         - "Inpatient admission records"
         - "Provider statement confirming high-acuity care"
       question: "Have you recently stayed overnight at a medical facility or received intensive medical care?"
-      explanation: "You may be eligible if you recently received intensive medical care such as: staying in a hospital overnight, staying in a psychiatric hospital, staying in a nurshing or rehabilitation facility, or follow-up care related to one of these stays."
+      explanation: "You may be eligible if you recently received intensive medical care such as: staying in a hospital overnight, staying in a psychiatric hospital, staying in a nursing or rehabilitation facility, or follow-up care related to one of these stays."
       yes_answer: "I have recently received overnight or intensive medical care."

--- a/reporting-app/spec/models/exemption_spec.rb
+++ b/reporting-app/spec/models/exemption_spec.rb
@@ -42,45 +42,45 @@ RSpec.describe Exemption, type: :model do
     let(:config) { described_class.find(type) }
 
     describe ".title_for" do
-      it "returns the title" do
-        expect(described_class.title_for(type)).to eq(config[:title])
+      it "returns the title from translations" do
+        expect(described_class.title_for(type)).to eq(I18n.t("exemption_types.#{type}.title"))
       end
     end
 
     describe ".description_for" do
-      it "returns the description" do
-        expect(described_class.description_for(type)).to eq(config[:description])
+      it "returns the description from translations" do
+        expect(described_class.description_for(type)).to eq(I18n.t("exemption_types.#{type}.description"))
       end
     end
 
     describe ".supporting_documents_for" do
-      it "returns the supporting documents" do
-        expect(described_class.supporting_documents_for(type)).to eq(config[:supporting_documents])
+      it "returns the supporting documents from translations" do
+        expect(described_class.supporting_documents_for(type)).to eq(I18n.t("exemption_types.#{type}.supporting_documents"))
       end
     end
 
     describe ".question_for" do
-      it "returns the question" do
-        expect(described_class.question_for(type)).to eq(config[:question])
+      it "returns the question from translations" do
+        expect(described_class.question_for(type)).to eq(I18n.t("exemption_types.#{type}.question"))
       end
     end
 
     describe ".explanation_for" do
-      it "returns the explanation" do
-        expect(described_class.explanation_for(type)).to eq(config[:explanation])
+      it "returns the explanation from translations" do
+        expect(described_class.explanation_for(type)).to eq(I18n.t("exemption_types.#{type}.explanation"))
       end
     end
 
     describe ".yes_answer_for" do
-      it "returns the yes_answer" do
-        expect(described_class.yes_answer_for(type)).to eq(config[:yes_answer])
+      it "returns the yes_answer from translations" do
+        expect(described_class.yes_answer_for(type)).to eq(I18n.t("exemption_types.#{type}.yes_answer"))
       end
     end
   end
 
   describe ".find" do
     it "returns the correct config for a given type" do
-      expect(described_class.find(:caregiver_child)[:title]).to eq("Parent or Caregiver of Dependent Age 13 or Younger")
+      expect(described_class.find(:caregiver_child)[:id]).to eq(:caregiver_child)
     end
 
     it "returns nil for an invalid type" do

--- a/reporting-app/spec/models/exemption_spec.rb
+++ b/reporting-app/spec/models/exemption_spec.rb
@@ -5,12 +5,13 @@ require "rails_helper"
 RSpec.describe Exemption, type: :model do
   describe ".all" do
     it "returns all 6 exemption types" do
-      expect(described_class.all.size).to eq(6)
+      expect(described_class.all.size).to eq(7)
     end
 
     it "contains specific exemption type IDs" do
       expected_ids = %i[
         caregiver_child
+        caregiver_disability
         medical_condition
         substance_treatment
         incarceration
@@ -25,6 +26,7 @@ RSpec.describe Exemption, type: :model do
     it "returns the list of valid exemption type strings" do
       expected_types = [
         "caregiver_child",
+        "caregiver_disability",
         "medical_condition",
         "substance_treatment",
         "incarceration",


### PR DESCRIPTION
## Ticket

Resolves #177 and #175 

- Refactor config to not contain default copy for the exemption screener. It was an odd decision to have one specific feature of the app contain text in one file vs the locale files, which store text for everything else.

## Changes

Modify exemption screener copy and question order
Add exemption type configuration documentation
Refactor config, move text to locale file by default


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->