### PR TITLE
Replace per-record inserts with bulk insert pipeline for chunk processing

### DIFF
--- a/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
+++ b/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
@@ -61,33 +61,14 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
     results = { succeeded: 0, failed: 0, errors: [] }
     context = { batch_upload_id: batch_upload.id }
 
-    records.each_with_index do |record, index|
-      row_number = calculate_row_number(chunk_number, index)
+    # Phase 1: Validate all records
+    valid_entries = validate_all_records(records, chunk_number, processor, results)
 
-      begin
-        processor.process(record, context: context)
-        results[:succeeded] += 1
-      rescue UnifiedRecordProcessor::ProcessingError => e
-        results[:failed] += 1
-        results[:errors] << {
-          row_number: row_number,
-          error_code: e.code,
-          error_message: e.message,
-          row_data: record
-        }
-      rescue StandardError => e
-        # Catch unexpected errors (shouldn't happen, but safety net)
-        Rails.logger.error("Unexpected error processing row #{row_number}: #{e.class} - #{e.message}")
-        Rails.logger.error("Backtrace: #{e.backtrace.join("\n")}")
-        results[:failed] += 1
-        results[:errors] << {
-          row_number: row_number,
-          error_code: BatchUploadErrors::Unknown::UNEXPECTED,
-          error_message: "Unexpected error: #{e.class} - #{e.message}",
-          row_data: record
-        }
-      end
-    end
+    # Phase 2: Batch duplicate check + within-batch dedup
+    non_duplicate_entries = filter_duplicates(valid_entries, processor, results)
+
+    # Phase 3: Bulk persist + publish events
+    bulk_create_certifications(non_duplicate_entries, context, processor, results)
 
     complete_audit_log(audit_log, results)
     update_counters!(batch_upload, records.size, results)
@@ -104,6 +85,102 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
   end
 
   private
