### PR TITLE
Harden batch upload v2 job reliability and fix cross-environment issues

### DIFF
--- a/infra/reporting-app/app-config/dev.tf
+++ b/infra/reporting-app/app-config/dev.tf
@@ -23,6 +23,9 @@ module "dev_config" {
   # Defaults to `false`. Uncomment the next line to enable.
   # enable_command_execution = true
 
+  # Increase memory from default 512 MiB to give headroom for Puma + GoodJob async workers
+  service_memory = 1024
+
   # Uncomment to override default feature flag values
   # feature_flag_overrides = {
   #   BAR = true
@@ -30,6 +33,7 @@ module "dev_config" {
 
   service_override_extra_environment_variables = {
     ENABLE_LOOKBOOK         = "true"
-    FEATURE_BATCH_UPLOAD_V2 = "false"
+    FEATURE_BATCH_UPLOAD_V2 = "true"
+    PERFORM_EMAIL_DELIVERY  = "false"
   }
 }

--- a/infra/reporting-app/service/storage.tf
+++ b/infra/reporting-app/service/storage.tf
@@ -3,9 +3,11 @@ locals {
   bucket_name    = "${local.prefix}${local.storage_config.bucket_name}"
 
   # CORS origins for browser-based direct uploads
-  # Use custom domain if available, otherwise use load balancer endpoint
-  # This ensures preview environments (which use ALB DNS) also get CORS configured
-  cors_allowed_origins = module.domain.domain_name != "" ? [
+  # Temporary environments (PR previews) use the ALB endpoint directly since
+  # they don't have a custom domain. Non-temporary environments use the custom domain.
+  cors_allowed_origins = local.is_temporary ? [
+    module.service.public_endpoint
+    ] : module.domain.domain_name != "" ? [
     "https://${module.domain.domain_name}"
     ] : [
     module.service.public_endpoint

--- a/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
+++ b/reporting-app/app/jobs/process_certification_batch_chunk_job.rb
@@ -4,7 +4,32 @@
 # Part of batch upload v2 streaming architecture - processes chunks in parallel
 class ProcessCertificationBatchChunkJob < ApplicationJob
   queue_as :default
-  retry_on ActiveRecord::Deadlocked, wait: :exponentially_longer, attempts: 3
+
+  # When a chunk is discarded (any unhandled error), report in as failed so the
+  # batch can reach a terminal state. All rows are counted as errored.
+  # The @counters_updated flag prevents double-counting if the error happened
+  # after update_counters! already ran in perform.
+  discard_on StandardError do |job, error|
+    batch_upload_id, chunk_number, _headers, _start_byte, _end_byte, record_count = job.arguments
+    batch_upload = CertificationBatchUpload.find_by(id: batch_upload_id)
+    next unless batch_upload && record_count
+
+    Rails.logger.error(
+      "Chunk #{chunk_number} for batch #{batch_upload_id} discarded: #{error.class} - #{error.message}"
+    )
+
+    unless job.counters_updated
+      CertificationBatchUpload.update_counters(
+        batch_upload.id,
+        num_rows_processed: record_count,
+        num_rows_errored: record_count
+      )
+    end
+
+    batch_upload.check_completion!
+  end
+
+  attr_reader :counters_updated
 
   # Process a chunk of certification records by reading from S3
   # @param batch_upload_id [String] The UUID of the CertificationBatchUpload record
@@ -12,16 +37,22 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
   # @param headers [Array<String>] CSV column headers
   # @param start_byte [Integer] Start of byte range in S3 object (inclusive)
   # @param end_byte [Integer] End of byte range in S3 object (inclusive)
+  # @param record_count [Integer] Number of records in this chunk (for failure reporting)
   # @param processor [UnifiedRecordProcessor] The processor to use (injectable for testing)
-  def perform(batch_upload_id, chunk_number, headers, start_byte, end_byte, processor: UnifiedRecordProcessor.new)
+  def perform(batch_upload_id, chunk_number, headers, start_byte, end_byte, record_count, processor: UnifiedRecordProcessor.new)
+    @counters_updated = false
+
     batch_upload = CertificationBatchUpload.find_by(id: batch_upload_id)
     return if batch_upload.nil?  # Batch was deleted, nothing to do
     audit_log = create_audit_log(batch_upload, chunk_number)
 
+    storage_key = batch_upload.storage_key
+    Rails.logger.info("Chunk #{chunk_number} for batch #{batch_upload_id}: reading key=#{storage_key} bytes=#{start_byte}-#{end_byte}")
+
     # Read records from S3 using byte-range coordinates
     reader = CsvStreamReader.new
     records = reader.read_chunk(
-      batch_upload.storage_key,
+      storage_key,
       headers: headers,
       start_byte: start_byte,
       end_byte: end_byte
@@ -60,8 +91,9 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
 
     complete_audit_log(audit_log, results)
     update_counters!(batch_upload, records.size, results)
+    @counters_updated = true
     store_errors!(batch_upload, results[:errors])
-    check_completion!(batch_upload)
+    batch_upload.check_completion!
 
   rescue StandardError => e
     # Mark audit log as failed if chunk job crashes (system error)
@@ -98,11 +130,12 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
   end
 
   def update_counters!(batch_upload, record_count, results)
-    batch_upload.with_lock do
-      batch_upload.increment!(:num_rows_processed, record_count)
-      batch_upload.increment!(:num_rows_succeeded, results[:succeeded])
-      batch_upload.increment!(:num_rows_errored, results[:failed])
-    end
+    CertificationBatchUpload.update_counters(
+      batch_upload.id,
+      num_rows_processed: record_count,
+      num_rows_succeeded: results[:succeeded],
+      num_rows_errored: results[:failed]
+    )
   end
 
   def store_errors!(batch_upload, errors)
@@ -121,26 +154,5 @@ class ProcessCertificationBatchChunkJob < ApplicationJob
     end
 
     CertificationBatchUploadError.insert_all(error_records)
-  end
-
-  # Check if batch is complete and transition to completed state.
-  # The counter lock in update_counters! ensures accurate totals; this lock
-  # serializes the completion check. Two guards:
-  # - num_rows_processed >= num_rows: skips all chunks that haven't pushed the
-  #   total to completion yet
-  # - completed?: handles the rare race where two chunks both see the final count
-  #   before either acquires this lock — first one completes the batch, second
-  #   finds it already done
-  def check_completion!(batch_upload)
-    batch_upload.with_lock do
-      return unless batch_upload.num_rows_processed >= batch_upload.num_rows
-      return if batch_upload.completed?
-
-      batch_upload.complete_processing!(
-        num_rows_succeeded: batch_upload.num_rows_succeeded,
-        num_rows_errored: batch_upload.num_rows_errored,
-        results: {} # Results now in audit_logs and upload_errors tables
-      )
-    end
   end
 end

--- a/reporting-app/app/jobs/process_certification_batch_upload_job.rb
+++ b/reporting-app/app/jobs/process_certification_batch_upload_job.rb
@@ -3,6 +3,7 @@
 # Background job to process uploaded certification CSV files
 class ProcessCertificationBatchUploadJob < ApplicationJob
   queue_as :default
+  discard_on StandardError
 
   # Process a certification batch upload
   # @param batch_upload_id [String] The UUID of the CertificationBatchUpload record
@@ -38,7 +39,13 @@ class ProcessCertificationBatchUploadJob < ApplicationJob
     # Single pass: count records and collect byte-range coordinates
     reader.each_chunk_with_offsets(batch_upload.storage_key) do |records, headers, start_byte, end_byte|
       total_records += records.size
-      chunks << { chunk_number: chunks.size + 1, headers: headers, start_byte: start_byte, end_byte: end_byte }
+      chunks << {
+        chunk_number: chunks.size + 1,
+        headers: headers,
+        start_byte: start_byte,
+        end_byte: end_byte,
+        record_count: records.size
+      }
     end
 
     # Set num_rows before enqueueing any jobs (prevents race condition)
@@ -61,7 +68,8 @@ class ProcessCertificationBatchUploadJob < ApplicationJob
         chunk[:chunk_number],
         chunk[:headers],
         chunk[:start_byte],
-        chunk[:end_byte]
+        chunk[:end_byte],
+        chunk[:record_count]
       )
     end
   end

--- a/reporting-app/app/models/certification_batch_upload.rb
+++ b/reporting-app/app/models/certification_batch_upload.rb
@@ -71,6 +71,57 @@ class CertificationBatchUpload < ApplicationRecord
     update!(num_rows_processed: num_rows_processed)
   end
 
+  # Check if all chunks have reported in and transition to a terminal state.
+  # Called by both successful chunks and the discard_on block for failed chunks.
+  #
+  # Uses SQL-level locking and update_columns to avoid strict_loading violations
+  # that occur when with_lock reloads the record without eager-loaded ActiveStorage.
+  #
+  # Status determination uses audit log status (not just row counts):
+  # - Any chunk completed (ran successfully) → completed (with errors if applicable)
+  # - All chunks failed (system errors) → failed
+  def check_completion!
+    # NOTE: Avoid `return` inside transaction blocks — Rails 7.2 treats non-local
+    # returns as rollbacks and raises ActiveRecord::Rollback in the ensure block.
+    # Use if/else flow control instead.
+    self.class.transaction do
+      # Lock the row and read attributes without loading a full AR object
+      row = self.class.unscoped.where(id: id).lock(true).pick(
+        :num_rows_processed, :num_rows, :status,
+        :num_rows_succeeded, :num_rows_errored
+      )
+
+      if row
+        num_processed, total, current_status, succeeded, errored = row
+
+        if num_processed >= total && !current_status.in?(%w[completed failed])
+          any_chunk_completed = CertificationBatchUploadAuditLog.where(
+            certification_batch_upload_id: id,
+            status: :completed
+          ).exists?
+
+          if any_chunk_completed
+            update_columns(
+              status: :completed,
+              num_rows_succeeded: succeeded,
+              num_rows_errored: errored,
+              results: {},
+              processed_at: Time.current,
+              updated_at: Time.current
+            )
+          else
+            update_columns(
+              status: :failed,
+              results: { error: "All chunks failed to process" },
+              processed_at: Time.current,
+              updated_at: Time.current
+            )
+          end
+        end
+      end
+    end
+  end
+
   # Check if can be processed
   def processable?
     pending?

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -151,7 +151,8 @@ class UnifiedRecordProcessor
       "certification_type" => record["certification_type"],
       "lookback_period" => record["lookback_period"]&.to_i,
       "number_of_months_to_certify" => record["number_of_months_to_certify"]&.to_i,
-      "due_period_days" => record["due_period_days"]&.to_i
+      "due_period_days" => record["due_period_days"]&.to_i,
+      "region" => record["region"]
     }.compact_blank
 
     @certification_service.certification_requirements_from_input(requirement_input)

--- a/reporting-app/config/environments/mock-production.rb
+++ b/reporting-app/config/environments/mock-production.rb
@@ -74,12 +74,17 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "reporting-app:production"
+  # Use GoodJob for persistent background job processing (matches production.rb)
+  config.active_job.queue_adapter = :good_job
 
   config.action_mailer.delivery_method = :ses_v2
   config.action_mailer.perform_caching = false
+
+  # Control whether emails are actually sent via SES. Emails are still
+  # generated (templates rendered) regardless of this setting.
+  if ENV["PERFORM_EMAIL_DELIVERY"] == "false"
+    config.action_mailer.perform_deliveries = false
+  end
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/reporting-app/config/environments/production.rb
+++ b/reporting-app/config/environments/production.rb
@@ -90,6 +90,12 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :ses_v2
 
+  # Control whether emails are actually sent via SES. Emails are still
+  # generated (templates rendered) regardless of this setting.
+  if ENV["PERFORM_EMAIL_DELIVERY"] == "false"
+    config.action_mailer.perform_deliveries = false
+  end
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/reporting-app/config/initializers/good_job.rb
+++ b/reporting-app/config/initializers/good_job.rb
@@ -11,11 +11,17 @@ Rails.application.configure do
   # Scope jobs to this environment to prevent cross-environment execution
   # when multiple environments share the same database (e.g., dev + preview).
   # GOOD_JOB_QUEUE_PREFIX is set per ECS task by terraform (local.service_name).
+  #
+  # Note: We use "_" as the delimiter (not ":") because GoodJob's queues config
+  # format uses ":" as a thread-count delimiter (e.g., "queue_name:2"). Using ":"
+  # in queue names causes GoodJob to misparse them (e.g., "prefix:default" becomes
+  # queue "prefix" with 0 threads).
   queue_prefix = ENV["GOOD_JOB_QUEUE_PREFIX"]
   if queue_prefix.present?
     config.active_job.queue_name_prefix = queue_prefix
-    config.active_job.queue_name_delimiter = ":"
-    config.good_job.queues = "#{queue_prefix}:*"
+    config.active_job.queue_name_delimiter = "_"
+    prefixed_queues = %w[default].map { |q| "#{queue_prefix}_#{q}" }.join(",")
+    config.good_job.queues = prefixed_queues
   else
     config.good_job.queues = "*"
   end
@@ -30,8 +36,10 @@ Rails.application.configure do
     }
   }
 
-  # Retry failed jobs automatically
-  config.good_job.retry_on_unhandled_error = true
+  # Don't retry unhandled errors automatically. Jobs that need retries should
+  # declare specific retry_on handlers with bounded attempts and backoff.
+  # Global retry with zero delay caused an OOM retry storm in production.
+  config.good_job.retry_on_unhandled_error = false
 
   # Poll interval for new jobs (1 second)
   config.good_job.poll_interval = 1

--- a/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
   let(:headers) { %w[member_id case_number member_email first_name last_name certification_date certification_type] }
   let(:start_byte) { 0 }
   let(:end_byte) { 999 }
+  let(:record_count) { 3 }
   let(:csv_reader) { instance_double(CsvStreamReader) }
 
   before do
@@ -50,30 +51,30 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
   describe '#perform' do
     context 'with all valid records' do
       let(:records) { [ valid_record ] }
+      let(:record_count) { 1 }
 
       before do
         allow(csv_reader).to receive(:read_chunk).and_return(records)
       end
 
       it 'processes records and updates batch' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        batch = CertificationBatchUpload.find(batch_upload.id)
 
-        expect(batch_upload.num_rows_processed).to eq(1)
-        expect(batch_upload.num_rows_succeeded).to eq(1)
-        expect(batch_upload.num_rows_errored).to eq(0)
+        expect(batch.num_rows_processed).to eq(1)
+        expect(batch.num_rows_succeeded).to eq(1)
+        expect(batch.num_rows_errored).to eq(0)
       end
 
       it 'creates certifications' do
         expect {
-          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
         }.to change(Certification, :count).by(1)
       end
 
       it 'creates certification origins' do
         expect {
-          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
         }.to change(CertificationOrigin, :count).by(1)
 
         origin = CertificationOrigin.last
@@ -82,7 +83,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       end
 
       it 'creates audit log entry' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
         logs = CertificationBatchUploadAuditLog
           .where(certification_batch_upload_id: batch_upload.id)
@@ -93,7 +94,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
 
       it 'does not create error entries' do
         expect {
-          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
         }.not_to change(CertificationBatchUploadError, :count)
       end
     end
@@ -114,17 +115,16 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       end
 
       it 'processes all records and tracks results' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        batch = CertificationBatchUpload.find(batch_upload.id)
 
-        expect(batch_upload.num_rows_processed).to eq(3)
-        expect(batch_upload.num_rows_succeeded).to eq(1) # Only valid_record
-        expect(batch_upload.num_rows_errored).to eq(2) # invalid + duplicate
+        expect(batch.num_rows_processed).to eq(3)
+        expect(batch.num_rows_succeeded).to eq(1) # Only valid_record
+        expect(batch.num_rows_errored).to eq(2) # invalid + duplicate
       end
 
       it 'creates audit log with correct counts' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
         logs = CertificationBatchUploadAuditLog
           .where(certification_batch_upload_id: batch_upload.id)
@@ -134,7 +134,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       end
 
       it 'stores error details for failed records' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
         errors = CertificationBatchUploadError
           .where(certification_batch_upload_id: batch_upload.id)
@@ -150,11 +150,10 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
 
       it 'continues processing after validation errors' do
         # All three records should be attempted, not stopped at first error
-        batch_id = batch_upload.id
-        described_class.perform_now(batch_id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
-        expect(batch_upload.num_rows_processed).to eq(3)
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.num_rows_processed).to eq(3)
       end
     end
 
@@ -176,23 +175,22 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         )
       end
       let(:chunk_3_records) { [ chunk_3_record ] }
