### PR TITLE
Add DocAI environment variables to SSM Parameter Store declarations

### DIFF
--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -57,5 +57,17 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}-${var.environment}/service/va-private-key"
     }
+    DOC_AI_API_HOST = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}-${var.environment}/service/doc-ai-api-host"
+    }
+    DOC_AI_TIMEOUT_SECONDS = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}-${var.environment}/service/doc-ai-timeout-seconds"
+    }
+    DOC_AI_LOW_CONFIDENCE_THRESHOLD = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}-${var.environment}/service/doc-ai-low-confidence-threshold"
+    }
   }
 }


### PR DESCRIPTION
Closes #316

## Summary

Declares three DocAI environment variables as `manage_method = "manual"` SSM Parameter Store secrets in Terraform. The actual values must be manually stored in SSM for dev and sandbox — see #316 for the paths and acceptance criteria.

## Changes

- `infra/reporting-app/app-config/env-config/environment_variables.tf` — adds SSM secret declarations for:
  - `DOC_AI_API_HOST`
  - `DOC_AI_TIMEOUT_SECONDS`
  - `DOC_AI_LOW_CONFIDENCE_THRESHOLD`

## Testing

No application code changes. Terraform plan should show three new SSM parameter data sources for each environment.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->