### PR TITLE
Update batch upload show page for V2 data model

### DIFF
--- a/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
+++ b/reporting-app/app/controllers/staff/certification_batch_uploads_controller.rb
@@ -5,6 +5,7 @@ require "csv"
 module Staff
   class CertificationBatchUploadsController < AdminController
     self.authorization_resource = CertificationBatchUpload
+    MAX_DISPLAYED_ERRORS = 100
 
     before_action :set_batch_upload, only: [ :show, :process_batch, :results, :download_errors ]
 
@@ -29,6 +30,11 @@ module Staff
 
     # GET /staff/certification_batch_uploads/:id
     def show
+      @upload_errors = if @batch_upload.v2_upload?
+        @batch_upload.upload_errors.order(:row_number).limit(MAX_DISPLAYED_ERRORS)
+      else
+        []
+      end
     end
 
     # GET /staff/certification_batch_uploads/:id/results
@@ -54,6 +60,12 @@ module Staff
 
     # POST /staff/certification_batch_uploads/:id/process_batch
     def process_batch
+      if Features.batch_upload_v2_enabled?
+        redirect_to certification_batch_upload_path(@batch_upload),
+                    alert: "V2 uploads are processed automatically."
+        return
+      end
+
       respond_to do |format|
         if @batch_upload.processable? == false
           message = "This batch cannot be processed. Current status: #{@batch_upload.status}."

--- a/reporting-app/app/models/certification_batch_upload.rb
+++ b/reporting-app/app/models/certification_batch_upload.rb
@@ -122,6 +122,20 @@ class CertificationBatchUpload < ApplicationRecord
     end
   end
 
+  # Returns true for v2 uploads, which store errors in normalized records
+  # rather than the results JSONB column.
+  #
+  # Heuristic: V2 uploads always have results: {} (set by check_completion!),
+  # while v1 uploads populate results with { successes: [...], errors: [...] }
+  # via complete_processing!.
+  #
+  # Note: Pending/processing uploads also have results: {} (the DB default),
+  # so this returns true for them as well. Callers in the view gate on
+  # completed? before branching on v2_upload?, so this is safe.
+  def v2_upload?
+    results.blank?
+  end
+
   # Check if can be processed
   def processable?
     pending?

--- a/reporting-app/app/views/staff/certification_batch_uploads/_completion_alert.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_completion_alert.html.erb
@@ -1,0 +1,23 @@
+<%# Shared alert banner for completed batch uploads (both v1 and v2) %>
+<%# Locals: batch_upload, success_message %>
+<% scope = "staff.certification_batch_uploads.show" %>
+<% if batch_upload.num_rows_errored.zero? %>
+  <div class="usa-alert usa-alert--success" role="alert">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading"><%= t("success_heading", scope: scope) %></h4>
+      <p class="usa-alert__text"><%= success_message %></p>
+    </div>
+  </div>
+<% else %>
+  <div class="usa-alert usa-alert--warning" role="alert">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading"><%= t("partial_success_heading", scope: scope) %></h4>
+      <p class="usa-alert__text">
+        <%= t("partial_success_message", scope: scope,
+              num_rows_succeeded: batch_upload.num_rows_succeeded,
+              num_rows_errored: batch_upload.num_rows_errored,
+              total: batch_upload.num_rows) %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/reporting-app/app/views/staff/certification_batch_uploads/_upload_row.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_upload_row.html.erb
@@ -30,10 +30,14 @@
   </td>
   <td>
     <% if batch_upload.pending? %>
-      <%= button_to t(".process"), process_batch_certification_batch_upload_path(batch_upload),
-            method: :post,
-            class: "usa-button usa-button--outline",
-            data: { confirm: t(".confirm_process", filename: batch_upload.filename) } %>
+      <% if feature_enabled?(:batch_upload_v2) %>
+        <span class="text-base-dark"><%= t(".queued") %></span>
+      <% else %>
+        <%= button_to t(".process"), process_batch_certification_batch_upload_path(batch_upload),
+              method: :post,
+              class: "usa-button usa-button--outline",
+              data: { confirm: t(".confirm_process", filename: batch_upload.filename) } %>
+      <% end %>
     <% elsif batch_upload.processing? %>
       <span class="text-base-dark"><%= t(".processing") %>...</span>
     <% elsif batch_upload.completed? %>

