### PR TITLE
Implement parallel chunk processing for batch upload v2

### DIFF
--- a/reporting-app/app/adapters/storage/base_adapter.rb
+++ b/reporting-app/app/adapters/storage/base_adapter.rb
@@ -35,5 +35,15 @@ module Storage
     def stream_object(key:, &block)
       raise NotImplementedError
     end
+
+    # Download an object from storage to a file
+    # Note: Prefer stream_object for large files when possible.
+    # This method is provided for scenarios where you need the complete
+    # file available (e.g., passing to libraries that expect file paths).
+    # @param key [String] The object key (path) in the bucket
+    # @param file [File, Tempfile] The file object to write to
+    def download_to_file(key:, file:)
+      stream_object(key: key) { |line| file.write(line) }
+    end
   end
 end

--- a/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
+++ b/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Background job to process a single chunk of certification records
+# Part of batch upload v2 streaming architecture - processes chunks in parallel
+class ProcessCertificationBatchChunkJob < ApplicationJob
+  queue_as :default
+  retry_on ActiveRecord::Deadlocked, wait: :exponentially_longer, attempts: 3
+
+  # Process a chunk of certification records
+  # @param batch_upload_id [String] The UUID of the CertificationBatchUpload record
+  # @param chunk_number [Integer] The sequential chunk number (1-indexed)
+  # @param records [Array<Hash>] Array of record hashes to process
+  def perform(batch_upload_id, chunk_number, records)
+    batch_upload = CertificationBatchUpload.find(batch_upload_id)
+    processor = UnifiedRecordProcessor.new
+    audit_log = create_audit_log(batch_upload, chunk_number)
+
+    results = { succeeded: 0, failed: 0, errors: [] }
+    context = { batch_upload_id: batch_upload.id }
+
+    records.each_with_index do |record, index|
+      row_number = calculate_row_number(chunk_number, index)
+
+      begin
+        processor.process(record, context: context)
+        results[:succeeded] += 1
+      rescue UnifiedRecordProcessor::ProcessingError => e
+        results[:failed] += 1
+        results[:errors] << {
+          row_number: row_number,
+          error_code: e.code,
+          error_message: e.message,
+          row_data: record
+        }
+      rescue StandardError => e
+        # Catch unexpected errors (shouldn't happen, but safety net)
+        results[:failed] += 1
+        results[:errors] << {
+          row_number: row_number,
+          error_code: "ERR_UNKNOWN",
+          error_message: e.message,
+          row_data: record
+        }
+      end
+    end
+
+    complete_audit_log(audit_log, results)
+    update_counters!(batch_upload, records.size, results)
+    store_errors!(batch_upload, results[:errors])
+    check_completion!(batch_upload)
+
+  rescue StandardError => e
+    # Mark audit log as failed if chunk job crashes (system error)
+    audit_log&.update!(status: :failed) if audit_log
+    Rails.logger.error("Chunk #{chunk_number} for batch #{batch_upload_id} failed: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    raise
+  end
+
+  private
+
+  def create_audit_log(batch_upload, chunk_number)
+    CertificationBatchUploadAuditLog.create!(
+      certification_batch_upload: batch_upload,
+      chunk_number: chunk_number,
+      status: :started,
+      succeeded_count: 0,
+      failed_count: 0
+    )
+  end
+
+  def complete_audit_log(audit_log, results)
+    audit_log.update!(
+      status: :completed,
+      succeeded_count: results[:succeeded],
+      failed_count: results[:failed]
+    )
+  end
+
+  def calculate_row_number(chunk_number, index)
+    # chunk_number is 1-indexed, index is 0-indexed
+    # Add 2 to account for CSV header row
+    ((chunk_number - 1) * CsvStreamReader::DEFAULT_CHUNK_SIZE) + index + 2
+  end
+
+  def update_counters!(batch_upload, record_count, results)
+    batch_upload.with_lock do
+      batch_upload.increment!(:num_rows_processed, record_count)
+      batch_upload.increment!(:num_rows_succeeded, results[:succeeded])
+      batch_upload.increment!(:num_rows_errored, results[:failed])
+    end
+  end
+
+  def store_errors!(batch_upload, errors)
+    return if errors.empty?
+
+    error_records = errors.map do |error|
+      {
+        certification_batch_upload_id: batch_upload.id,
+        row_number: error[:row_number],
+        error_code: error[:error_code],
+        error_message: error[:error_message],
+        row_data: error[:row_data],
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+    end
+
+    CertificationBatchUploadError.insert_all(error_records)
+  end
+
+  # Check if batch is complete and transition to completed state
+  # Uses pessimistic lock with retry to handle concurrent chunk completion
+  def check_completion!(batch_upload)
+    retries = 0
+    begin
+      batch_upload.with_lock do
+        return unless batch_upload.num_rows_processed >= batch_upload.num_rows
+        return if batch_upload.completed?
+
+        batch_upload.complete_processing!(
+          num_rows_succeeded: batch_upload.num_rows_succeeded,
+          num_rows_errored: batch_upload.num_rows_errored,
+          results: {} # Results now in audit_logs and upload_errors tables
+        )
+      end
+    rescue ActiveRecord::LockWaitTimeout => e
+      retries += 1
+      if retries < 3
+        Rails.logger.info("Lock timeout on completion check (attempt #{retries}/3), retrying after backoff")
+        sleep(2**retries) # Exponential backoff: 2s, 4s, 8s
+        retry
+      else
+        Rails.logger.error("Failed to acquire completion lock after 3 retries: #{e.message}")
+        raise
+      end
+    end
+  end
+end

--- a/reporting-app/app/jobs/process_certification_batch_upload_job.rb
+++ b/reporting-app/app/jobs/process_certification_batch_upload_job.rb
@@ -9,56 +9,18 @@ class ProcessCertificationBatchUploadJob < ApplicationJob
   def perform(batch_upload_id)
     batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_upload_id)
 
-    # Guard: V2 uploads not yet supported
-    # TODO: Remove this guard when v2 processing is implemented (Stories 1-3)
-    if batch_upload.uses_cloud_storage?
+    # Route to appropriate processing path based on upload type and feature flag
+    # TODO: Simplify to only process_streaming when FEATURE_BATCH_UPLOAD_V2 flag is removed
+    if Features.batch_upload_v2_enabled? && batch_upload.uses_cloud_storage?
+      process_streaming(batch_upload)
+    elsif batch_upload.uses_cloud_storage?
+      process_from_cloud_storage_sequential(batch_upload) # TODO: Remove - temporary fallback
+    elsif batch_upload.uses_active_storage?
+      process_from_active_storage(batch_upload) # TODO: Remove - legacy v1 path
+    else
       batch_upload.fail_processing!(
-        error_message: "Batch upload v2 is not yet implemented"
+        error_message: "Invalid upload state: missing both file attachment and storage key"
       )
-      return
-    end
-
-    # Guard: Ensure valid v1 upload
-    unless batch_upload.uses_active_storage?
-      batch_upload.fail_processing!(
-        error_message: "Invalid upload state: missing file attachment"
-      )
-      return
-    end
-
-    # V1 upload processing (ActiveStorage)
-    # Mark as processing
-    batch_upload.start_processing!
-
-    # Download attached file to temporary location
-    temp_file = Tempfile.new([ "batch_upload", ".csv" ], encoding: "UTF-8")
-    begin
-      temp_file.write(batch_upload.file.download.force_encoding("UTF-8"))
-      temp_file.rewind
-
-      # Process the CSV
-      service = CertificationBatchUploadService.new(batch_upload: batch_upload)
-      success = service.process_csv(temp_file)
-
-      if success
-        # Store results and mark complete
-        batch_upload.complete_processing!(
-          num_rows_succeeded: service.successes.count,
-          num_rows_errored: service.errors.count,
-          results: {
-            successes: service.successes,
-            errors: service.errors
-          }
-        )
-      else
-        # Mark as failed
-        batch_upload.fail_processing!(
-          error_message: service.errors.first&.dig(:message) || "Unknown error"
-        )
-      end
-    ensure
-      temp_file.close
-      temp_file.unlink
     end
 
   rescue StandardError => e
@@ -68,5 +30,103 @@ class ProcessCertificationBatchUploadJob < ApplicationJob
 
     batch_upload.fail_processing!(error_message: e.message) if batch_upload
     raise
+  end
+
+  private
+
+  # NEW: Streaming path for v2 uploads (only when feature flag enabled)
+  # This will become the ONLY processing path once feature flag is removed
+  def process_streaming(batch_upload)
+    batch_upload.start_processing!
+
+    reader = CsvStreamReader.new
+    chunk_number = 0
+    total_records = 0
+
+    reader.each_chunk(batch_upload.storage_key) do |records|
+      chunk_number += 1
+      total_records += records.size
+
+      ProcessCertificationBatchChunkJob.perform_later(
+        batch_upload.id,
+        chunk_number,
+        records
+      )
+    end
+
+    batch_upload.update!(num_rows: total_records)
+  rescue StandardError => e
+    batch_upload.fail_processing!(error_message: e.message)
+    raise
+  end
+
+  # FALLBACK: Cloud storage but flag disabled - download and process sequentially
+  # TODO: Remove this method when FEATURE_BATCH_UPLOAD_V2 flag is removed
+  # This is a temporary safety fallback during v2 rollout
+  def process_from_cloud_storage_sequential(batch_upload)
+    batch_upload.start_processing!
+
+    temp_file = Tempfile.new([ "batch_upload", ".csv" ], encoding: "UTF-8")
+    begin
+      # Download from cloud storage to temp file
+      storage_adapter = Rails.application.config.storage_adapter
+      storage_adapter.download_to_file(key: batch_upload.storage_key, file: temp_file)
+      temp_file.rewind
+
+      # Process using existing service (v1 style)
+      service = CertificationBatchUploadService.new(batch_upload: batch_upload)
+      success = service.process_csv(temp_file)
+
+      handle_service_result(batch_upload, service, success)
+    ensure
+      temp_file.close
+      temp_file.unlink
+    end
+  rescue StandardError => e
+    batch_upload.fail_processing!(error_message: e.message)
+    raise
+  end
+
+  # EXISTING: Active Storage path (preserved for backward compatibility)
+  # TODO: Remove this method when FEATURE_BATCH_UPLOAD_V2 flag is removed
+  # After flag removal, all uploads will use cloud storage (v2)
+  def process_from_active_storage(batch_upload)
+    batch_upload.start_processing!
+
+    temp_file = Tempfile.new([ "batch_upload", ".csv" ], encoding: "UTF-8")
+    begin
+      temp_file.write(batch_upload.file.download.force_encoding("UTF-8"))
+      temp_file.rewind
+
+      service = CertificationBatchUploadService.new(batch_upload: batch_upload)
+      success = service.process_csv(temp_file)
+
+      handle_service_result(batch_upload, service, success)
+    ensure
+      temp_file.close
+      temp_file.unlink
+    end
+  rescue StandardError => e
+    batch_upload.fail_processing!(error_message: e.message)
+    raise
+  end
+
+  def handle_service_result(batch_upload, service, success)
+    if success
+      # Store results and mark complete
+      batch_upload.complete_processing!(
+        num_rows_succeeded: service.successes.count,
+        num_rows_errored: service.errors.count,
+        results: {
+          successes: service.successes,
+          errors: service.errors
+        }
+      )
+    else
+      # Mark as failed
+      batch_upload.fail_processing!(
+        error_message: service.errors.first&.dig(:message) || "Unknown error"
+      )
+    end
   end
 end

--- a/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 3) }
+  let(:valid_record) do
+    {
+      "member_id" => "M600",
+      "case_number" => "C-600",
+      "member_email" => "test6@example.com",
+      "first_name" => "Test",
+      "last_name" => "Six",
+      "certification_date" => "2025-04-10",
+      "certification_type" => "new_application"
+    }
+  end
+  let(:invalid_record) do
+    {
+      "member_id" => "M700",
+      "case_number" => "C-700"
+      # Missing required fields
+    }
+  end
+  let(:duplicate_record) do
+    {
+      "member_id" => "M800",
+      "case_number" => "C-800",
+      "member_email" => "test8@example.com",
+      "first_name" => "Test",
+      "last_name" => "Eight",
+      "certification_date" => "2025-04-12",
+      "certification_type" => "new_application"
+    }
+  end
+
+  before do
+    allow(Strata::EventManager).to receive(:publish)
+  end
+
+  describe '#perform' do
+    context 'with all valid records' do
+      let(:records) { [ valid_record ] }
+
+      it 'processes records and updates batch' do
+        described_class.perform_now(batch_upload.id, 1, records)
+        batch_upload.reload
+
+        expect(batch_upload.num_rows_processed).to eq(1)
+        expect(batch_upload.num_rows_succeeded).to eq(1)
+        expect(batch_upload.num_rows_errored).to eq(0)
+      end
+
+      it 'creates certifications' do
+        expect {
+          described_class.perform_now(batch_upload.id, 1, records)
+        }.to change(Certification, :count).by(1)
+      end
+
+      it 'creates certification origins' do
+        expect {
+          described_class.perform_now(batch_upload.id, 1, records)
+        }.to change(CertificationOrigin, :count).by(1)
+
+        origin = CertificationOrigin.last
+        expect(origin.source_type).to eq(CertificationOrigin::SOURCE_TYPE_BATCH_UPLOAD)
+        expect(origin.source_id).to eq(batch_upload.id)
+      end
+
+      it 'creates audit log entry' do
+        described_class.perform_now(batch_upload.id, 1, records)
+
+        logs = CertificationBatchUploadAuditLog
+          .where(certification_batch_upload_id: batch_upload.id)
+          .pluck(:chunk_number, :status, :succeeded_count, :failed_count)
+
+        expect(logs).to eq([ [ 1, "completed", 1, 0 ] ])
+      end
+
+      it 'does not create error entries' do
+        expect {
+          described_class.perform_now(batch_upload.id, 1, records)
+        }.not_to change(CertificationBatchUploadError, :count)
+      end
+    end
+
+    context 'with mixed valid and invalid records' do
+      let(:records) { [ valid_record, invalid_record, duplicate_record ] }
+
+      before do
+        # Create existing certification for duplicate check
+        create(:certification,
+          member_id: duplicate_record["member_id"],
+          case_number: duplicate_record["case_number"],
+          certification_requirements: {
+            certification_date: duplicate_record["certification_date"]
+          }
+        )
+      end
+
+      it 'processes all records and tracks results' do
+        described_class.perform_now(batch_upload.id, 1, records)
+        batch_upload.reload
+
+        expect(batch_upload.num_rows_processed).to eq(3)
+        expect(batch_upload.num_rows_succeeded).to eq(1) # Only valid_record
+        expect(batch_upload.num_rows_errored).to eq(2) # invalid + duplicate
+      end
+
+      it 'creates audit log with correct counts' do
+        described_class.perform_now(batch_upload.id, 1, records)
+
+        logs = CertificationBatchUploadAuditLog
+          .where(certification_batch_upload_id: batch_upload.id)
+          .pluck(:chunk_number, :status, :succeeded_count, :failed_count)
+
+        expect(logs).to eq([ [ 1, "completed", 1, 2 ] ])
+      end
+
+      it 'stores error details for failed records' do
+        described_class.perform_now(batch_upload.id, 1, records)
+
+        errors = CertificationBatchUploadError
+          .where(certification_batch_upload_id: batch_upload.id)
+          .order(:row_number)
+          .pluck(:row_number, :error_code, :error_message)
+
+        # Invalid record error (row 3) and duplicate record error (row 4)
+        expect(errors).to match([
+          [ 3, a_string_starting_with("VAL_"), a_string_including("Missing required fields") ],
+          [ 4, "DUP_001", a_string_including("Duplicate certification") ]
+        ])
+      end
+
+      it 'continues processing after validation errors' do
+        # All three records should be attempted, not stopped at first error
+        described_class.perform_now(batch_upload.id, 1, records)
+
+        expect(batch_upload.reload.num_rows_processed).to eq(3)
+      end
+    end
+
+    context 'with multiple chunks completing' do
+      let(:chunk_1_records) { [ valid_record ] }
+      let(:chunk_2_record) do
+        valid_record.merge(
+          "member_id" => "M601",
+          "case_number" => "C-601",
+          "member_email" => "test601@example.com"
+        )
+      end
+      let(:chunk_2_records) { [ chunk_2_record ] }
+      let(:chunk_3_record) do
+        valid_record.merge(
+          "member_id" => "M602",
+          "case_number" => "C-602",
+          "member_email" => "test602@example.com"
+        )
+      end
+      let(:chunk_3_records) { [ chunk_3_record ] }
+
+      it 'marks batch as complete when all chunks finish' do
+        # Process chunks 1 and 2
+        described_class.perform_now(batch_upload.id, 1, chunk_1_records)
+        described_class.perform_now(batch_upload.id, 2, chunk_2_records)
+        batch_upload.reload
+        expect(batch_upload.status).to eq("processing")
+
+        # Process final chunk
+        described_class.perform_now(batch_upload.id, 3, chunk_3_records)
+        batch_upload.reload
+        expect(batch_upload.status).to eq("completed")
+      end
+
+      it 'handles concurrent chunk completion safely' do
+        # Process all 3 chunks concurrently to test race condition handling
+        threads = [
+          Thread.new { described_class.perform_now(batch_upload.id, 1, chunk_1_records) },
+          Thread.new { described_class.perform_now(batch_upload.id, 2, chunk_2_records) },
+          Thread.new { described_class.perform_now(batch_upload.id, 3, chunk_3_records) }
+        ]
+        threads.each(&:join)
+
+        batch_upload.reload
+        expect(batch_upload.status).to eq("completed")
+        expect(batch_upload.num_rows_processed).to eq(3)
+        expect(batch_upload.num_rows_succeeded).to eq(3)
+        expect(batch_upload.num_rows_errored).to eq(0)
+
+        # Verify all certifications were created
+        expect(Certification.where(
+          member_id: [ "M600", "M601", "M602" ]
+        ).count).to eq(3)
+      end
+    end
+
+    context 'with row number calculation' do
+      it 'calculates correct row numbers for first chunk' do
+        records = [ valid_record, invalid_record ]
+        described_class.perform_now(batch_upload.id, 1, records)
+
+        # Chunk 1, index 0 → row 2 (first data row after header)
+        # Chunk 1, index 1 → row 3 (invalid record)
+        error_row_numbers = CertificationBatchUploadError
+          .where(certification_batch_upload_id: batch_upload.id)
+          .pluck(:row_number)
+
+        expect(error_row_numbers).to eq([ 3 ])
+      end
+
+      it 'calculates correct row numbers for second chunk' do
+        records = [ invalid_record ]
+        chunk_size = CsvStreamReader::DEFAULT_CHUNK_SIZE
+
+        described_class.perform_now(batch_upload.id, 2, records)
+
+        # Chunk 2, index 0 → row (1000 + 2)
+        error_row_numbers = CertificationBatchUploadError
+          .where(certification_batch_upload_id: batch_upload.id)
+          .pluck(:row_number)
+
+        expect(error_row_numbers).to eq([ chunk_size + 2 ])
+      end
+    end
+
+    context 'with error handling configuration' do
+      it 'is configured to retry on ActiveRecord::Deadlocked' do
+        # Verify the retry_on configuration exists
+        retry_callbacks = described_class.rescue_handlers.select do |handler|
+          handler.first == "ActiveRecord::Deadlocked"
+        end
+
+        expect(retry_callbacks).not_to be_empty
+      end
+    end
+  end
+
+  describe 'job queuing' do
+    it 'enqueues the job with correct parameters' do
+      records = [ valid_record ]
+
+      expect {
+        described_class.perform_later(batch_upload.id, 1, records)
+      }.to have_enqueued_job(described_class).with(batch_upload.id, 1, records)
+    end
+  end
+end

