### PR TITLE
Add API authentication

### DIFF
--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -20,5 +20,9 @@ locals {
       manage_method     = "generated"
       secret_store_name = "/${var.app_name}-${var.environment}/service/rails-secret-key-base"
     }
+    API_SECRET_KEY = {
+      manage_method     = "generated"
+      secret_store_name = "/${var.app_name}-${var.environment}/service/api-secret-key"
+    }
   }
 }

--- a/reporting-app/app/controllers/api/healthcheck_controller.rb
+++ b/reporting-app/app/controllers/api/healthcheck_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::HealthcheckController < ApiController
+  skip_before_action :authenticate_api_request!
+
   # @summary Check service health
   # @tags healthcheck
   #

--- a/reporting-app/app/controllers/api_controller.rb
+++ b/reporting-app/app/controllers/api_controller.rb
@@ -54,11 +54,11 @@ class ApiController < ActionController::Metal
   def authenticate_api_request!
     strategy = Strata::Auth::Strategies::Hmac.new(secret_key: Rails.configuration.api_secret_key)
     authenticator = Strata::ApiAuthenticator.new(strategy: strategy)
-
+    
     begin
       authenticator.authenticate!(request)
       @current_api_client = Api::Client.new
-    rescue Strata::Auth::AuthenticationError => e
+    rescue Strata::Auth::AuthenticationError, Strata::Auth::InvalidSignature, Strata::Auth::MissingCredentials => e
       render_errors([ e.message ], :unauthorized) && return
     end
   end

--- a/reporting-app/app/controllers/api_controller.rb
+++ b/reporting-app/app/controllers/api_controller.rb
@@ -12,6 +12,8 @@ class ApiController < ActionController::Metal
 
   include Pundit::Authorization
 
+  before_action :authenticate_api_request!
+
   def render_errors(errors, status = :unprocessable_content)
     # handle being given an ActiveModel (or any object) with an errors method
     if errors.respond_to?(:errors) && errors.errors.any?
@@ -47,5 +49,21 @@ class ApiController < ActionController::Metal
     errors.details.flat_map do |field_name, field_errs|
       field_errs.map { |err| err.merge(field: field_name) }
     end
+  end
+
+  def authenticate_api_request!
+    strategy = Strata::Auth::Strategies::Hmac.new(secret_key: Rails.configuration.api_secret_key)
+    authenticator = Strata::ApiAuthenticator.new(strategy: strategy)
+
+    begin
+      authenticator.authenticate!(request)
+      @current_api_client = Api::Client.new
+    rescue Strata::Auth::AuthenticationError => e
+      render_errors([ e.message ], :unauthorized) && return
+    end
+  end
+
+  def pundit_user
+    @current_api_client
   end
 end

--- a/reporting-app/app/controllers/api_controller.rb
+++ b/reporting-app/app/controllers/api_controller.rb
@@ -54,7 +54,7 @@ class ApiController < ActionController::Metal
   def authenticate_api_request!
     strategy = Strata::Auth::Strategies::Hmac.new(secret_key: Rails.configuration.api_secret_key)
     authenticator = Strata::ApiAuthenticator.new(strategy: strategy)
-    
+
     begin
       authenticator.authenticate!(request)
       @current_api_client = Api::Client.new

--- a/reporting-app/app/models/api/client.rb
+++ b/reporting-app/app/models/api/client.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Api::Client
+  # represents an authenticated API client (state system)
+  # Used by Pundit policies
+
+  def state_system?
+    true
+  end
+
+  def staff?
+    false
+  end
+
+  def member?
+    false
+  end
+end

--- a/reporting-app/app/policies/certification_policy.rb
+++ b/reporting-app/app/policies/certification_policy.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 class CertificationPolicy < ApplicationPolicy
-  def initialize(user, record)
-    # TODO: for demo purposes at the moment allow unauthenticated, but at some
-    # point that will change
-    # raise Pundit::NotAuthorizedError, "must be logged in" unless user
-    @user = user
-    @record = record
-  end
-
   def index?
     staff? || state_system?
   end
