### PR TITLE
FIX - Naderk/oscer 259 migrate sso omni auth open id connect gem

### DIFF
--- a/reporting-app/config/initializers/sso.rb
+++ b/reporting-app/config/initializers/sso.rb
@@ -2,14 +2,14 @@
 
 # Build redirect URI with correct scheme and port
 # Defaults to HTTPS (production assumption) unless explicitly disabled
-# Set ENABLE_HTTPS=false for local development without SSL
+# Set DISABLE_HTTPS=true for local development without SSL
 def build_sso_redirect_uri
   host = ENV.fetch("APP_HOST", "localhost")
   port = ENV.fetch("APP_PORT", "443")
-  https_enabled = ENV.fetch("ENABLE_HTTPS", "true") == "true"
+  https_disabled = ENV.fetch("DISABLE_HTTPS", "false") == "true"
 
-  scheme = https_enabled ? "https" : "http"
-  standard_port = https_enabled ? "443" : "80"
+  scheme = https_disabled ? "http" : "https"
+  standard_port = https_disabled ? "80" : "443"
   port_suffix = (port == standard_port) ? "" : ":#{port}"
 
   "#{scheme}://#{host}#{port_suffix}/auth/sso/callback"


### PR DESCRIPTION
## Summary

Improve SSO redirect URI construction to properly handle production deployments behind load balancers with SSL termination.

**Changes:**
- Default to HTTPS for production (no config needed)
- Add `DISABLE_HTTPS` environment variable for local development
- Handle non-standard ports for both HTTP and HTTPS
- Refactor to DRY implementation

## Problem

The previous implementation determined HTTP vs HTTPS based solely on port number, which broke in production/sandbox where:
- Load balancer terminates SSL on port 443
- Container runs on internal port 8000
- `APP_PORT=8000` incorrectly generated `http://host:8000/...` instead of `https://host/...`

## Solution

Default to HTTPS (production), only use HTTP when `DISABLE_HTTPS=true` is explicitly set (local dev).


## Environment Variable Behavior

| Environment | DISABLE_HTTPS | Result |
|-------------|---------------|--------|
| Production (default) | not set → `false` | `https://domain.com/auth/sso/callback` |
| Local dev | `true` | `http://localhost:3000/auth/sso/callback` |
| Non-standard HTTPS port | not set + port 8443 | `https://domain.com:8443/auth/sso/callback` |

## Test plan

- [ ] Verify local dev with `DISABLE_HTTPS=true` uses `http://localhost:3000/...`
- [ ] Verify production default uses `https://domain.com/...`
- [ ] Verify non-standard HTTPS port includes port in URL
- [ ] Run SSO spec tests (14 examples pass)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->