+      let(:record_count) { 1 }
 
       it 'marks batch as complete when all chunks finish' do
         allow(csv_reader).to receive(:read_chunk)
           .and_return(chunk_1_records, chunk_2_records, chunk_3_records)
 
         # Process chunks 1 and 2
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
-        described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte)
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
-        expect(batch_upload.status).to eq("processing")
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte, record_count)
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.status).to eq("processing")
 
         # Process final chunk
-        described_class.perform_now(batch_upload.id, 3, headers, start_byte, end_byte)
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
-        expect(batch_upload.status).to eq("completed")
+        described_class.perform_now(batch_upload.id, 3, headers, start_byte, end_byte, record_count)
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.status).to eq("completed")
       end
 
       it 'handles concurrent chunk completion safely' do
@@ -201,19 +199,17 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
 
         # Process all 3 chunks concurrently to test race condition handling
         threads = [
-          Thread.new { described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte) },
-          Thread.new { described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte) },
-          Thread.new { described_class.perform_now(batch_upload.id, 3, headers, start_byte, end_byte) }
+          Thread.new { described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count) },
+          Thread.new { described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte, record_count) },
+          Thread.new { described_class.perform_now(batch_upload.id, 3, headers, start_byte, end_byte, record_count) }
         ]
         threads.each(&:join)
 
