### PR TITLE
Clean up batch upload show view

### DIFF
--- a/reporting-app/app/helpers/certification_batch_uploads_helper.rb
+++ b/reporting-app/app/helpers/certification_batch_uploads_helper.rb
@@ -24,4 +24,34 @@ module CertificationBatchUploadsHelper
       UPLOADER_LABEL_SYSTEM
     end
   end
+
+  # Returns alert options (type, heading, message) for the batch upload's current status,
+  # or nil if the status has no alert (e.g. completed, which renders its own partial).
+  def status_alert_options(batch_upload)
+    scope = "staff.certification_batch_uploads.show"
+
+    case batch_upload.status
+    when "pending"
+      {
+        type: "info",
+        message: t("queued_message", scope: scope)
+      }
+    when "processing"
+      {
+        type: "info",
+        message: t(
+          "processing_message",
+          scope: scope,
+          processed: batch_upload.num_rows_processed,
+          total: batch_upload.num_rows
+        )
+      }
+    when "failed"
+      {
+        type: "error",
+        heading: t("failed_heading", scope: scope),
+        message: batch_upload.results&.dig("error") || t("failed_message", scope: scope)
+      }
+    end
+  end
 end

--- a/reporting-app/app/views/staff/certification_batch_uploads/_completion_alert.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_completion_alert.html.erb
@@ -2,22 +2,14 @@
 <%# Locals: batch_upload, success_message %>
 <% scope = "staff.certification_batch_uploads.show" %>
 <% if batch_upload.num_rows_errored.zero? %>
-  <div class="usa-alert usa-alert--success" role="alert">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading"><%= t("success_heading", scope: scope) %></h4>
-      <p class="usa-alert__text"><%= success_message %></p>
-    </div>
-  </div>
+  <%= render "staff/certification_batch_uploads/status_alert",
+             type: "success", heading: t("success_heading", scope: scope),
+             message: success_message %>
 <% else %>
-  <div class="usa-alert usa-alert--warning" role="alert">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading"><%= t("partial_success_heading", scope: scope) %></h4>
-      <p class="usa-alert__text">
-        <%= t("partial_success_message", scope: scope,
-              num_rows_succeeded: batch_upload.num_rows_succeeded,
-              num_rows_errored: batch_upload.num_rows_errored,
-              total: batch_upload.num_rows) %>
-      </p>
-    </div>
-  </div>
+  <%= render "staff/certification_batch_uploads/status_alert",
+             type: "warning", heading: t("partial_success_heading", scope: scope),
+             message: t("partial_success_message", scope: scope,
+                        num_rows_succeeded: batch_upload.num_rows_succeeded,
+                        num_rows_errored: batch_upload.num_rows_errored,
+                        total: batch_upload.num_rows) %>
 <% end %>

--- a/reporting-app/app/views/staff/certification_batch_uploads/_status_alert.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/_status_alert.html.erb
@@ -1,0 +1,10 @@
+<%# Shared USWDS alert banner for batch upload status messages %>
+<%# Locals: type (info/error/success/warning), heading (optional), message %>
+<div class="usa-alert usa-alert--<%= type %>" <%= type == "error" ? 'role="alert"' : 'role="status"' %>>
+  <div class="usa-alert__body">
+    <% if local_assigns[:heading] %>
+      <h2 class="usa-alert__heading"><%= heading %></h2>
+    <% end %>
+    <p class="usa-alert__text"><%= message %></p>
+  </div>
+</div>

--- a/reporting-app/app/views/staff/certification_batch_uploads/show.html.erb
+++ b/reporting-app/app/views/staff/certification_batch_uploads/show.html.erb
@@ -2,52 +2,34 @@
 <%= render partial: 'application/flash' %>
 <h1><%= @batch_upload.filename %></h1>
 <dl class="grid-row margin-bottom-2">