+
+  # Phase 1: Validate all records, separate valid from invalid
+  # Returns array of { record:, row_number: } for valid records
+  def validate_all_records(records, chunk_number, processor, results)
+    valid_entries = []
+
+    records.each_with_index do |record, index|
+      row_number = calculate_row_number(chunk_number, index)
+      validation = processor.validate_record(record)
+
+      if validation[:valid]
+        valid_entries << { record: record, row_number: row_number }
+      else
+        results[:failed] += 1
+        results[:errors] << {
+          row_number: row_number,
+          error_code: validation[:error_code],
+          error_message: validation[:error_message],
+          row_data: record
+        }
+      end
+    end
+
+    valid_entries
+  end
+
+  # Phase 2: Batch duplicate check against DB + within-batch dedup
+  # Returns array of { record:, row_number: } for non-duplicate records
+  def filter_duplicates(valid_entries, processor, results)
+    return [] if valid_entries.empty?
+
+    records_only = valid_entries.map { |e| e[:record] }
+    existing_keys = processor.find_existing_duplicates(records_only)
+    seen_keys = Set.new
+    non_duplicate_entries = []
+
+    valid_entries.each do |entry|
+      record = entry[:record]
+
+      # Skip duplicate check for records with blank key fields (matches existing behavior)
+      if record["member_id"].blank? || record["case_number"].blank? || record["certification_date"].blank?
+        non_duplicate_entries << entry
+        next
+      end
+
+      key = processor.compound_key(record["member_id"], record["case_number"], record["certification_date"])
+
+      if existing_keys.include?(key)
+        results[:failed] += 1
+        results[:errors] << {
+          row_number: entry[:row_number],
+          error_code: BatchUploadErrors::Duplicate::EXISTING_CERTIFICATION,
+          error_message: "Duplicate certification for member_id #{record['member_id']}, " \
+                         "case_number #{record['case_number']}, certification_date #{record['certification_date']}",
+          row_data: record
+        }
+      elsif seen_keys.include?(key)
+        results[:failed] += 1
+        results[:errors] << {
+          row_number: entry[:row_number],
+          error_code: BatchUploadErrors::Duplicate::WITHIN_BATCH,
+          error_message: "Duplicate within batch for member_id #{record['member_id']}, " \
+                         "case_number #{record['case_number']}, certification_date #{record['certification_date']}",
+          row_data: record
+        }
+      else
+        seen_keys.add(key)
+        non_duplicate_entries << entry
+      end
+    end
+
+    non_duplicate_entries
+  end
+
+  # Phase 3: Bulk insert all non-duplicate records
+  def bulk_create_certifications(entries, context, processor, results)
+    return if entries.empty?
+
+    records_only = entries.map { |e| e[:record] }
+    processor.bulk_persist!(records_only, context)
+    results[:succeeded] += entries.size
+  rescue StandardError => e
+    Rails.logger.error("Bulk insert failed: #{e.class} - #{e.message}")
+    Rails.logger.error("Backtrace: #{e.backtrace.join("\n")}")
+
+    # Mark all records in this batch as failed
+    entries.each do |entry|
+      results[:failed] += 1
+      results[:errors] << {
+        row_number: entry[:row_number],
+        error_code: BatchUploadErrors::Database::SAVE_FAILED,
+        error_message: "Bulk insert failed: #{e.class} - #{e.message}",
+        row_data: entry[:record]
+      }
+    end
+  end
 
   def create_audit_log(batch_upload, chunk_number)
     CertificationBatchUploadAuditLog.create!(

--- a/reporting-app/app/services/README_ERRORS.md
+++ b/reporting-app/app/services/README_ERRORS.md
@@ -26,7 +26,8 @@ Error codes follow the pattern `[CATEGORY]_[NUMBER]`:
 
 ### Duplicate Errors (DUP_*)
 
-- **DUP_001** - Certification already exists (same `member_id`, `case_number`, `certification_date`)
+- **DUP_001** - Certification already exists in database (same `member_id`, `case_number`, `certification_date`)
+- **DUP_002** - Duplicate record within same batch chunk (same compound key appears multiple times)
 
 ### Database Errors (DB_*)
 

--- a/reporting-app/app/services/batch_upload_errors.rb
+++ b/reporting-app/app/services/batch_upload_errors.rb
@@ -21,7 +21,8 @@ module BatchUploadErrors
 
   # Duplicate errors - record already exists
   module Duplicate
-    EXISTING_CERTIFICATION = "DUP_001"  # Certification already exists
+    EXISTING_CERTIFICATION = "DUP_001"  # Certification already exists in database
+    WITHIN_BATCH = "DUP_002"            # Duplicate within same batch chunk
   end
 
   # Database errors - persistence failures

--- a/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
@@ -292,31 +292,39 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
     context 'when delegating to processor' do
       let(:processor) { instance_double(UnifiedRecordProcessor) }
       let(:records) { [ valid_record ] }
-      let(:mock_certification) { instance_double(Certification, id: 1) }
       let(:record_count) { 1 }
 
       before do
         allow(csv_reader).to receive(:read_chunk).and_return(records)
+        allow(processor).to receive_messages(validate_record: { valid: true }, find_existing_duplicates: Set.new, compound_key: "M600|C-600|2025-04-10", bulk_persist!: [ "fake-id-1" ])
       end
 
-      it 'calls processor with record and context' do
-        allow(processor).to receive(:process).and_return(mock_certification)
-
+      it 'calls validate_record for each record' do
         described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
-        expect(processor).to have_received(:process)
-          .with(valid_record, context: { batch_upload_id: batch_upload.id })
+        expect(processor).to have_received(:validate_record).with(valid_record)
+      end
+
+      it 'calls find_existing_duplicates with valid records' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
+
+        expect(processor).to have_received(:find_existing_duplicates).with([ valid_record ])
+      end
+
+      it 'calls bulk_persist! with non-duplicate records and context' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
+
+        expect(processor).to have_received(:bulk_persist!)
+          .with([ valid_record ], { batch_upload_id: batch_upload.id })
       end
 
       it 'uses injected processor instead of creating new one' do
-        allow(processor).to receive(:process).and_return(mock_certification)
         allow(UnifiedRecordProcessor).to receive(:new).and_call_original
 
         described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
-        # Should use injected processor, not create a new one
         expect(UnifiedRecordProcessor).not_to have_received(:new)
-        expect(processor).to have_received(:process)
+        expect(processor).to have_received(:validate_record)
       end
     end
 
@@ -353,29 +361,28 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       end
     end
 
-    context 'with unexpected errors' do
+    context 'when bulk insert fails' do
       let(:processor) { instance_double(UnifiedRecordProcessor) }
       let(:records) { [ valid_record ] }
       let(:record_count) { 1 }
 
       before do
         allow(csv_reader).to receive(:read_chunk).and_return(records)
+        allow(processor).to receive_messages(validate_record: { valid: true }, find_existing_duplicates: Set.new, compound_key: "M600|C-600|2025-04-10")
       end
 
-      it 'catches unexpected StandardError and logs with backtrace' do
-        error = StandardError.new("Something went wrong")
-        allow(processor).to receive(:process).and_raise(error)
+      it 'catches bulk insert failure and logs with backtrace' do
+        allow(processor).to receive(:bulk_persist!).and_raise(StandardError, "DB connection lost")
         allow(Rails.logger).to receive(:error)
 
         described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
-        expect(Rails.logger).to have_received(:error).with(/Unexpected error processing row 2: StandardError - Something went wrong/)
+        expect(Rails.logger).to have_received(:error).with(/Bulk insert failed: StandardError - DB connection lost/)
         expect(Rails.logger).to have_received(:error).with(/Backtrace:/)
       end
 
-      it 'stores error with UNK_001 code and exception class' do
-        error = RuntimeError.new("Unexpected failure")
-        allow(processor).to receive(:process).and_raise(error)
+      it 'stores error with DB_001 code for all records in batch' do
+        allow(processor).to receive(:bulk_persist!).and_raise(StandardError, "DB connection lost")
         allow(Rails.logger).to receive(:error)
 
         described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
@@ -385,13 +392,15 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
           .pluck(:error_code, :error_message)
 
         expect(errors).to eq([
-          [ BatchUploadErrors::Unknown::UNEXPECTED, "Unexpected error: RuntimeError - Unexpected failure" ]
+          [
+            BatchUploadErrors::Database::SAVE_FAILED,
+            "Bulk insert failed: StandardError - DB connection lost"
+          ]
         ])
       end
 
-      it 'increments error counter for unexpected errors' do
-        error = StandardError.new("Something went wrong")
-        allow(processor).to receive(:process).and_raise(error)
+      it 'increments error counter for all records when bulk insert fails' do
+        allow(processor).to receive(:bulk_persist!).and_raise(StandardError, "DB connection lost")
         allow(Rails.logger).to receive(:error)
 
         described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
@@ -531,6 +540,53 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
             described_class.perform_later(non_existent_id, 1, headers, start_byte, end_byte, 1)
           end
         }.not_to raise_error