-        batch_id = batch_upload.id
-
-        batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
-        expect(batch_upload.status).to eq("completed")
-        expect(batch_upload.num_rows_processed).to eq(3)
-        expect(batch_upload.num_rows_succeeded).to eq(3)
-        expect(batch_upload.num_rows_errored).to eq(0)
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.status).to eq("completed")
+        expect(batch.num_rows_processed).to eq(3)
+        expect(batch.num_rows_succeeded).to eq(3)
+        expect(batch.num_rows_errored).to eq(0)
 
         # Verify all certifications were created
         expect(Certification.where(
@@ -223,11 +219,13 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
     end
 
     context 'with row number calculation' do
+      let(:record_count) { 2 }
+
       it 'calculates correct row numbers for first chunk' do
         records = [ valid_record, invalid_record ]
         allow(csv_reader).to receive(:read_chunk).and_return(records)
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
         # Chunk 1, index 0 → row 2 (first data row after header)
         # Chunk 1, index 1 → row 3 (invalid record)
@@ -243,7 +241,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         chunk_size = CsvStreamReader::DEFAULT_CHUNK_SIZE
         allow(csv_reader).to receive(:read_chunk).and_return(records)
 
-        described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 2, headers, start_byte, end_byte, 1)
 
         # Chunk 2, index 0 → row (1000 + 2)
         error_row_numbers = CertificationBatchUploadError
@@ -255,43 +253,39 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
     end
 
     context 'when S3 read fails' do
-      it 'marks audit log as failed and re-raises' do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 1) }
+      let(:record_count) { 1 }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'marks audit log as failed' do
         allow(csv_reader).to receive(:read_chunk)
           .and_raise(Aws::S3::Errors::ServiceError.new(nil, "S3 unavailable"))
