### PR TITLE
Add PurgeUnattachedBlobsJob for orphaned blob cleanup

### DIFF
--- a/reporting-app/app/jobs/purge_unattached_blobs_job.rb
+++ b/reporting-app/app/jobs/purge_unattached_blobs_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class PurgeUnattachedBlobsJob < ApplicationJob
+  def perform
+    purged = 0
+    failed = 0
+
+    ActiveStorage::Blob.unattached
+      .where("active_storage_blobs.created_at < ?", 24.hours.ago)
+      .includes(:variant_records)
+      .find_each do |blob|
+        blob.purge
+        purged += 1
+      rescue StandardError => e
+        failed += 1
+        Rails.logger.warn("PurgeUnattachedBlobsJob: failed to purge blob #{blob.id}: #{e.message}")
+      end
+
+    Rails.logger.info("PurgeUnattachedBlobsJob: purged #{purged} blob(s), #{failed} failure(s)")
+  end
+end

--- a/reporting-app/config/initializers/good_job.rb
+++ b/reporting-app/config/initializers/good_job.rb
@@ -11,8 +11,15 @@ Rails.application.configure do
   # Process all queues
   config.good_job.queues = "*"
 
-  # Enable cron for future scheduled jobs
+  # Enable cron for scheduled jobs
   config.good_job.enable_cron = true
+  config.good_job.cron = {
+    purge_unattached_blobs: {
+      cron: "0 3 * * *",
+      class: "PurgeUnattachedBlobsJob",
+      description: "Clean up orphaned Active Storage blobs from abandoned uploads"
+    }
+  }
 
   # Retry failed jobs automatically
   config.good_job.retry_on_unhandled_error = true

--- a/reporting-app/spec/jobs/purge_unattached_blobs_job_spec.rb
+++ b/reporting-app/spec/jobs/purge_unattached_blobs_job_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PurgeUnattachedBlobsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe "#perform" do
+    context "when there are unattached blobs older than 24 hours" do
+      it "purges them" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("old orphaned file"),
+          filename: "old_orphan.csv",
+          content_type: "text/csv"
+        )
+        blob.update_column(:created_at, 25.hours.ago)
+
+        expect { described_class.perform_now }.to change(ActiveStorage::Blob, :count).by(-1)
+      end
+    end
+
+    context "when there are unattached blobs newer than 24 hours" do
+      it "does not purge them" do
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("recent orphaned file"),
+          filename: "recent_orphan.csv",
+          content_type: "text/csv"
+        )
+
+        expect { described_class.perform_now }.not_to change(ActiveStorage::Blob, :count)
+      end
+    end
+
+    context "when there are attached blobs regardless of age" do
+      it "does not purge them" do
+        batch_upload = create(:certification_batch_upload)
+        batch_upload.file.blob.update_column(:created_at, 48.hours.ago)
+
+        expect { described_class.perform_now }.not_to change(ActiveStorage::Blob, :count)
+      end
+    end
+
+    context "when there are no matching blobs" do
+      it "handles gracefully without errors" do
+        expect { described_class.perform_now }.not_to raise_error
+      end
+    end
+
+    context "when purge raises an error on one blob" do
+      it "continues processing remaining blobs" do
+        blob1 = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("blob one"),
+          filename: "blob1.csv",
+          content_type: "text/csv"
+        )
+        blob1.update_column(:created_at, 25.hours.ago)
+
+        blob2 = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("blob two"),
+          filename: "blob2.csv",
+          content_type: "text/csv"
+        )
+        blob2.update_column(:created_at, 25.hours.ago)
+
+        allow(blob1).to receive(:purge).and_raise(StandardError, "S3 unavailable")
+        allow(blob2).to receive(:purge)
+
+        relation = instance_double(ActiveRecord::Relation)
+        allow(ActiveStorage::Blob).to receive(:unattached).and_return(relation)
+        allow(relation).to receive_messages(where: relation, includes: relation)
+        allow(relation).to receive(:find_each).and_yield(blob1).and_yield(blob2)
+
+        expect { described_class.perform_now }.not_to raise_error
+        expect(blob2).to have_received(:purge)
+      end
+    end
+
+    it "logs the purge summary" do
+      allow(Rails.logger).to receive(:info)
+
+      described_class.perform_now
+
+      expect(Rails.logger).to have_received(:info).with("PurgeUnattachedBlobsJob: purged 0 blob(s), 0 failure(s)")
+    end
+  end
+end


### PR DESCRIPTION
With direct_upload: true (batch upload v2), browsers upload files to S3 before form submission. If a user abandons the page mid-upload, the blob exists in S3 but is never attached to a record. These orphaned blobs accumulate indefinitely, consuming storage.

This adds a scheduled job that runs daily at 3 AM via GoodJob cron to purge unattached Active Storage blobs older than 24 hours. The 24-hour grace period avoids race conditions with in-progress uploads.

Key implementation details:
- Uses find_each for memory-efficient batch processing
- Per-blob error isolation (rescue StandardError) so one failed purge doesn't block cleanup of remaining blobs
- includes(:variant_records) to satisfy strict_loading_by_default
- Summary logging for operational visibility

Resolves #295

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->