+      end
+    end
+
+    context 'with within-batch duplicates' do
+      let(:duplicate_within_batch) do
+        valid_record.dup  # Same member_id, case_number, certification_date
+      end
+      let(:records) { [ valid_record, duplicate_within_batch ] }
+
+      before do
+        allow(csv_reader).to receive(:read_chunk).and_return(records)
+      end
+
+      it 'keeps first occurrence and errors on duplicate' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, records.size)
+
+        batch_id = batch_upload.id
+        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
+
+        expect(batch_upload.num_rows_succeeded).to eq(1)
+        expect(batch_upload.num_rows_errored).to eq(1)
+      end
+
+      it 'stores DUP_002 error for within-batch duplicate' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, records.size)
+
+        errors = CertificationBatchUploadError
+          .where(certification_batch_upload_id: batch_upload.id)
+          .pluck(:error_code)
+
+        expect(errors).to eq([ BatchUploadErrors::Duplicate::WITHIN_BATCH ])
+      end
+    end
+
+    context 'with CertificationCreated event publishing' do
+      let(:records) { [ valid_record ] }
+
+      before do
+        allow(csv_reader).to receive(:read_chunk).and_return(records)
+      end
+
+      it 'publishes CertificationCreated event for each created certification' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, records.size)
+
+        cert_id = Certification.last.id
+        expect(Strata::EventManager).to have_received(:publish)
+          .with("CertificationCreated", { certification_id: cert_id })
       end
     end
   end

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -3,16 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe Certification, type: :model do
-  describe 'after_create_commit callback' do
+  describe '.publish_created_event' do
     it 'publishes CertificationCreated event with certification_id' do
       allow(Strata::EventManager).to receive(:publish)