@@ -30,28 +22,11 @@ class CertificationPolicy < ApplicationPolicy
   end
 
   class Scope < ApplicationPolicy::Scope
-    def initialize(user, scope)
-      # TODO: for demo purposes at the moment allow unauthenticated, but at some
-      # point that will change
-      # raise Pundit::NotAuthorizedError, "must be logged in" unless user
-      @user = user
-      @scope = scope
-    end
-
     def resolve
       scope.all
     end
   end
 
-  private
-
-  def staff?
-    # TODO: once we have user types
-    true
-  end
-
-  def state_system?
-    # TODO: once we have user types
-    true
-  end
+  delegate :staff?, to: :user
+  delegate :state_system?, to: :user
 end

--- a/reporting-app/config/environments/development.rb
+++ b/reporting-app/config/environments/development.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/integer/time"
 # Custom setting: set the default url.
 Rails.application.default_url_options = { host: ENV["APP_HOST"], port: ENV["APP_PORT"] }
 
+Rails.application.config.api_secret_key = ENV["API_SECRET_KEY"]
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/reporting-app/config/environments/production.rb
+++ b/reporting-app/config/environments/production.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/integer/time"
 # Custom setting: set the default url.
 Rails.application.default_url_options = { host: ENV["APP_HOST"], port: ENV["APP_PORT"] }
 
+Rails.application.config.api_secret_key = ENV["API_SECRET_KEY"]
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/reporting-app/config/environments/test.rb
+++ b/reporting-app/config/environments/test.rb
@@ -10,6 +10,8 @@ require "active_support/core_ext/integer/time"
 # Custom setting: set the default url.
 Rails.application.default_url_options[:host] = "localhost"
 
+Rails.application.config.api_secret_key = "test-key"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/reporting-app/spec/policies/certification_policy_spec.rb
+++ b/reporting-app/spec/policies/certification_policy_spec.rb
@@ -4,9 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CertificationPolicy, type: :policy do
   let(:current_user) { create(:user) }
-  let(:staff_user) { create(:user) }
   let(:state_system_user) { Api::Client.new }
-
   let(:record) { create(:certification) }
 
   let(:resolved_scope) do

--- a/reporting-app/spec/policies/certification_policy_spec.rb
+++ b/reporting-app/spec/policies/certification_policy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CertificationPolicy, type: :policy do
   end
 
   context "when Staff" do
-    let(:current_user) { :staff_user }
+    let(:current_user) { create(:user, :as_caseworker) }
 
     it "forbids the destroy action" do
       expect(described_class.new(current_user, record)).to forbid_action(:destroy)
@@ -34,7 +34,7 @@ RSpec.describe CertificationPolicy, type: :policy do
   end
 
   context "when State System" do
-    let(:current_user) { :state_system_user }
+    let(:current_user) { Api::Client.new }
 
     it "forbids the destroy action" do
       expect(described_class.new(current_user, record)).to forbid_action(:destroy)

--- a/reporting-app/spec/policies/certification_policy_spec.rb
+++ b/reporting-app/spec/policies/certification_policy_spec.rb
@@ -3,11 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe CertificationPolicy, type: :policy do
-  subject { described_class.new(current_user, record) }
-
   let(:current_user) { create(:user) }
   let(:staff_user) { create(:user) }
-  let(:state_system_user) { create(:user) }
+  let(:state_system_user) { Api::Client.new }
 
   let(:record) { create(:certification) }
 
@@ -18,17 +16,17 @@ RSpec.describe CertificationPolicy, type: :policy do
   context "when unauthenticated" do
     let(:current_user) { nil }
 
-    it { is_expected.to forbid_only_actions(:destroy) }
-
-    it 'includes all records in the resolved scope' do
-      expect(resolved_scope).to include(record)
+    it "raises a Pundit::NotAuthorizedError" do
+      expect { described_class.new(current_user, record) }.to raise_error(Pundit::NotAuthorizedError)
     end
   end
 
   context "when Staff" do
     let(:current_user) { :staff_user }
 
