### PR TITLE
Scope GoodJob queues per environment to prevent cross-environment job execution

### DIFF
--- a/infra/reporting-app/service/main.tf
+++ b/infra/reporting-app/service/main.tf
@@ -95,7 +95,8 @@ module "service" {
 
   extra_environment_variables = merge(
     {
-      BUCKET_NAME = local.bucket_name
+      BUCKET_NAME           = local.bucket_name
+      GOOD_JOB_QUEUE_PREFIX = local.service_name
     },
     local.identity_provider_environment_variables,
     local.sso_environment_variables,

--- a/reporting-app/config/initializers/good_job.rb
+++ b/reporting-app/config/initializers/good_job.rb
@@ -8,8 +8,17 @@ Rails.application.configure do
   # Pool size: Puma (5) + GoodJob (2) + buffer (1) = 8
   config.good_job.max_threads = ENV.fetch("GOOD_JOB_MAX_THREADS", 2).to_i
 
-  # Process all queues
-  config.good_job.queues = "*"
+  # Scope jobs to this environment to prevent cross-environment execution
+  # when multiple environments share the same database (e.g., dev + preview).
+  # GOOD_JOB_QUEUE_PREFIX is set per ECS task by terraform (local.service_name).
+  queue_prefix = ENV["GOOD_JOB_QUEUE_PREFIX"]
+  if queue_prefix.present?
+    config.active_job.queue_name_prefix = queue_prefix
+    config.active_job.queue_name_delimiter = ":"
+    config.good_job.queues = "#{queue_prefix}:*"
+  else
+    config.good_job.queues = "*"
+  end
 
   # Enable cron for scheduled jobs
   config.good_job.enable_cron = true


### PR DESCRIPTION
## Problem

During batch upload v2 testing, multi-chunk uploads consistently failed with
`Aws::S3::Errors::NoSuchKey`. Single-chunk uploads worked fine. The failures
triggered a GoodJob retry storm that OOM-killed the ECS container repeatedly.

## Root Cause

Dev and preview environments (e.g., p-300) share the same PostgreSQL database.
GoodJob runs in async mode with `queues: "*"`, so every container polls the
same `good_jobs` table and can pick up any job via SELECT FOR UPDATE SKIP
LOCKED.

When a preview container grabs a chunk job enqueued by dev:
1. The job's storage_key is just the S3 object key (no bucket)
2. The executing container resolves the bucket from its own BUCKET_NAME env var
3. Preview's bucket (p-300-oscer-reporting-app-dev) ≠ dev's bucket
   (oscer-reporting-app-dev)
4. S3 returns NoSuchKey → job fails → GoodJob retries immediately → OOM

Multi-chunk uploads fail more often because more jobs = more chances for the
wrong container to win the lock on at least one.

## Fix

Use ActiveJob's built-in queue_name_prefix to scope each environment's jobs.
A new GOOD_JOB_QUEUE_PREFIX env var (set to terraform's local.service_name,
which is already unique per workspace) prefixes all queue names:

- Dev: enqueues to "reporting-app-dev:default", processes "reporting-app-dev:*"
- Preview p-300: enqueues to "p-300-reporting-app-dev:default", processes
  "p-300-reporting-app-dev:*"
- Local dev (no env var): continues with queues: "*" — no behavior change

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->