--- a/reporting-app/app/views/staff/certification_batch_uploads/_v1_completed.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_v1_completed.html.erb
@@ -1,0 +1,58 @@
+<%# V1: errors/successes stored in results JSONB %>
+<%# Locals: batch_upload %>
+<% scope = "staff.certification_batch_uploads.show" %>
+<% successes = batch_upload.results.dig("successes") || [] %>
+<% errors = batch_upload.results.dig("errors") || [] %>
+<%= render "staff/certification_batch_uploads/completion_alert",
+           batch_upload: batch_upload,
+           success_message: t("success_message", scope: scope, count: batch_upload.num_rows_succeeded) %>
+<% if successes.any? %>
+  <div class="margin-top-4">
+    <h2><%= t("successful_uploads", scope: scope) %> (<%= successes.count %>)</h2>
+    <table class="usa-table usa-table--borderless width-full">
+      <thead>
+        <tr>
+          <th scope="col"><%= t("columns.row", scope: scope) %></th>
+          <th scope="col"><%= t("columns.case_number", scope: scope) %></th>
+          <th scope="col"><%= t("columns.member_id", scope: scope) %></th>
+          <th scope="col"><%= t("columns.status", scope: scope) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% successes.each do |success| %>
+          <tr>
+            <td><%= success["row"] || success[:row] %></td>
+            <td><%= success["case_number"] || success[:case_number] %></td>
+            <td><%= success["member_id"] || success[:member_id] %></td>
+            <td><span class="usa-tag usa-tag--success"><%= t("status.success", scope: scope) %></span></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+<% if errors.any? %>
+  <div class="margin-top-4">
+    <h2><%= t("failed_uploads", scope: scope) %> (<%= errors.count %>)</h2>
+    <table class="usa-table usa-table--borderless width-full">
+      <thead>
+        <tr>
+          <th scope="col"><%= t("columns.row", scope: scope) %></th>
+          <th scope="col"><%= t("columns.error", scope: scope) %></th>
+          <th scope="col"><%= t("columns.data", scope: scope) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% errors.each do |error| %>
+          <tr>
+            <td><%= error["row"] || error[:row] %></td>
+            <td class="text-error"><%= error["message"] || error[:message] %></td>
+            <td>
+              <pre class="font-mono-2xs"><code><%= JSON.pretty_generate(error["data"] || error[:data]) %></code></pre>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/reporting-app/app/views/staff/certification_batch_uploads/_v2_completed.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_v2_completed.html.erb
@@ -1,0 +1,45 @@
+<%# V2: errors stored in normalized CertificationBatchUploadError records %>
+<%# Locals: batch_upload, upload_errors %>
+<% scope = "staff.certification_batch_uploads.show" %>
+<% max_displayed = Staff::CertificationBatchUploadsController::MAX_DISPLAYED_ERRORS %>
+<%= render "staff/certification_batch_uploads/completion_alert",
+           batch_upload: batch_upload,
+           success_message: t("v2_success_summary", scope: scope, count: batch_upload.num_rows_succeeded) %>
+<% if upload_errors.any? %>
+  <div class="margin-top-4">
+    <h2><%= t("failed_uploads", scope: scope) %> (<%= batch_upload.num_rows_errored %>)</h2>
+    <% if batch_upload.num_rows_errored > max_displayed %>
+      <p class="text-base-dark">
+        <%= t("v2_errors_truncated", scope: scope, limit: max_displayed, total: batch_upload.num_rows_errored) %>
+      </p>
+    <% end %>
+    <table class="usa-table usa-table--borderless width-full" data-testid="v2-error-table">
+      <thead>
+        <tr>
+          <th scope="col"><%= t("columns.row", scope: scope) %></th>
+          <th scope="col"><%= t("columns.error_code", scope: scope) %></th>
+          <th scope="col"><%= t("columns.error_message", scope: scope) %></th>
+          <th scope="col"><%= t("columns.data", scope: scope) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% upload_errors.each do |error| %>
+          <tr>
+            <td><%= error.row_number %></td>
+            <td><%= error.error_code %></td>
+            <td class="text-error"><%= error.error_message %></td>
+            <td>
+              <pre class="font-mono-2xs"><code><%= error.row_data&.to_json %></code></pre>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <div class="margin-top-2">
+      <%= link_to t("download_errors_csv", scope: scope),
+            download_errors_certification_batch_upload_path(batch_upload),
+            class: "usa-button usa-button--outline",
+            data: { turbo: false } %>
+    </div>
+  </div>
+<% end %>

--- a/reporting-app/app/views/staff/certification_batch_uploads/show.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/show.html.erb
@@ -24,13 +24,21 @@
 <% if @batch_upload.pending? %>
   <div class="usa-alert usa-alert--info margin-top-4" role="alert">
     <div class="usa-alert__body">