-    it { is_expected.to forbid_only_actions(:destroy) }
+    it "forbids the destroy action" do
+      expect(described_class.new(current_user, record)).to forbid_action(:destroy)
+    end
 
     it 'includes all records in the resolved scope' do
       expect(resolved_scope).to include(record)
@@ -38,7 +36,9 @@ RSpec.describe CertificationPolicy, type: :policy do
   context "when State System" do
     let(:current_user) { :state_system_user }
 
-    it { is_expected.to forbid_only_actions(:destroy) }
+    it "forbids the destroy action" do
+      expect(described_class.new(current_user, record)).to forbid_action(:destroy)
+    end
 
     it 'includes all records in the resolved scope' do
       expect(resolved_scope).to include(record)

--- a/reporting-app/spec/rails_helper.rb
+++ b/reporting-app/spec/rails_helper.rb
@@ -39,6 +39,7 @@ require 'rspec/rails'
 require_relative 'support/factory_bot'
 require_relative 'support/pundit_spec_view_helper'
 require_relative 'support/policy_shared_examples'
+require "strata/testing/api_auth_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -64,6 +65,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
+  config.include Strata::Testing::ApiAuthHelpers
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include PunditSpecViewHelper, type: :view
 

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "/api/certifications", type: :request do
   include Warden::Test::Helpers
 
   let(:member_user) { create(:user) }
-
   let(:valid_json_request_attributes) {
     {
       member_id: "foobar",
@@ -20,21 +19,18 @@ RSpec.describe "/api/certifications", type: :request do
       certification_requirements: build(:certification_certification_requirement_params, :with_direct_params).as_json
     }
   }
-
   let(:invalid_request_attributes) {
     {
       certification_requirements: "()"
     }
   }
-
   # This should return the minimal set of values that should be in the headers
   # in order to pass any filters (e.g. authentication) defined in
   # CertificationsController, or in your router and rack
   # middleware. Be sure to keep this updated too.
   let(:valid_headers) {
-    {}
+    auth_headers(valid_json_request_attributes)
   }
-
   let(:valid_certifications) {
     [
       create(:certification),
@@ -53,6 +49,11 @@ RSpec.describe "/api/certifications", type: :request do
     ]
   }
 
+  def auth_headers(params = nil)
+    body = params ? params.to_json : "Hello World"
+    hmac_auth_headers(body: body, secret: Rails.configuration.api_secret_key)
+  end
+
   after do
     Warden.test_reset!
   end
@@ -60,7 +61,7 @@ RSpec.describe "/api/certifications", type: :request do
   describe "GET /{id}" do
     it "renders a successful response" do
       valid_certifications.each do |certification|
-        get api_certification_url(certification)
+        get api_certification_url(certification), headers: auth_headers
         expect(response).to be_successful
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
@@ -69,7 +70,7 @@ RSpec.describe "/api/certifications", type: :request do
     it "renders a successful response with invalid data" do
       certification = create(:certification)
       certification.update_column("certification_requirements", "()")
-      get api_certification_url(certification)
+      get api_certification_url(certification), headers: auth_headers
       expect(response).to be_successful
       expect(response).to match_openapi_doc(OPENAPI_DOC)
     end
@@ -78,10 +79,11 @@ RSpec.describe "/api/certifications", type: :request do
   describe "POST /" do
     context "with valid parameters" do
       it "creates a new Certification and renders response" do
+        params = valid_json_request_attributes
         expect {
           post api_certifications_url,
-               params: valid_json_request_attributes,
-               headers: valid_headers,
+               params: params,
+               headers: auth_headers(params),
                as: :json
         }.to change(Certification, :count).by(1)
 
@@ -93,12 +95,13 @@ RSpec.describe "/api/certifications", type: :request do
 
     context "with no member info" do
       it "creates a new Certification and renders response" do