-        allow(Rails.logger).to receive(:error)
 
-        expect {
-          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
-        }.to raise_error(Aws::S3::Errors::ServiceError)
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        end
 
         audit_log = CertificationBatchUploadAuditLog
           .find_by(certification_batch_upload_id: batch_upload.id)
         expect(audit_log.status).to eq("failed")
       end
 
-      it 'does not increment batch counters' do
+      it 'increments counters via discard_on and reaches terminal state' do
         allow(csv_reader).to receive(:read_chunk)
           .and_raise(Aws::S3::Errors::ServiceError.new(nil, "S3 unavailable"))
-        allow(Rails.logger).to receive(:error)
 
-        expect {
-          described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
-        }.to raise_error(Aws::S3::Errors::ServiceError)
-
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.find(batch_id)
-        expect(batch_upload.num_rows_processed).to eq(0)
-      end
-    end
-
-    context 'with error handling configuration' do
-      it 'is configured to retry on ActiveRecord::Deadlocked' do
-        # Verify the retry_on configuration exists
-        retry_callbacks = described_class.rescue_handlers.select do |handler|
-          handler.first == "ActiveRecord::Deadlocked"
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
         end
 
-        expect(retry_callbacks).not_to be_empty
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.num_rows_processed).to eq(1)
+        expect(batch.num_rows_errored).to eq(1)
+        expect(batch.status).to eq("failed")
       end
     end
 