--- a/reporting-app/spec/jobs/process_certification_batch_upload_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_upload_job_spec.rb
@@ -6,64 +6,215 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:user) { create(:user) }
-  let(:batch_upload) { create(:certification_batch_upload, uploader: user) }
+
+  before do
+    allow(Strata::EventManager).to receive(:publish)
+  end
 
   describe '#perform' do
-    context 'with valid CSV' do
-      before do
-        allow(Strata::EventManager).to receive(:publish)
+    context 'with Active Storage (legacy v1 path)' do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user) }
 
-        # Attach valid CSV content
-        csv_content = <<~CSV
+      context 'with valid CSV' do
+        before do
+          # Attach valid CSV content
+          csv_content = <<~CSV
+            member_id,case_number,member_email,first_name,last_name,certification_date,certification_type
+            M200,C-200,test@example.com,Test,User,2025-01-15,new_application
+            M300,C-300,test2@example.com,Aurélie,Castañeda,2025-02-20,new_application
+          CSV
+          batch_upload.file.attach(
+            io: StringIO.new(csv_content),
+            filename: 'test.csv',
+            content_type: 'text/csv'
+          )
+        end
+
+        it 'processes the batch upload successfully' do
+          described_class.perform_now(batch_upload.id)
+          batch_upload.reload
+
+          expect(batch_upload).to be_completed
+          expect(batch_upload.num_rows_succeeded).to eq(2)
+          expect(batch_upload.num_rows_errored).to eq(0)
+        end
+
+        it 'creates certifications' do
+          expect {
+            described_class.perform_now(batch_upload.id)
+          }.to change(Certification, :count).from(0).to(2)
+        end
+
+        it 'stores results' do
+          described_class.perform_now(batch_upload.id)
+          batch_upload.reload
+
+          expect(batch_upload.results["successes"]).to be_present
+          expect(batch_upload.results["successes"].first["member_id"]).to eq("M200")
+        end
+
+        it 'works regardless of feature flag' do
+          with_batch_upload_v2_enabled do
+            described_class.perform_now(batch_upload.id)
+            batch_upload.reload
+            expect(batch_upload).to be_completed
+          end
+        end
+      end
+
+      context 'with invalid CSV' do
+        before do
+          # Attach invalid CSV (missing required fields)
+          csv_content = <<~CSV
+            member_id,case_number,member_email
+            ,C-201,invalid@example.com
+          CSV
+          batch_upload.file.attach(
+            io: StringIO.new(csv_content),
+            filename: 'test.csv',
+            content_type: 'text/csv'
+          )
+        end
+
+        it 'marks batch as failed' do
+          described_class.perform_now(batch_upload.id)
+          batch_upload.reload
+
+          expect(batch_upload).to be_failed
+        end
+      end
+
+      context 'when processing fails' do
+        let(:certification_batch_upload_service) { instance_double(CertificationBatchUploadService) }
+
+        before do
+          allow(CertificationBatchUploadService).to receive(:new).and_return(certification_batch_upload_service)
+          allow(certification_batch_upload_service).to receive(:process_csv).and_raise(StandardError, "Test error")
+        end
+
+        it 'marks batch as failed' do
+          expect {
+            described_class.perform_now(batch_upload.id)
+          }.to raise_error(StandardError)
+
+          batch_upload.reload
+          expect(batch_upload).to be_failed
+          expect(batch_upload.results["error"]).to eq("Test error")
+        end
+      end
+    end
+
+    context 'with cloud storage (v2 uploads)' do
+      let(:batch_upload) do
+        create(:certification_batch_upload, uploader: user, storage_key: "batch-uploads/test-uuid/test.csv")
+      end
+      let(:storage_adapter) { instance_double(Storage::S3Adapter) }
+      let(:csv_content) do
+        <<~CSV
           member_id,case_number,member_email,first_name,last_name,certification_date,certification_type