+        params = valid_json_request_attributes.deep_merge({
+          member_id: "no_user"
+        })
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.deep_merge({
-                member_id: "no_user"
-              }),
-              headers: valid_headers,
+              params: params,
+              headers: auth_headers(params),
               as: :json
         }.to change(Certification, :count).by(1)
 
@@ -110,13 +113,14 @@ RSpec.describe "/api/certifications", type: :request do
 
     context "with no matching member info" do
       it "creates a new Certification and renders response" do
+        params = valid_json_request_attributes.deep_merge({
+          member_id: "no_user",
+          member_data: { account_email: "neverfound@foo.com" }
+        })
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.deep_merge({
-                member_id: "no_user",
-                member_data: { account_email: "neverfound@foo.com" }
-              }),
-              headers: valid_headers,
+              params: params,
+              headers: auth_headers(params),
               as: :json
         }.to change(Certification, :count).by(1)
 
@@ -129,13 +133,15 @@ RSpec.describe "/api/certifications", type: :request do
     context "with certification type" do
       it "creates a new Certification and renders response" do
         requirement_params = build(:certification_certification_requirement_params, :with_certification_type)
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
 
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.merge({
-                certification_requirements: requirement_params.as_json
-              }),
-              headers: valid_headers
+              params: params,
+              headers: auth_headers(params),
+              as: :json
         }.to change(Certification, :count).by(1)
 
         expect(response).to have_http_status(:created)
@@ -151,13 +157,15 @@ RSpec.describe "/api/certifications", type: :request do
     context "with direct certification requirements" do
       it "creates a new Certification and renders response" do
         certification_requirements = build(:certification_certification_requirements)
+        params = valid_json_request_attributes.merge({
+          certification_requirements: certification_requirements.as_json
+        })
 
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.merge({
-                certification_requirements: certification_requirements.as_json
-              }),
-              headers: valid_headers
+              params: params,
+              headers: auth_headers(params),
+              as: :json
         }.to change(Certification, :count).by(1)
 
         expect(response).to be_successful
@@ -175,12 +183,14 @@ RSpec.describe "/api/certifications", type: :request do
                             :with_account_email,
                             :partially_met_work_hours_requirement
                            )
+        params = valid_json_request_attributes.merge({
+          member_data: member_data.as_json
+        })
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.merge({
-                member_data: member_data.as_json
-              }),
-              headers: valid_headers
+              params: params,
+              headers: auth_headers(params),
+              as: :json
         }.to change(Certification, :count).by(1)
 
         expect(response).to be_successful
@@ -196,12 +206,14 @@ RSpec.describe "/api/certifications", type: :request do
                             :with_account_email,
                             :with_activities
                            )
+        params = valid_json_request_attributes.merge({
+          member_data: member_data.as_json
+        })
         expect {
           post api_certifications_url,
-              params: valid_json_request_attributes.merge({
-                member_data: member_data.as_json
-              }),
-              headers: valid_headers
+              params: params,
+              headers: auth_headers(params),
+              as: :json
         }.to change(Certification, :count).from(0).to(1)
 
         expect(response).to be_successful
@@ -236,14 +248,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.to change(ExParteActivity, :count).from(0).to(1)
           .and change(Certification, :count).from(0).to(1)
 
@@ -271,14 +285,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.not_to change(ExParteActivity, :count)
 
         expect(response).to have_http_status(:created)
@@ -306,14 +322,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.to change(ExParteActivity, :count).from(0).to(1)
 
         expect(response).to have_http_status(:created)
@@ -336,14 +354,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.to change(CertificationOrigin, :count).from(0).to(1)
 
         expect(response).to have_http_status(:created)
@@ -367,14 +387,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.not_to change(Certification, :count)
 
         expect(response).to have_http_status(:unprocessable_content)
