### PR TITLE
Configure S3 CORS and cloud provider for batch upload v2

### DIFF
--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -10,3 +10,18 @@ resource "aws_s3_bucket" "storage" {
   # checkov:skip=CKV2_AWS_62:S3 bucket does not need notifications enabled
   # checkov:skip=CKV_AWS_21:Bucket versioning is not needed
 }
+
+# CORS configuration for browser-based direct uploads
+# Allows web browsers to upload files directly to S3 (bypassing Rails server)
+resource "aws_s3_bucket_cors_configuration" "storage" {
+  count  = length(var.cors_allowed_origins) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.storage.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST"]
+    allowed_origins = var.cors_allowed_origins
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -8,3 +8,9 @@ variable "name" {
   type        = string
   description = "Name of the AWS S3 bucket. Needs to be globally unique across all regions."
 }
+
+variable "cors_allowed_origins" {
+  type        = list(string)
+  description = "List of origins allowed for CORS requests (e.g., ['https://example.com']). Required for browser-based direct uploads."
+  default     = []
+}

--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -7,6 +7,10 @@ locals {
     VA_API_HOST       = "https://sandbox-api.va.gov"
     VA_TOKEN_AUDIENCE = "https://deptva-eval.okta.com/oauth2/ausi3u00gw66b9Ojk2p7/v1/token"
     VA_TOKEN_HOST     = "https://sandbox-api.va.gov/oauth2/veteran-verification/system/v1/token"
+
+    # Cloud provider for storage adapter selection
+    # BUCKET_NAME is set in service/main.tf
+    CLOUD_PROVIDER = "aws"
   }
 
   # Configuration for secrets

--- a/infra/reporting-app/service/storage.tf
+++ b/infra/reporting-app/service/storage.tf
@@ -1,10 +1,20 @@
 locals {
   storage_config = local.environment_config.storage_config
   bucket_name    = "${local.prefix}${local.storage_config.bucket_name}"
+
+  # CORS origins for browser-based direct uploads
+  # Use custom domain if available, otherwise use load balancer endpoint
+  # This ensures preview environments (which use ALB DNS) also get CORS configured
+  cors_allowed_origins = module.domain.domain_name != "" ? [
+    "https://${module.domain.domain_name}"
+    ] : [
+    module.service.public_endpoint
+  ]
 }
 
 module "storage" {
-  source       = "../../modules/storage"
-  name         = local.bucket_name
-  is_temporary = local.is_temporary
+  source               = "../../modules/storage"
+  name                 = local.bucket_name
+  is_temporary         = local.is_temporary
+  cors_allowed_origins = local.cors_allowed_origins
 }


### PR DESCRIPTION
Resolves #210

## Summary

Adds Terraform configuration to enable browser-based direct uploads to S3 for batch upload v2 (Active Storage Direct Upload).

## Changes

- Added S3 CORS configuration to storage module
- Configured CORS origins to support both custom domains and preview environments
- Added CLOUD_PROVIDER environment variable for storage adapter selection

## Testing

After merging and running `terraform apply`:

```bash
# Verify CORS configuration
aws s3api get-bucket-cors --bucket <bucket-name>
```

Expected output should show allowed origins matching the environment's domain or ALB endpoint.

## Dependencies

- Requires FEATURE_BATCH_UPLOAD_V2=true in Rails app
- Works with Active Storage Direct Upload (Story 9: PR #276)
- Enables browser → S3 uploads bypassing Rails server

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->