-          M200,C-200,test@example.com,Test,User,2025-01-15,new_application
-          M300,C-300,test2@example.com,Aurélie,Castañeda,2025-02-20,new_application
+          M400,C-400,test4@example.com,Test,Four,2025-03-10,new_application
+          M500,C-500,test5@example.com,Test,Five,2025-03-15,new_application
         CSV
-        batch_upload.file.attach(
-          io: StringIO.new(csv_content),
-          filename: 'test.csv',
-          content_type: 'text/csv'
-        )
       end
 
-      it 'processes the batch upload successfully' do
-        described_class.perform_now(batch_upload.id)
-        batch_upload.reload
-
-        expect(batch_upload).to be_completed
-        expect(batch_upload.num_rows_succeeded).to eq(2)
-        expect(batch_upload.num_rows_errored).to eq(0)
+      before do
+        # Set storage_adapter on Rails config for this test
+        Rails.application.config.storage_adapter = storage_adapter
       end
 
-      it 'creates certifications' do
-        expect {
-          described_class.perform_now(batch_upload.id)
-        }.to change(Certification, :count).from(0).to(2)
+      context 'when feature flag is ENABLED' do
+        let(:csv_reader) { instance_double(CsvStreamReader) }
+
+        before do
+          allow(CsvStreamReader).to receive(:new).and_return(csv_reader)
+        end
+
+        it 'enqueues chunk jobs for streaming' do
+          allow(csv_reader).to receive(:each_chunk).and_yield([
+            { "member_id" => "M400", "case_number" => "C-400", "member_email" => "test4@example.com",
+              "first_name" => "Test", "last_name" => "Four", "certification_date" => "2025-03-10",
+              "certification_type" => "new_application" }
+          ]).and_yield([
+            { "member_id" => "M500", "case_number" => "C-500", "member_email" => "test5@example.com",
+              "first_name" => "Test", "last_name" => "Five", "certification_date" => "2025-03-15",
+              "certification_type" => "new_application" }
+          ])
+
+          with_batch_upload_v2_enabled do
+            expect {
+              described_class.perform_now(batch_upload.id)
+            }.to have_enqueued_job(ProcessCertificationBatchChunkJob).exactly(2).times
+          end
+        end
+
+        it 'updates num_rows' do
+          allow(csv_reader).to receive(:each_chunk).and_yield(
+            Array.new(1000) { {} }
+          ).and_yield(
+            Array.new(500) { {} }
+          )
+
+          with_batch_upload_v2_enabled do
+            described_class.perform_now(batch_upload.id)
+            batch_upload.reload
+            expect(batch_upload.num_rows).to eq(1500)
+          end
+        end
+
+        it 'marks as processing' do
+          allow(csv_reader).to receive(:each_chunk).and_yield([ {} ])
+
+          with_batch_upload_v2_enabled do
+            described_class.perform_now(batch_upload.id)
+            batch_upload.reload
+            expect(batch_upload.status).to eq("processing")
+          end
+        end
       end
 