@@ -299,6 +293,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       let(:processor) { instance_double(UnifiedRecordProcessor) }
       let(:records) { [ valid_record ] }
       let(:mock_certification) { instance_double(Certification, id: 1) }
+      let(:record_count) { 1 }
 
       before do
         allow(csv_reader).to receive(:read_chunk).and_return(records)
@@ -307,7 +302,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       it 'calls processor with record and context' do
         allow(processor).to receive(:process).and_return(mock_certification)
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, processor: processor)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
         expect(processor).to have_received(:process)
           .with(valid_record, context: { batch_upload_id: batch_upload.id })
@@ -317,7 +312,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         allow(processor).to receive(:process).and_return(mock_certification)
         allow(UnifiedRecordProcessor).to receive(:new).and_call_original
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, processor: processor)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
         # Should use injected processor, not create a new one
         expect(UnifiedRecordProcessor).not_to have_received(:new)
@@ -326,12 +321,14 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
     end
 
     context 'when delegating to reader' do
+      let(:record_count) { 1 }
+
       before do
         allow(csv_reader).to receive(:read_chunk).and_return([ valid_record ])
       end
 
       it 'calls read_chunk with correct arguments' do
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
 
         expect(csv_reader).to have_received(:read_chunk).with(
           batch_upload.storage_key,
@@ -347,7 +344,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         non_existent_id = "00000000-0000-0000-0000-000000000000"
 
         expect {
-          described_class.perform_now(non_existent_id, 1, headers, start_byte, end_byte)
+          described_class.perform_now(non_existent_id, 1, headers, start_byte, end_byte, 1)
         }.not_to change(Certification, :count)
 
         # Should not create audit logs or errors
@@ -359,6 +356,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
     context 'with unexpected errors' do
       let(:processor) { instance_double(UnifiedRecordProcessor) }
       let(:records) { [ valid_record ] }
+      let(:record_count) { 1 }
 
       before do
         allow(csv_reader).to receive(:read_chunk).and_return(records)
@@ -369,7 +367,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         allow(processor).to receive(:process).and_raise(error)
         allow(Rails.logger).to receive(:error)
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, processor: processor)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
         expect(Rails.logger).to have_received(:error).with(/Unexpected error processing row 2: StandardError - Something went wrong/)
         expect(Rails.logger).to have_received(:error).with(/Backtrace:/)