-  <dt class="grid-col-3 text-bold"><%= t(".uploader") %>:</dt>
+  <dt class="grid-col-3"><strong><%= t(".uploader") %>:</strong></dt>
   <dd class="grid-col-9"><%= uploader_display_name(@batch_upload) %></dd>
-  <dt class="grid-col-3 text-bold"><%= t(".uploaded_at") %>:</dt>
+  <dt class="grid-col-3"><strong><%= t(".uploaded_at") %>:</strong></dt>
   <dd class="grid-col-9"><%= @batch_upload.created_at.strftime("%B %d, %Y at %I:%M %p") %></dd>
-  <dt class="grid-col-3 text-bold"><%= t(".upload_status") %>:</dt>
+  <dt class="grid-col-3"><strong><%= t(".upload_status") %>:</strong></dt>
   <dd class="grid-col-9">
     <span class="usa-tag <%= status_tag_class(@batch_upload.status) %>">
       <%= t("certification_batch_uploads.statuses.#{@batch_upload.status}") %>
     </span>
   </dd>
   <% if @batch_upload.num_rows > 0 %>
-    <dt class="grid-col-3 text-bold"><%= t(".num_rows") %>:</dt>
+    <dt class="grid-col-3"><strong><%= t(".num_rows") %>:</strong></dt>
     <dd class="grid-col-9"><%= @batch_upload.num_rows %></dd>
   <% end %>
   <% if @batch_upload.processed_at %>
-    <dt class="grid-col-3 text-bold"><%= t(".processed_at") %>:</dt>
+    <dt class="grid-col-3"><strong><%= t(".processed_at") %>:</strong></dt>
     <dd class="grid-col-9"><%= @batch_upload.processed_at.strftime("%B %d, %Y at %I:%M %p") %></dd>
   <% end %>
 </dl>
-<% if @batch_upload.pending? %>
-  <div class="usa-alert usa-alert--info margin-top-4" role="alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <%= t(".queued_message") %>
-      </p>
-    </div>
-  </div>
-<% elsif @batch_upload.processing? %>
-  <div class="usa-alert usa-alert--info margin-top-4" role="alert">
-    <div class="usa-alert__body">
-      <p class="usa-alert__text">
-        <%= t(".processing_message", processed: @batch_upload.num_rows_processed, total: @batch_upload.num_rows) %>
-      </p>
-    </div>
-  </div>
-<% elsif @batch_upload.failed? %>
-  <div class="usa-alert usa-alert--error margin-top-4" role="alert">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading"><%= t(".failed_heading") %></h4>
-      <p class="usa-alert__text"><%= @batch_upload.results.dig("error") || t(".failed_message") %></p>
-    </div>
-  </div>
-<% elsif @batch_upload.completed? %>
-  <%= render "staff/certification_batch_uploads/completed",
-             batch_upload: @batch_upload, upload_errors: @upload_errors %>
-<% end %>
+<% alert_options = status_alert_options(@batch_upload) %>
+<div class="margin-top-4">
+  <% if alert_options %>
+    <%= render "staff/certification_batch_uploads/status_alert", **alert_options %>
+  <% elsif @batch_upload.completed? %>
+    <%= render "staff/certification_batch_uploads/completed",
+               batch_upload: @batch_upload, upload_errors: @upload_errors %>
+  <% end %>
+</div>
 <div class="margin-top-4">
   <%= link_to t(".back_to_queue"), certification_batch_uploads_path, class: "usa-button usa-button--outline" %>
   <%= link_to t(".back_to_dashboard"), staff_path, class: "usa-button usa-button--unstyled" %>

--- a/reporting-app/spec/factories/certification_batch_uploads_factory.rb
+++ b/reporting-app/spec/factories/certification_batch_uploads_factory.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
     trait :failed do
       status { :failed }
       processed_at { Time.current }
-      results { { error: "Processing failed" } }
+      results { { "error" => "Processing failed" } }
     end
 
     trait :api_sourced do