-      <p class="usa-alert__text"><%= t(".pending_message") %></p>
+      <p class="usa-alert__text">
+        <% if feature_enabled?(:batch_upload_v2) %>
+          <%= t(".queued_message") %>
+        <% else %>
+          <%= t(".pending_message") %>
+        <% end %>
+      </p>
     </div>
   </div>
-  <%= button_to t(".process_button"), process_batch_certification_batch_upload_path(@batch_upload),
-        method: :post,
-        class: "usa-button margin-top-2",
-        data: { confirm: t(".confirm_process") } %>
+  <% unless feature_enabled?(:batch_upload_v2) %>
+    <%= button_to t(".process_button"), process_batch_certification_batch_upload_path(@batch_upload),
+          method: :post,
+          class: "usa-button margin-top-2",
+          data: { confirm: t(".confirm_process") } %>
+  <% end %>
 <% elsif @batch_upload.processing? %>
   <div class="usa-alert usa-alert--info margin-top-4" role="alert">
     <div class="usa-alert__body">
@@ -46,80 +54,13 @@
       <p class="usa-alert__text"><%= @batch_upload.results.dig("error") || t(".failed_message") %></p>
     </div>
   </div>
-<% elsif @batch_upload.completed? && @batch_upload.results.present? %>
-  <% successes = @batch_upload.results.dig("successes") || [] %>
-  <% errors = @batch_upload.results.dig("errors") || [] %>
-  <% if @batch_upload.num_rows_errored.zero? %>
-    <div class="usa-alert usa-alert--success" role="alert">
-      <div class="usa-alert__body">
-        <h4 class="usa-alert__heading"><%= t(".success_heading") %></h4>
-        <p class="usa-alert__text">
-          <%= t(".success_message", count: @batch_upload.num_rows_succeeded) %>
-        </p>
-      </div>
-    </div>
+<% elsif @batch_upload.completed? %>
+  <% if @batch_upload.v2_upload? %>
+    <%= render "staff/certification_batch_uploads/v2_completed",
+               batch_upload: @batch_upload, upload_errors: @upload_errors %>
   <% else %>
-    <div class="usa-alert usa-alert--warning" role="alert">
-      <div class="usa-alert__body">
-        <h4 class="usa-alert__heading"><%= t(".partial_success_heading") %></h4>
-        <p class="usa-alert__text">
-          <%= t(".partial_success_message",
-                num_rows_succeeded: @batch_upload.num_rows_succeeded,
-                num_rows_errored: @batch_upload.num_rows_errored,
-                total: @batch_upload.num_rows) %>
-        </p>
-      </div>
-    </div>
-  <% end %>
-  <% if successes.any? %>
-    <div class="margin-top-4">
-      <h2><%= t(".successful_uploads") %> (<%= successes.count %>)</h2>
-      <table class="usa-table usa-table--borderless width-full">
-        <thead>
-          <tr>
-            <th scope="col"><%= t(".columns.row") %></th>
-            <th scope="col"><%= t(".columns.case_number") %></th>
-            <th scope="col"><%= t(".columns.member_id") %></th>
-            <th scope="col"><%= t(".columns.status") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% successes.each do |success| %>
-            <tr>
-              <td><%= success["row"] || success[:row] %></td>
-              <td><%= success["case_number"] || success[:case_number] %></td>
-              <td><%= success["member_id"] || success[:member_id] %></td>
-              <td><span class="usa-tag usa-tag--success"><%= t(".status.success") %></span></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  <% end %>
-  <% if errors.any? %>
-    <div class="margin-top-4">
-      <h2><%= t(".failed_uploads") %> (<%= errors.count %>)</h2>
-      <table class="usa-table usa-table--borderless width-full">
-        <thead>
-          <tr>
-            <th scope="col"><%= t(".columns.row") %></th>
-            <th scope="col"><%= t(".columns.error") %></th>
-            <th scope="col"><%= t(".columns.data") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% errors.each do |error| %>
-            <tr>
-              <td><%= error["row"] || error[:row] %></td>
-              <td class="text-error"><%= error["message"] || error[:message] %></td>
-              <td>
-                <pre class="font-mono-2xs"><code><%= JSON.pretty_generate(error["data"] || error[:data]) %></code></pre>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+    <%= render "staff/certification_batch_uploads/v1_completed",
+               batch_upload: @batch_upload %>
   <% end %>
 <% end %>
 <div class="margin-top-4">