@@ -380,7 +378,7 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         allow(processor).to receive(:process).and_raise(error)
         allow(Rails.logger).to receive(:error)
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, processor: processor)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
         errors = CertificationBatchUploadError
           .where(certification_batch_upload_id: batch_upload.id)
@@ -396,21 +394,152 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
         allow(processor).to receive(:process).and_raise(error)
         allow(Rails.logger).to receive(:error)
 
-        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, processor: processor)
-        batch_id = batch_upload.id
-        batch_upload = CertificationBatchUpload.find(batch_id)
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count, processor: processor)
 
-        expect(batch_upload.num_rows_errored).to eq(1)
-        expect(batch_upload.num_rows_succeeded).to eq(0)
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.num_rows_errored).to eq(1)
+        expect(batch.num_rows_succeeded).to eq(0)
+      end
+    end
+  end
+
+  describe 'discard_on behavior' do
+    context 'when a chunk fails with an unhandled error' do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 5) }
+      let(:record_count) { 5 }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'increments counters with all rows as errored' do
+        allow(csv_reader).to receive(:read_chunk)
+          .and_raise(RuntimeError, "S3 connection lost")
+
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        end
+
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.num_rows_processed).to eq(5)
+        expect(batch.num_rows_errored).to eq(5)
+        expect(batch.num_rows_succeeded).to eq(0)
+      end
+
+      it 'triggers check_completion! to reach a terminal state' do
+        allow(csv_reader).to receive(:read_chunk)
+          .and_raise(RuntimeError, "S3 connection lost")
+
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+        end
+
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.status).to eq("failed")
+        expect(batch.results["error"]).to eq("All chunks failed to process")
+      end
+
+      it 'does not double-count when counters were already updated' do
+        # Simulate error happening after update_counters! (e.g., in store_errors!)
+        allow(csv_reader).to receive(:read_chunk).and_return([ valid_record ])
+        allow(CertificationBatchUploadError).to receive(:insert_all)
+          .and_raise(RuntimeError, "DB write failed")
+
+        batch_upload.update!(num_rows: 1)
+
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, 1)
+        end
+
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        # Should be 1, not 2 (counters_updated was true when error occurred)
+        expect(batch.num_rows_processed).to eq(1)
+      end
+    end
+
+    context 'with partial chunk failure (some succeed, some fail)' do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 2) }
+      let(:chunk_1_records) { [ valid_record ] }
+
+      it 'marks batch as completed when some chunks succeed and others crash' do
+        # Use explicit call counter to guarantee first call returns, second raises
+        call_count = 0
+        allow(csv_reader).to receive(:read_chunk) do |*_args, **_kwargs|
+          call_count += 1
+          raise RuntimeError, "S3 timeout" if call_count > 1
+          chunk_1_records
+        end
+
+        # Process chunk 1 successfully
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, 1)
+
+        # Process chunk 2 which will fail (via perform_enqueued_jobs to trigger discard_on)
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 2, headers, start_byte, end_byte, 1)
+        end
+
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        # Any chunk completed → status is completed (not failed)
+        expect(batch.status).to eq("completed")
+        expect(batch.num_rows_processed).to eq(2)
+        expect(batch.num_rows_succeeded).to eq(1)
+        expect(batch.num_rows_errored).to eq(1)
+      end
+    end
+
+    context 'when all chunks fail' do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 2) }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'marks batch as failed' do
+        allow(csv_reader).to receive(:read_chunk)
+          .and_raise(RuntimeError, "S3 connection lost")
+
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, 1)
+        end
+        perform_enqueued_jobs do
+          described_class.perform_later(batch_upload.id, 2, headers, start_byte, end_byte, 1)
+        end
+
+        batch = CertificationBatchUpload.find(batch_upload.id)
+        expect(batch.status).to eq("failed")
+        expect(batch.results["error"]).to eq("All chunks failed to process")
+      end
+    end
+
+    context 'when batch upload is not found in discard_on' do
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+        allow(csv_reader).to receive(:read_chunk)
+          .and_raise(RuntimeError, "Some error")
+      end
+
+      it 'does not raise when batch is missing' do
+        non_existent_id = "00000000-0000-0000-0000-000000000000"
+
+        expect {
+          perform_enqueued_jobs do
+            described_class.perform_later(non_existent_id, 1, headers, start_byte, end_byte, 1)
+          end
+        }.not_to raise_error
       end
     end
   end
 
   describe 'job queuing' do
