### PR TITLE
SSO configuration – always-on config, toggle via SSO_ENABLED

### DIFF
--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -19,9 +19,9 @@ locals {
       GOOD_JOB_MAX_THREADS    = "2"
       DATABASE_POOL           = "8"
     },
-    # SSO environment variables (when SSO is enabled)
-    var.enable_sso && var.enable_identity_provider ? {
-      SSO_ENABLED     = "true"
+    # SSO configuration: always set so any environment can enable SSO by overriding SSO_ENABLED to "true"
+    var.enable_identity_provider ? {
+      SSO_ENABLED     = "false"
       SSO_SCOPES      = "openid profile email"
       SSO_CLAIM_EMAIL = "email"
       SSO_CLAIM_NAME  = "name"

--- a/infra/reporting-app/app-config/env-config/identity_provider.tf
+++ b/infra/reporting-app/app-config/env-config/identity_provider.tf
@@ -39,11 +39,9 @@ locals {
 
     verification_email = local.verification_email
 
-    # Staff SSO enabled flag (for service layer to conditionally add SSO env vars)
-    enable_sso = var.enable_sso
-
-    # Client configuration for Cognito app client
-    # When SSO is enabled, includes the /auth/sso/callback URL
+    # Client configuration for Cognito app client.
+    # SSO callback URL is always included when identity provider + domain exist, so any
+    # environment can enable SSO by setting SSO_ENABLED=true in service_override_extra_environment_variables.
     #
     # Do not hardcode URLs here. Instead use:
     #   - callback_url_path / logout_url_path locals for main app paths
@@ -52,8 +50,7 @@ locals {
     client = {
       callback_urls = concat(
         var.domain_name != null ? ["https://${var.domain_name}/${local.callback_url_path}"] : [],
-        # Add SSO callback URL when SSO is enabled
-        var.enable_sso && var.domain_name != null ? ["https://${var.domain_name}/${local.sso_callback_url_path}"] : [],
+        var.domain_name != null ? ["https://${var.domain_name}/${local.sso_callback_url_path}"] : [],
         var.extra_identity_provider_callback_urls,
         var.sso_callback_urls
       )

--- a/infra/reporting-app/app-config/env-config/variables.tf
+++ b/infra/reporting-app/app-config/env-config/variables.tf
@@ -60,13 +60,7 @@ variable "extra_identity_provider_logout_urls" {
   default     = []
 }
 
-# Staff SSO Configuration
-variable "enable_sso" {
-  type        = bool
-  description = "Enables Staff Single Sign-On via OIDC (uses Cognito as identity provider)"
-  default     = false
-}
-
+# Staff SSO Configuration (optional overrides)
 variable "sso_callback_urls" {
   type        = list(string)
   description = "List of additional SSO callback URLs. Used for local development with ngrok."

--- a/infra/reporting-app/app-config/sandbox.tf
+++ b/infra/reporting-app/app-config/sandbox.tf
@@ -14,9 +14,6 @@ module "sandbox_config" {
   # Enable and configure identity provider.
   enable_identity_provider = local.enable_identity_provider
 
-  # Enable Staff SSO authentication via Cognito OIDC
-  enable_sso = true
-
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
   # Defaults to `false`. Uncomment the next line to enable.
@@ -24,5 +21,6 @@ module "sandbox_config" {
 
   service_override_extra_environment_variables = {
     ENABLE_LOOKBOOK = "true"
+    SSO_ENABLED     = "true"
   }
 }

--- a/infra/reporting-app/service/identity_provider.tf
+++ b/infra/reporting-app/service/identity_provider.tf
@@ -1,9 +1,6 @@
 locals {
   identity_provider_config = local.environment_config.identity_provider_config
 
-  # Check if SSO is enabled for this environment
-  enable_sso = local.identity_provider_config != null ? local.identity_provider_config.enable_sso : false
-
   # If this is a temporary environment, re-use an existing Cognito user pool. Otherwise, create a new one.
   identity_provider_user_pool_id = module.app_config.enable_identity_provider ? (
     local.is_temporary ? module.existing_identity_provider[0].user_pool_id : module.identity_provider[0].user_pool_id
@@ -13,10 +10,8 @@ locals {
     COGNITO_CLIENT_ID    = module.identity_provider_client[0].client_id
   } : {}
 
-  # SSO uses the same Cognito app client (callback URLs are merged in identity_provider_config)
-  # Only add SSO env vars when SSO is enabled
-  sso_environment_variables = local.enable_sso ? {
-    # SSO issuer URL is Cognito's OIDC issuer endpoint
+  # SSO env vars are always set when identity provider is enabled. App turns SSO on when SSO_ENABLED=true.
+  sso_environment_variables = module.app_config.enable_identity_provider ? {
     SSO_ISSUER_URL = "https://cognito-idp.${local.service_config.region}.amazonaws.com/${local.identity_provider_user_pool_id}"
     SSO_CLIENT_ID  = module.identity_provider_client[0].client_id
   } : {}
@@ -53,7 +48,7 @@ module "existing_identity_provider" {
 # If the app has `enable_identity_provider` set to true, create a new identity provider
 # client for the service. A new client is created for all environments, including
 # temporary environments.
-# When SSO is enabled, the callback URLs include /auth/sso/callback (merged in identity_provider_config)
+# When SSO is used, callback URLs include /auth/sso/callback (always set in identity_provider_config)
 module "identity_provider_client" {
   count  = module.app_config.enable_identity_provider ? 1 : 0
   source = "../../modules/identity-provider-client/resources"

--- a/infra/reporting-app/service/main.tf
+++ b/infra/reporting-app/service/main.tf
@@ -113,8 +113,8 @@ module "service" {
       name      = "COGNITO_CLIENT_SECRET"
       valueFrom = module.identity_provider_client[0].client_secret_arn
     }] : [],
-    # SSO uses the same Cognito client, so SSO_CLIENT_SECRET = COGNITO_CLIENT_SECRET
-    local.enable_sso ? [{
+    # SSO uses the same Cognito client; always inject so envs can enable SSO via SSO_ENABLED=true
+    module.app_config.enable_identity_provider ? [{
       name      = "SSO_CLIENT_SECRET"
       valueFrom = module.identity_provider_client[0].client_secret_arn
     }] : []


### PR DESCRIPTION
## Summary

Simplifies Staff SSO infrastructure so that **SSO configuration is always present** in every environment that has an identity provider. SSO is turned on or off per environment by setting the **`SSO_ENABLED`** environment variable (default `"false"`). No separate Terraform variable or conditional wiring; to enable SSO you override `SSO_ENABLED` (e.g. in `service_override_extra_environment_variables`) and redeploy.

## Why

- **Easier to enable SSO** — No need to run Terraform to add/remove SSO env vars or callback URLs. All SSO-related config is already in the task definition; enable by setting one env var and redeploying.
- **Less moving parts** — Removed the `enable_sso` Terraform variable and the two-layer conditional logic (app-config + service layer). Single source of truth: `SSO_ENABLED` in the task definition.
- **Manual toggle option** — You can enable SSO in an environment by creating a new task definition revision with `SSO_ENABLED=true` (e.g. via AWS console or CI) and redeploying, without changing Terraform.


Run Terraform apply for the **service** for that environment, then redeploy the app. The task definition will get a new revision with `SSO_ENABLED=true`; all other SSO vars and secrets are already present.

**Option B – Manual task definition**  
Create a new ECS task definition revision, set container env var `SSO_ENABLED` to `"true"`, update the ECS service to use that revision, and redeploy. No Terraform change. (Note: a future Terraform apply may overwrite the task definition unless the override is also added in Terraform.)

## Deployment notes

- **Terraform plan** will show:
  - Cognito user pool client updated (SSO callback URL added if not already present).
  - ECS task definition updated/replaced (new env vars and `SSO_CLIENT_SECRET`).
  - ECS service updated to use the new task definition revision.
  - Workflow orchestrator IAM policy may update if it depends on task definition ARN (expected cascade).
- **First apply** for an env that already had identity provider will add the SSO callback URL and all SSO env vars; default remains `SSO_ENABLED=false` unless overridden for that env.
- Application behavior is unchanged: the app already reads `SSO_ENABLED` and other SSO vars from the environment (`config/initializers/sso.rb`).


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->