--- a/reporting-app/config/locales/views/staff/certification_batch_uploads.en.yml
+++ b/reporting-app/config/locales/views/staff/certification_batch_uploads.en.yml
@@ -22,6 +22,7 @@ en:
       upload_row:
         process: "Process"
         processing: "Processing"
+        queued: "Queued"
         view_results: "View Results"
         view_error: "View Error"
         confirm_process: "Are you sure you want to process %{filename}? This will create certifications for all valid rows."
@@ -84,12 +85,18 @@ en:
         partial_success_message: "%{num_rows_succeeded} succeeded, %{num_rows_errored} failed out of %{total} total rows"
         successful_uploads: "Successful Uploads"
         failed_uploads: "Failed Uploads"
+        queued_message: "This file has been queued for processing and will begin shortly."
+        v2_success_summary: "All %{count} records processed successfully."
+        v2_errors_truncated: "Showing first %{limit} of %{total} errors. Download CSV for full report."
+        download_errors_csv: "Download Errors CSV"
         columns:
           row: "Row"
           case_number: "Case Number"
           member_id: "Member ID"
           status: "Status"
           error: "Error"
+          error_code: "Error Code"
+          error_message: "Error Message"
           data: "Row Data"
         status:
           success: "Success"

--- a/reporting-app/spec/factories/certification_batch_uploads_factory.rb
+++ b/reporting-app/spec/factories/certification_batch_uploads_factory.rb
@@ -33,6 +33,11 @@ FactoryBot.define do
       results { { successes: [], errors: [] } }
     end
 
+    trait :completed_v2 do
+      completed
+      results { {} }
+    end
+
     trait :failed do
       status { :failed }
       processed_at { Time.current }

--- a/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
+++ b/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
@@ -227,6 +227,137 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
       expect(response).to be_successful
       expect(response.body).to include(batch_upload.filename)
     end
+
+    context "with v2 completed upload and no errors" do
+      let(:batch_upload) do
+        create(:certification_batch_upload, :completed_v2,
+               uploader: user, num_rows_succeeded: 10, num_rows_errored: 0, num_rows: 10)
+      end
+
+      it "shows v2 success summary" do
+        get certification_batch_upload_path(batch_upload)
+
+        expect(response).to be_successful
+        expect(response.body).to include("All 10 records processed successfully")
+        expect(response.body).not_to include("v2-error-table")
+      end
+    end
+
+    context "with v2 completed upload and errors" do
+      let(:batch_upload) do
+        create(:certification_batch_upload, :completed_v2,
+               uploader: user, num_rows_succeeded: 8, num_rows_errored: 2, num_rows: 10)
+      end
+
+      it "shows error table from upload_errors association" do
+        create(
+          :certification_batch_upload_error,
+          certification_batch_upload: batch_upload,
+          row_number: 2,
+          error_code: "VAL_001",
+          error_message: "Missing required field",
+          row_data: { "member_id" => "M001" }
+        )
+        create(
+          :certification_batch_upload_error,
+          certification_batch_upload: batch_upload,
+          row_number: 5,
+          error_code: "VAL_002",
+          error_message: "Invalid date format",
+          row_data: { "member_id" => "M002" }
+        )
+
+        get certification_batch_upload_path(batch_upload)
+
+        expect(response).to be_successful
+        expect(response.body).to include("v2-error-table")
+        expect(response.body).to include("VAL_001")
+        expect(response.body).to include("Missing required field")
+        expect(response.body).to include("VAL_002")
+        expect(response.body).to include("Invalid date format")
+        expect(response.body).to include("Download Errors CSV")
+      end
+    end
+
+    context "with v2 completed upload and more than 100 errors" do
+      let(:batch_upload) do
+        create(:certification_batch_upload, :completed_v2,
+               uploader: user, num_rows_succeeded: 0, num_rows_errored: 150, num_rows: 150)
+      end
+
+      it "shows truncation message" do
+        create_list(:certification_batch_upload_error, 101, certification_batch_upload: batch_upload)
+
+        get certification_batch_upload_path(batch_upload)
+
+        expect(response).to be_successful
+        expect(response.body).to include("Showing first 100 of 150 errors")
+      end
+    end
+
+    context "with v1 completed upload (no regression)" do
+      let(:batch_upload) do
+        create(:certification_batch_upload, :completed, uploader: user,
+               results: {
+                 "successes" => [
+                   { "row" => 1, "case_number" => "C-001", "member_id" => "M001" }
+                 ],
+                 "errors" => [
+                   { "row" => 2, "message" => "Invalid data", "data" => { "member_id" => "M002" } }
+                 ]
+               })
+      end
+
+      it "renders v1 success and error tables from results JSONB" do
+        with_batch_upload_v2_disabled do
+          get certification_batch_upload_path(batch_upload)
+
+          expect(response).to be_successful
+          expect(response.body).to include("C-001")
+          expect(response.body).to include("M001")
+          expect(response.body).to include("Invalid data")
+          expect(response.body).not_to include("v2-error-table")
+        end
+      end
+    end
+
+    context "with failed upload (no regression)" do
+      let(:batch_upload) do
+        create(:certification_batch_upload, :failed, uploader: user,
+               results: { "error" => "CSV parsing failed: invalid encoding" })
+      end
+
+      it "renders error message from results" do
+        get certification_batch_upload_path(batch_upload)
+
+        expect(response).to be_successful
+        expect(response.body).to include("CSV parsing failed: invalid encoding")
+      end
+    end
+
+    context "with v2 pending upload" do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :pending) }
+
+      it "shows queued message and hides Process button when v2 enabled" do
+        with_batch_upload_v2_enabled do
+          get certification_batch_upload_path(batch_upload)
+
+          expect(response).to be_successful
+          expect(response.body).to include("queued for processing")
+          expect(response.body).not_to include("Process This File")
+        end
+      end
+
+      it "shows Process button when v2 disabled" do
+        with_batch_upload_v2_disabled do
+          get certification_batch_upload_path(batch_upload)
+
+          expect(response).to be_successful
+          expect(response.body).to include("Process This File")
+          expect(response.body).not_to include("queued for processing")
+        end
+      end
+    end
   end
 
   describe "POST /staff/staff/certification_batch_uploads/:id/process_batch" do