-      it 'stores results' do
-        described_class.perform_now(batch_upload.id)
-        batch_upload.reload
+      context 'when feature flag is DISABLED' do
+        before do
+          allow(storage_adapter).to receive(:download_to_file) do |key:, file:|
+            file.write(csv_content)
+            file.rewind
+          end
+        end
 
-        expect(batch_upload.results["successes"]).to be_present
-        expect(batch_upload.results["successes"].first["member_id"]).to eq("M200")
+        it 'falls back to sequential processing' do
+          with_batch_upload_v2_disabled do
+            expect {
+              described_class.perform_now(batch_upload.id)
+            }.not_to have_enqueued_job(ProcessCertificationBatchChunkJob)
+          end
+        end
+
+        it 'still completes successfully' do
+          with_batch_upload_v2_disabled do
+            described_class.perform_now(batch_upload.id)
+            batch_upload.reload
+
+            expect(batch_upload).to be_completed
+            expect(batch_upload.num_rows_succeeded).to eq(2)
+          end
+        end
+
+        it 'creates certifications' do
+          with_batch_upload_v2_disabled do
+            expect {
+              described_class.perform_now(batch_upload.id)
+            }.to change(Certification, :count).by(2)
+          end
+        end
       end
     end
 
-    context 'with invalid CSV' do
-      before do
-        allow(Strata::EventManager).to receive(:publish)
-
-        # Attach invalid CSV (missing required fields)
-        csv_content = <<~CSV
-          member_id,case_number,member_email
-          ,C-201,invalid@example.com
-        CSV
-        batch_upload.file.attach(
-          io: StringIO.new(csv_content),
-          filename: 'test.csv',
-          content_type: 'text/csv'
-        )
+    context 'with invalid upload state' do
+      let(:batch_upload) do
+        batch = build(:certification_batch_upload, uploader: user)
+        batch.file = nil
+        batch.storage_key = nil
+        batch.save(validate: false)
+        batch
       end
 
       it 'marks batch as failed' do
