### PR TITLE
Enable batch upload v2 feature flag for dev environment

### DIFF
--- a/infra/reporting-app/app-config/dev.tf
+++ b/infra/reporting-app/app-config/dev.tf
@@ -29,6 +29,7 @@ module "dev_config" {
   # }
 
   service_override_extra_environment_variables = {
-    ENABLE_LOOKBOOK = "true"
+    ENABLE_LOOKBOOK         = "true"
+    FEATURE_BATCH_UPLOAD_V2 = "true"
   }
 }


### PR DESCRIPTION
Adds FEATURE_BATCH_UPLOAD_V2=true to the dev environment's extra environment variables, enabling batch upload v2 with cloud storage and streaming for testing on the dev instance.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->