+
+      described_class.publish_created_event("test-id-123")
+
+      expect(Strata::EventManager).to have_received(:publish).with(
+        'CertificationCreated',
+        { certification_id: "test-id-123" }
+      )
+    end
+  end
+
+  describe 'after_create_commit callback' do
+    it 'calls publish_created_event' do
+      allow(described_class).to receive(:publish_created_event)
       certification = build(:certification)
 
       certification.save!
-      expect(Strata::EventManager).to have_received(:publish).with(
-        'CertificationCreated',
-        { certification_id: certification.id }
-      )
+
+      expect(described_class).to have_received(:publish_created_event).with(certification.id)
     end
   end
 
@@ -110,8 +121,8 @@ RSpec.describe Certification, type: :model do
   describe '.from_batch_upload' do
     let(:user) { create(:user) }
     let(:batch_upload) { create(:certification_batch_upload, uploader: user) }
-    let!(:batch_cert) { create(:certification, member_id: "M888", case_number: "C-888") }
-    let!(:manual_cert) { create(:certification, member_id: "M889", case_number: "C-889") }
+    let(:batch_cert) { create(:certification, member_id: "M888", case_number: "C-888") }
+    let(:manual_cert) { create(:certification, member_id: "M889", case_number: "C-889") }
 
     before do
       CertificationOrigin.create!(

--- a/reporting-app/spec/services/unified_record_processor_spec.rb
+++ b/reporting-app/spec/services/unified_record_processor_spec.rb
@@ -277,4 +277,227 @@ RSpec.describe UnifiedRecordProcessor do
       end
     end
   end
+
+  describe "#validate_record" do
+    let(:valid_record) do
+      {
+        "member_id" => "M12345",
+        "case_number" => "C-001",
+        "member_email" => "test@example.com",
+        "certification_date" => "2025-01-15",
+        "certification_type" => "new_application"
+      }
+    end
+
+    it "returns valid: true for a valid record" do
+      result = processor.validate_record(valid_record)
+
+      expect(result).to eq({ valid: true })
+    end
+
+    it "returns valid: false with error details for missing fields" do
+      record = { "member_id" => "M123" }
+
+      result = processor.validate_record(record)
+
+      expect(result[:valid]).to be false
+      expect(result[:error_code]).to eq(BatchUploadErrors::Validation::MISSING_FIELDS)
+      expect(result[:error_message]).to include("Missing required fields")
+    end
+
+    it "returns valid: false for invalid date format" do
+      record = valid_record.merge("certification_date" => "01/15/2025")
+
+      result = processor.validate_record(record)
+
+      expect(result[:valid]).to be false
+      expect(result[:error_code]).to eq(BatchUploadErrors::Validation::INVALID_DATE)
+    end
+
+    it "does not persist any records" do
+      expect { processor.validate_record(valid_record) }
+        .not_to change(Certification, :count)
+    end
+  end
+
+  describe "#compound_key" do
+    it "joins fields with pipe separator" do
+      key = processor.compound_key("M123", "C-001", "2025-01-15")
+
+      expect(key).to eq("M123|C-001|2025-01-15")
+    end
+
+    it "handles nil values" do
+      key = processor.compound_key("M123", nil, "2025-01-15")
+
+      expect(key).to eq("M123||2025-01-15")
+    end
+  end
+
+  describe "#find_existing_duplicates" do
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+    end
+
+    let(:records) do
+      [
+        {
+          "member_id" => "M100",
+          "case_number" => "C-100",
+          "certification_date" => "2025-01-15"
+        },
+        {
+          "member_id" => "M200",
+          "case_number" => "C-200",
+          "certification_date" => "2025-02-20"
+        }
+      ]
+    end
+
+    it "returns empty set when no existing certifications match" do
+      result = processor.find_existing_duplicates(records)
+
+      expect(result).to be_empty
+    end
+
+    it "returns compound keys for records that exist in database" do
+      cert = create(:certification, member_id: "M100", case_number: "C-100")
+      cert.update_column(:certification_requirements, { "certification_date" => "2025-01-15" })
+
+      result = processor.find_existing_duplicates(records)
+
+      expect(result).to include("M100|C-100|2025-01-15")
+      expect(result).not_to include("M200|C-200|2025-02-20")
+    end
+
+    it "returns empty set when all records have blank member_ids" do
+      blank_records = [ { "member_id" => "", "case_number" => "C-1" } ]
+
+      result = processor.find_existing_duplicates(blank_records)
+
+      expect(result).to be_empty
+    end
+
+    it "executes a single database query" do
+      allow(Certification).to receive(:where).and_call_original
+
+      processor.find_existing_duplicates(records)
+
+      expect(Certification).to have_received(:where).once
+    end
+  end
+
+  describe "#bulk_persist!" do
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+    end
+
+    let(:valid_records) do
+      [
+        {
+          "member_id" => "M100",
+          "case_number" => "C-100",
+          "member_email" => "test1@example.com",
+          "first_name" => "Alice",
+          "last_name" => "One",
+          "certification_date" => "2025-01-15",
+          "certification_type" => "new_application"
+        },
+        {
+          "member_id" => "M200",
+          "case_number" => "C-200",
+          "member_email" => "test2@example.com",
+          "first_name" => "Bob",
+          "last_name" => "Two",
+          "certification_date" => "2025-02-20",
+          "certification_type" => "new_application"
+        }
+      ]
+    end
+
+    it "creates certifications via bulk insert" do
+      expect {
+        processor.bulk_persist!(valid_records, {})
+      }.to change(Certification, :count).by(2)
+    end
+
+    it "returns array of certification IDs" do
+      ids = processor.bulk_persist!(valid_records, {})
+
+      expect(ids).to be_an(Array)
+      expect(ids.size).to eq(2)
+      expect(Certification.where(id: ids).count).to eq(2)
+    end
+
+    it "correctly serializes JSONB attributes (round-trip)" do
+      ids = processor.bulk_persist!(valid_records, {})
+
+      cert = Certification.find(ids.first)
+      expect(cert.member_id).to eq("M100")
+      expect(cert.case_number).to eq("C-100")
+      expect(cert.certification_requirements.certification_date.to_s).to eq("2025-01-15")
+      expect(cert.certification_requirements.certification_type).to eq("new_application")
+      expect(cert.member_data.name.first).to eq("Alice")
+      expect(cert.member_data.account_email).to eq("test1@example.com")
+    end
+
+    it "publishes CertificationCreated event for each certification" do
+      ids = processor.bulk_persist!(valid_records, {})
+
+      ids.each do |cert_id|
+        expect(Strata::EventManager).to have_received(:publish)
+          .with("CertificationCreated", { certification_id: cert_id })
+      end
+    end
+
+    it "creates CertificationOrigins when batch_upload_id provided" do
+      batch_upload = create(:certification_batch_upload)
+
+      expect {
+        processor.bulk_persist!(valid_records, { batch_upload_id: batch_upload.id })
+      }.to change(CertificationOrigin, :count).by(2)
+
+      origins = CertificationOrigin.last(2)
+      origins.each do |origin|
+        expect(origin.source_type).to eq(CertificationOrigin::SOURCE_TYPE_BATCH_UPLOAD)
+        expect(origin.source_id).to eq(batch_upload.id)
+      end
+    end
+
+    it "does not create CertificationOrigins without batch_upload_id" do
+      expect {
+        processor.bulk_persist!(valid_records, {})
+      }.not_to change(CertificationOrigin, :count)
+    end
+
+    it "returns empty array for empty input" do
+      result = processor.bulk_persist!([], {})
+
+      expect(result).to eq([])
+    end
+
+    it "continues publishing events if one fails" do
+      allow(Strata::EventManager).to receive(:publish).and_raise(StandardError, "event error")
+      allow(Rails.logger).to receive(:error)
+
+      # Should not raise despite event publish failures
+      ids = processor.bulk_persist!(valid_records, {})
+
+      expect(ids.size).to eq(2)
+      expect(Rails.logger).to have_received(:error).twice
+    end
+
+    it "wraps inserts in a transaction (both or neither)" do
+      batch_upload = create(:certification_batch_upload)
+      # Force CertificationOrigin.insert_all! to fail
+      allow(CertificationOrigin).to receive(:insert_all!).and_raise(ActiveRecord::RecordNotUnique, "duplicate")
+
+      expect {
+        processor.bulk_persist!(valid_records, { batch_upload_id: batch_upload.id })
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+
+      # Transaction rollback means no certifications created
+      expect(Certification.where(member_id: %w[M100 M200]).count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Chunk jobs previously processed records one at a time: for each of 1,000 rows, validate → EXISTS duplicate check → INSERT cert → INSERT origin → synchronous business process events. This meant 2,000+ individual INSERT statements and 1,000 individual EXISTS queries per chunk.

This replaces the per-record loop with a 3-phase bulk pipeline:

Phase 1 - Validate all records:
  Runs validation on all 1,000 records, separating valid from invalid.
  No database queries needed.

Phase 2 - Batch duplicate check:
  Single WHERE IN query replaces 1,000 individual EXISTS queries.
  Also detects within-batch duplicates (same member_id + case_number +
  certification_date appearing multiple times in one chunk).

Phase 3 - Bulk persist + events:
  insert_all! for certifications and origins in one transaction (2 bulk
  INSERTs vs 2,000 individual INSERTs), then publishes CertificationCreated
  events per record to trigger the business process chain.

Controlled profiling (Docker, fresh DB, 5k all-valid rows) shows:
  - Dedup: 33ms batch vs 3,311ms individual (100x faster)
  - Insert: 620ms bulk vs ~3,700ms individual (4.5x faster)
  - Overall: ~98s/chunk vs ~107s/chunk (~8% faster)

The modest overall gain is because the synchronous Strata business process chain dominates at ~97s/chunk in both approaches.

Changes:

ProcessCertificationBatchChunkJob:
  - Replace single record loop with 3-phase pipeline
  - Add validate_all_records, filter_duplicates, bulk_create_certifications

UnifiedRecordProcessor:
  - Add validate_record (non-raising validation for phase 1)
  - Add find_existing_duplicates (batch WHERE IN query)
  - Add compound_key (member_id|case_number|date composite key)
  - Add bulk_persist! (insert_all! with event publishing)
  - Existing process() path unchanged for non-batch callers

Certification model:
  - Extract publish_created_event as class method (callable without an instance, needed by bulk_persist! which uses insert_all!)

BatchUploadErrors:
  - Add WITHIN_BATCH duplicate error code

Part of #110

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->