--- a/reporting-app/spec/helpers/certification_batch_uploads_helper_spec.rb
+++ b/reporting-app/spec/helpers/certification_batch_uploads_helper_spec.rb
@@ -26,4 +26,47 @@ RSpec.describe CertificationBatchUploadsHelper, type: :helper do
       expect(helper.uploader_display_name(batch_upload)).to eq("Unknown")
     end
   end
+
+  describe "#status_alert_options" do
+    it "returns info alert for pending uploads" do
+      batch_upload = build(:certification_batch_upload, status: :pending)
+      result = helper.status_alert_options(batch_upload)
+
+      expect(result[:type]).to eq("info")
+      expect(result[:message]).to be_present
+      expect(result).not_to have_key(:heading)
+    end
+
+    it "returns info alert with progress for processing uploads" do
+      batch_upload = build(:certification_batch_upload, :processing)
+      result = helper.status_alert_options(batch_upload)
+
+      expect(result[:type]).to eq("info")
+      expect(result[:message]).to include("5", "10")
+      expect(result).not_to have_key(:heading)
+    end
+
+    it "returns error alert with heading for failed uploads" do
+      batch_upload = build(:certification_batch_upload, :failed, results: { "error" => "Something broke" })
+      result = helper.status_alert_options(batch_upload)
+
+      expect(result[:type]).to eq("error")
+      expect(result[:heading]).to be_present
+      expect(result[:message]).to eq("Something broke")
+    end
+
+    it "returns fallback message when failed upload has no error detail" do
+      batch_upload = build(:certification_batch_upload, :failed, results: {})
+      result = helper.status_alert_options(batch_upload)
+
+      expect(result[:type]).to eq("error")
+      expect(result[:message]).to be_present
+    end
+
+    it "returns nil for completed uploads" do
+      batch_upload = build(:certification_batch_upload, :completed)
+
+      expect(helper.status_alert_options(batch_upload)).to be_nil
+    end
+  end
 end

--- a/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
+++ b/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
@@ -213,6 +213,17 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
       end
     end
 
+    context "with processing upload" do
+      let(:batch_upload) { create(:certification_batch_upload, :processing, uploader: user) }
+
+      it "shows processing progress message" do
+        get certification_batch_upload_path(batch_upload)
+
+        expect(response).to be_successful
+        expect(response.body).to include("5", "10")
+      end
+    end
+
     context "with pending upload" do
       let(:batch_upload) { create(:certification_batch_upload, uploader: user, status: :pending) }
 


### PR DESCRIPTION
**Stacked on:** PR #318 (`giverm/OSCER-310-remove-v1-batch-upload-code`)

Extract inline status-branching logic from show.html.erb into a
reusable _status_alert partial and a status_alert_options helper method.
This eliminates repeated usa-alert markup and moves presentation logic
out of the template.

## Changes
- Add _status_alert.html.erb partial with documented locals (type,
  heading, message) and proper ARIA roles: role="alert" for errors
  (assertive), role="status" for info/success/warning (polite)
- Add status_alert_options helper that maps batch upload status to
  alert options (or nil for completed), with full test coverage
- Refactor _completion_alert.html.erb to delegate to _status_alert
  instead of duplicating alert markup
- Replace text-bold utility class on <dt> elements with semantic
  <strong> tags, matching existing precedent in activity report views
- Fix alert heading level from <h4> to <h2> for correct hierarchy
  after the page's <h1> (previously skipped h2/h3, a WCAG violation)
- Move spacing (margin-top-4) from alert data to parent layout wrapper,
  separating layout concerns from component concerns
- Add safe navigation for results&.dig("error") to guard against nil
- Fix :failed factory trait to use string-keyed hash matching
  production data shape
- Add request spec for processing status rendering

## Impact
Staff-facing batch upload show page only. No behavior changes —
purely structural refactoring with a11y improvements.

## Notes
After #318 merges, the base can be changed to `main`.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->