@@ -71,30 +222,14 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
         batch_upload.reload
 
         expect(batch_upload).to be_failed
-      end
-    end
-
-    context 'when processing fails' do
-      let (:certification_batch_upload_service) { instance_double(CertificationBatchUploadService) }
-
-      before do
-        allow(CertificationBatchUploadService).to receive(:new).and_return(certification_batch_upload_service)
-        allow(certification_batch_upload_service).to receive(:process_csv).and_raise(StandardError, "Test error")
-      end
-
-      it 'marks batch as failed' do
-        expect {
-          described_class.perform_now(batch_upload.id)
-        }.to raise_error(StandardError)
-
-        batch_upload.reload
-        expect(batch_upload).to be_failed
-        expect(batch_upload.results["error"]).to eq("Test error")
+        expect(batch_upload.results["error"]).to include("missing both file attachment and storage key")
       end
     end
   end
 
   describe 'job queuing' do
+    let(:batch_upload) { create(:certification_batch_upload, uploader: user) }
+
     it 'enqueues the job' do
       expect {
         described_class.perform_later(batch_upload.id)


### PR DESCRIPTION
Implement parallel chunk processing for batch upload v2

Resolves #205
Resolves #206

Implements Stories 6 & 7 of the batch upload v2 epic (#110), enabling
parallel processing of large CSV files by breaking them into chunks that
process concurrently. This provides significant speedup over sequential
processing while maintaining data integrity through careful concurrency
control.

## Changes

**Story 6: Evolve ProcessCertificationBatchUploadJob (orchestrator)**
- Added three processing paths: v2 streaming (default), v2 fallback
  (sequential), and v1 legacy (Active Storage)
- Orchestrator parses CSV using CsvStreamReader and distributes chunks
  to ProcessCertificationBatchChunkJob for parallel execution
- Feature flag gating via Features.batch_upload_v2_enabled?
- Added download_to_file to BaseAdapter for fallback path

**Story 7: Create ProcessCertificationBatchChunkJob (worker)**
- Processes individual chunks of records through UnifiedRecordProcessor
- Creates audit logs (CertificationBatchUploadAuditLog) for each chunk
- Stores errors in CertificationBatchUploadError table with row numbers
- Updates batch counters atomically using pessimistic locking
- Checks for batch completion when chunk finishes

**Concurrency safety:**
- Uses pessimistic row-level locking (with_lock) to prevent race conditions
  when multiple chunks complete simultaneously
- Idempotency guard ensures complete_processing! called exactly once
- Retry logic with exponential backoff handles transient lock contention
  gracefully under high concurrency

## Architecture Notes

**Memory model:** The current implementation loads parsed CSV records into
memory and passes them to chunk jobs via the job queue. This works well for
typical production file sizes. If future scale demands it, the architecture
can be optimized to stream chunks from temporary storage instead, enabling
processing of arbitrarily large files with constant memory usage.

**Callback preservation:** Uses individual record processing (not insert_all)
to preserve ActiveRecord callbacks, specifically after_create_commit that
publishes Strata events for each certification.

## Test Coverage

- 29 job specs passing
- Concurrent chunk completion test verifies race condition handling
- Error handling for validation failures and duplicates
- Row number calculation for multi-chunk files

This enables Stories 9-12 (progress tracking, enhanced error reporting,
optimizations, and admin interface).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->