@@ -403,14 +425,16 @@ RSpec.describe "/api/certifications", type: :request do
             }
           ]
         )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
 
         expect {
           post api_certifications_url,
-            params: valid_json_request_attributes.merge({
-              member_id: member_id,
-              member_data: member_data.as_json
-            }),
-            headers: valid_headers
+            params: params,
+            headers: auth_headers(params),
+            as: :json
         }.to change(ExParteActivity, :count).from(0).to(2)
 
         expect(response).to have_http_status(:created)
@@ -424,9 +448,11 @@ RSpec.describe "/api/certifications", type: :request do
 
     context "with invalid parameters" do
       it "does not create a new Certification and renders response" do
+        params = invalid_request_attributes
         expect {
           post api_certifications_url,
-               params: invalid_request_attributes,
+               params: params,
+               headers: auth_headers(params),
                as: :json
         }.not_to change(Certification, :count)
 
@@ -436,11 +462,12 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid cert requirements - lookback_period" do
+        params = valid_json_request_attributes.merge({
+          certification_requirements: { "lookback_period": 2 }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               certification_requirements: { "lookback_period": 2 }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error
@@ -449,11 +476,12 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid cert requirements - array" do
+        params = valid_json_request_attributes.merge({
+          certification_requirements: { "months_to_be_certified": [ "2025-10-16", "FOOBAR" ] }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               certification_requirements: { "months_to_be_certified": [ "2025-10-16", "FOOBAR" ] }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error
@@ -462,19 +490,20 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid activities - missing required field" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "community_service"
+                # missing required fields: hours, period_start, period_end
+              }
+            ]
+          }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               member_data: {
-                 activities: [
-                   {
-                     "type": "hourly",
-                     "category": "community_service"
-                     # missing required fields: hours, period_start, period_end
-                   }
-                 ]
-               }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error
@@ -483,22 +512,23 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid activities - invalid verification_status" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "community_service",
+                "hours": 20,
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s,
+                "verification_status": "invalid_status"
+              }
+            ]
+          }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               member_data: {
-                 activities: [
-                   {
-                     "type": "hourly",
-                     "category": "community_service",
-                     "hours": 20,
-                     "period_start": Date.today.to_s,
-                     "period_end": Date.today.to_s,
-                     "verification_status": "invalid_status"
-                   }
-                 ]
-               }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error
@@ -507,21 +537,22 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid activities - invalid type" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "invalid_type",
+                "category": "community_service",
+                "hours": 20,
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s
+              }
+            ]
+          }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               member_data: {
-                 activities: [
-                   {
-                     "type": "invalid_type",
-                     "category": "community_service",
-                     "hours": 20,
-                     "period_start": Date.today.to_s,
-                     "period_end": Date.today.to_s
-                   }
-                 ]
-               }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error
@@ -530,21 +561,22 @@ RSpec.describe "/api/certifications", type: :request do
       end
 
       it "invalid activities - invalid category" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "invalid_category",
+                "hours": 20,
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s
+              }
+            ]
+          }
+        })
         post api_certifications_url,
-             params: valid_json_request_attributes.merge({
-               member_data: {
-                 activities: [
-                   {
-                     "type": "hourly",
-                     "category": "invalid_category",
-                     "hours": 20,
-                     "period_start": Date.today.to_s,
-                     "period_end": Date.today.to_s
-                   }
-                 ]
-               }
-             }),
-             headers: valid_headers,
+             params: params,
+             headers: auth_headers(params),
              as: :json
 
         expect(response).to be_client_error

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "/api/certifications", type: :request do
   }
 
   def auth_headers(params = nil)
-    body = params ? params.to_json : "Hello World"
+    body = params ? params.to_json : ""
     hmac_auth_headers(body: body, secret: Rails.configuration.api_secret_key)
   end
 


### PR DESCRIPTION
## Ticket

Resolves #188 #189 #190 #191 

## Changes

Add API client object to be used as the Pundit user
Add Strata SDK api authenticator into base API controller
Update Certification policy to check pundit user/ remove hardcoded checks
Update API unit tests with API auth
Add api secret via Terraform


## Testing

I'll need to verify testing via making API calls after deployment to dev

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->