### PR TITLE
Enable batch upload V2 and bump memory for sandbox

### DIFF
--- a/infra/reporting-app/app-config/sandbox.tf
+++ b/infra/reporting-app/app-config/sandbox.tf
@@ -19,8 +19,12 @@ module "sandbox_config" {
   # Defaults to `false`. Uncomment the next line to enable.
   # enable_command_execution = true
 
+  # Increase memory from default 512 MiB to give headroom for Puma + GoodJob async workers
+  service_memory = 1024
+
   service_override_extra_environment_variables = {
-    ENABLE_LOOKBOOK = "true"
-    SSO_ENABLED     = "true"
+    ENABLE_LOOKBOOK         = "true"
+    SSO_ENABLED             = "true"
+    FEATURE_BATCH_UPLOAD_V2 = "true"
   }
 }


### PR DESCRIPTION
Enable batch upload V2 and bump memory for sandbox environment

Prepares the sandbox environment for V2 batch upload processing:

- Set FEATURE_BATCH_UPLOAD_V2=true to enable cloud storage streaming
  and parallel chunk processing behind the existing feature flag.
- Bump service_memory from 512 MiB (default) to 1024 MiB, matching
  dev, to give headroom for Puma + GoodJob async workers running
  in-process. Without this, V2 batch jobs risk OOM under load
  (same issue we hit on dev, fixed in PR #300).

Intended to be merged once V2 has been validated on dev.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->