@@ -257,6 +388,19 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
 
         expect(response).to redirect_to(certification_batch_upload_path(batch_upload))
         expect(flash[:alert]).to include("cannot be processed")
+      end
+    end
+
+    context "with batch_upload_v2 enabled" do
+      let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :pending) }
+
+      it "rejects process_batch and redirects with alert" do
+        with_batch_upload_v2_enabled do
+          post process_batch_certification_batch_upload_path(batch_upload)
+
+          expect(response).to redirect_to(certification_batch_upload_path(batch_upload))
+          expect(flash[:alert]).to include("processed automatically")
+        end
       end
     end
   end
@@ -466,6 +610,34 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
             expect(response.body).to include("No errors")
             expect(response.body).not_to include("Download Errors")
           end
+        end
+      end
+    end
+
+    context "with batch_upload_v2 enabled pending upload" do
+      it "shows Queued text instead of Process button" do
+        with_batch_upload_v2_enabled do
+          create(:certification_batch_upload, uploader: user, status: :pending)
+
+          get certification_batch_uploads_path
+
+          expect(response).to be_successful
+          expect(response.body).to include("Queued")
+          expect(response.body).not_to include('value="Process"')
+        end
+      end
+    end
+
+    context "with batch_upload_v2 disabled pending upload" do
+      it "shows Process button" do
+        with_batch_upload_v2_disabled do
+          create(:certification_batch_upload, uploader: user, status: :pending)
+
+          get certification_batch_uploads_path
+
+          expect(response).to be_successful
+          expect(response.body).to include("Process")
+          expect(response.body).not_to include(">Queued<")
         end
       end
     end


### PR DESCRIPTION
Update batch upload show page for V2 data model

V2 uploads store errors in normalized CertificationBatchUploadError
records with results: {}, so the show page (which read from the results
JSONB column) displayed empty detail tables for v2 completed uploads.

Changes:
- Add v2_upload? predicate on CertificationBatchUpload (data-driven via
  results.blank?, not flag-dependent, so v2 uploads render correctly
  regardless of current flag state)
- Branch show page completed section: v2 renders error table from
  upload_errors association with row_number, error_code, error_message,
  row_data columns; v1 path unchanged reading from results JSONB
- Extract shared _completion_alert, _v2_completed, _v1_completed
  partials (show.html.erb reduced from 200+ to 70 lines)
- Hide "Process" button on show page and index row when v2 enabled
  (v2 auto-processes on upload; show "Queued" text instead)
- Add server-side gate on process_batch to reject v2 uploads
- Cap error display at 100 rows via shared MAX_DISPLAYED_ERRORS constant
  with truncation message and "Download Errors CSV" link

Resolves #296

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->