-    it 'enqueues the job with correct parameters' do
+    it 'enqueues the job with correct parameters including record_count' do
       expect {
-        described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte)
-      }.to have_enqueued_job(described_class).with(batch_upload.id, 1, headers, start_byte, end_byte)
+        described_class.perform_later(batch_upload.id, 1, headers, start_byte, end_byte, 3)
+      }.to have_enqueued_job(described_class).with(batch_upload.id, 1, headers, start_byte, end_byte, 3)
     end
   end
 end

--- a/reporting-app/spec/jobs/process_certification_batch_upload_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_upload_job_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
                 1,
                 expected_headers,
                 0,
-                100
+                100,
+                1
               ]
             )
             expect(enqueued[1]["arguments"]).to eq(
@@ -124,7 +125,8 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
                 2,
                 expected_headers,
                 101,
-                200
+                200,
+                1
               ]
             )
           end
@@ -153,9 +155,8 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
             .and_raise(StandardError, "S3 connection lost")
 
           with_batch_upload_v2_enabled do
-            expect {
-              described_class.perform_now(batch_upload.id)
-            }.to raise_error(StandardError, "S3 connection lost")
+            # discard_on StandardError swallows the error; rescue block still calls fail_processing!
+            described_class.perform_now(batch_upload.id)
 
             batch_id = batch_upload.id
             batch_upload = CertificationBatchUpload.includes(file_attachment: :blob).find(batch_id)
@@ -212,9 +213,8 @@ RSpec.describe ProcessCertificationBatchUploadJob, type: :job do
         end
 
         it 'marks batch as failed' do
-          expect {
-            described_class.perform_now(batch_upload.id)
-          }.to raise_error(StandardError)
+          # discard_on StandardError swallows the error; rescue block still calls fail_processing!
+          described_class.perform_now(batch_upload.id)
 
           batch_id = batch_upload.id
 

--- a/reporting-app/spec/models/certification_batch_upload_spec.rb
+++ b/reporting-app/spec/models/certification_batch_upload_spec.rb
@@ -98,6 +98,87 @@ RSpec.describe CertificationBatchUpload, type: :model do
     end
   end
 
