### PR TITLE
Disable batch upload v2 feature flag on dev environment

### DIFF
--- a/infra/reporting-app/app-config/dev.tf
+++ b/infra/reporting-app/app-config/dev.tf
@@ -30,6 +30,6 @@ module "dev_config" {
 
   service_override_extra_environment_variables = {
     ENABLE_LOOKBOOK         = "true"
-    FEATURE_BATCH_UPLOAD_V2 = "true"
+    FEATURE_BATCH_UPLOAD_V2 = "false"
   }
 }


### PR DESCRIPTION
Batch upload v2 jobs fail and retry infinitely due to retry_on_unhandled_error: true in GoodJob config, causing OOM crashes and a container restart loop. Disable the feature flag to stop the crash loop and restore dev environment stability.

This reverts the flag added in dfbbf72. Once deployed, new batch uploads will use the v1 (legacy sequential) path. Existing stuck jobs will need to be cleared from the good_jobs table manually:

  DELETE FROM good_jobs
  WHERE job_class IN (
    'ProcessCertificationBatchUploadJob',
    'ProcessCertificationBatchChunkJob'
  ) AND finished_at IS NULL;

A follow-up PR will fix the retry configuration to prevent infinite retries when v2 is re-enabled.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->