+  describe '#check_completion!' do
+    let(:batch_upload) do
+      create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 2,
+        num_rows_processed: 2, num_rows_succeeded: 1, num_rows_errored: 1)
+    end
+
+    # Use find instead of reload to avoid strict_loading violations on ActiveStorage
+    def reload_batch(id)
+      CertificationBatchUpload.find(id)
+    end
+
+    context 'when not all rows are processed' do
+      let(:batch_upload) do
+        create(:certification_batch_upload, uploader: user, status: :processing, num_rows: 3,
+          num_rows_processed: 2, num_rows_succeeded: 1, num_rows_errored: 1)
+      end
+
+      it 'does not transition status' do
+        batch_upload.check_completion!
+        expect(reload_batch(batch_upload.id).status).to eq("processing")
+      end
+    end
+
+    context 'when already completed' do
+      let(:batch_upload) do
+        create(:certification_batch_upload, uploader: user, status: :completed, num_rows: 2,
+          num_rows_processed: 2, num_rows_succeeded: 2, num_rows_errored: 0)
+      end
+
+      it 'does not overwrite status' do
+        batch_upload.check_completion!
+        expect(reload_batch(batch_upload.id).status).to eq("completed")
+      end
+    end
+
+    context 'when already failed' do
+      let(:batch_upload) do
+        create(:certification_batch_upload, uploader: user, status: :failed, num_rows: 2,
+          num_rows_processed: 2)
+      end
+
+      it 'does not overwrite status' do
+        batch_upload.check_completion!
+        expect(reload_batch(batch_upload.id).status).to eq("failed")
+      end
+    end
+
+    context 'when any chunk completed successfully' do
+      before do
+        create(:audit_log, certification_batch_upload: batch_upload, chunk_number: 1, status: :completed)
+        create(:audit_log, certification_batch_upload: batch_upload, chunk_number: 2, status: :failed)
+      end
+
+      it 'marks batch as completed' do
+        batch_upload.check_completion!
+
+        batch = reload_batch(batch_upload.id)
+        expect(batch.status).to eq("completed")
+        expect(batch.num_rows_succeeded).to eq(1)
+        expect(batch.num_rows_errored).to eq(1)
+        expect(batch.processed_at).to be_present
+      end
+    end
+
+    context 'when all chunks failed' do
+      before do
+        create(:audit_log, certification_batch_upload: batch_upload, chunk_number: 1, status: :failed)
+        create(:audit_log, certification_batch_upload: batch_upload, chunk_number: 2, status: :failed)
+      end
+
+      it 'marks batch as failed' do
+        batch_upload.check_completion!
+
+        batch = reload_batch(batch_upload.id)
+        expect(batch.status).to eq("failed")
+        expect(batch.results["error"]).to eq("All chunks failed to process")
+        expect(batch.processed_at).to be_present
+      end
+    end
+  end
+
   describe '#processable?' do
     it 'returns true when pending' do
       batch_upload = create(:certification_batch_upload, uploader: user, status: :pending)


### PR DESCRIPTION
## Summary

Resolves multiple issues discovered during batch upload v2 testing on dev/preview
environments (see #110). The core problems were: (1) GoodJob's global
`retry_on_unhandled_error` causing an infinite retry storm that OOM'd the container,
(2) cross-environment job execution when dev and preview share a database, and
(3) chunk jobs that crash leaving batches stuck in "processing" forever.

### Job reliability (chunk + orchestrator)

- Add `discard_on StandardError` to both jobs to prevent GoodJob's global retry
  from creating an infinite retry storm (the root cause of OOM kills)
- Pass `record_count` to chunk jobs so the discard_on block can report all rows
  as errored when a chunk crashes, ensuring the batch reaches a terminal state
- Move `check_completion!` from chunk job to `CertificationBatchUpload` model so
  both the happy path and the discard_on block can trigger completion checks
- Use `update_counters` (SQL-level atomic increment) instead of `with_lock` +
  `increment!` to avoid strict_loading violations from ActiveStorage eager loading
- Track `@counters_updated` flag to prevent double-counting when errors occur
  after counters were already updated

### GoodJob queue scoping

- Disable `retry_on_unhandled_error` globally — jobs that need retries should
  declare explicit `retry_on` with bounded attempts
- Add `GOOD_JOB_QUEUE_PREFIX` env var (set per ECS task via Terraform) to scope
  job queues per environment, preventing preview containers from grabbing dev jobs
- Use `_` as queue name delimiter (not `:`) because GoodJob parses `:` as a
  thread-count separator in its multi-scheduler config

### Infrastructure

- Fix S3 CORS for preview environments — temporary envs use ALB endpoint directly
- Increase dev ECS container memory from 512 MiB to 1024 MiB for headroom
- Add `PERFORM_EMAIL_DELIVERY` toggle to prevent SES email floods during testing
- Enable batch upload v2 feature flag on dev

### Other

- Add `region` field mapping to UnifiedRecordProcessor
- Configure GoodJob queue adapter in mock-production environment

## Test plan

- [x] Upload test CSV on preview site — batch completes successfully
- [x] Multi-chunk uploads (3000+ rows) process without OOM
- [x] Failed chunks report errors and batch reaches terminal state
- [x] Preview and dev environments no longer pick up each other's jobs
- [x] CI passes (RSpec + RuboCop)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->