### PR TITLE
Add Reusable Redirect URI and Member OIDC Config

### DIFF
--- a/reporting-app/config/initializers/sso.rb
+++ b/reporting-app/config/initializers/sso.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
-# Build redirect URI with correct scheme and port
-# Defaults to HTTPS (production assumption) unless explicitly disabled
-# Set DISABLE_HTTPS=true for local development without SSL
-def build_sso_redirect_uri
+# Build OIDC redirect URI with correct scheme, host, port, and path.
+# Used by both staff SSO and member OIDC.
+# Defaults to HTTPS (production assumption) unless DISABLE_HTTPS=true (e.g. local dev).
+#
+# @param path [String] Callback path (e.g. "/auth/sso/callback" or "/auth/member_oidc/callback")
+# @return [String] Full redirect URI
+def build_oidc_redirect_uri(path)
   host = ENV.fetch("APP_HOST", "localhost")
   port = ENV.fetch("APP_PORT", "443")
   https_disabled = ENV.fetch("DISABLE_HTTPS", "false") == "true"
@@ -11,8 +14,9 @@ def build_sso_redirect_uri
   scheme = https_disabled ? "http" : "https"
   standard_port = https_disabled ? "80" : "443"
   port_suffix = (port == standard_port) ? "" : ":#{port}"
+  path = path.start_with?("/") ? path : "/#{path}"
 
-  "#{scheme}://#{host}#{port_suffix}/auth/sso/callback"
+  "#{scheme}://#{host}#{port_suffix}#{path}"
 end
 
 # SSO Configuration for Staff Single Sign-On via OIDC
@@ -26,7 +30,6 @@ end
 #   SSO_SCOPES         - Space-separated scopes (default: "openid profile email")
 #   SSO_INTERNAL_HOST  - Override hostname for API calls (Docker networking)
 
-# Store config for use in views/helpers
 Rails.application.config.sso = {
   enabled: ENV.fetch("SSO_ENABLED", "false") == "true",
   claims: {
@@ -38,14 +41,38 @@ Rails.application.config.sso = {
   }
 }.freeze
 
-# Configure OmniAuth OpenID Connect strategy
-if Rails.application.config.sso[:enabled] || Rails.env.test?
+# Member OIDC Configuration (citizen IdP sign-in)
+#
+# Required environment variables (when MEMBER_OIDC_ENABLED=true):
+#   MEMBER_OIDC_ISSUER_URL     - Citizen IdP issuer URL
+#   MEMBER_OIDC_CLIENT_ID      - OIDC client ID
+#   MEMBER_OIDC_CLIENT_SECRET  - OIDC client secret
+#
+# Optional:
+#   MEMBER_OIDC_SCOPES         - Space-separated scopes (default: "openid profile email")
+#   MEMBER_OIDC_INTERNAL_HOST  - Override hostname for server-to-IdP calls (Docker)
+#   MEMBER_OIDC_CLAIM_EMAIL    - Claim key for email (default: "email")
+#   MEMBER_OIDC_CLAIM_NAME     - Claim key for name (default: "name")
+#   MEMBER_OIDC_CLAIM_UID     - Claim key for unique id (default: "sub")
+
+Rails.application.config.member_oidc = {
+  enabled: ENV.fetch("MEMBER_OIDC_ENABLED", "false") == "true",
+  claims: {
+    email: ENV.fetch("MEMBER_OIDC_CLAIM_EMAIL", "email"),
+    name: ENV.fetch("MEMBER_OIDC_CLAIM_NAME", "name"),
+    unique_id: ENV.fetch("MEMBER_OIDC_CLAIM_UID", "sub")
+  }
+}.freeze
+
+# Register OmniAuth OIDC provider(s)
+staff_sso_enabled = Rails.application.config.sso[:enabled] || Rails.env.test?
+member_oidc_enabled = Rails.application.config.member_oidc[:enabled]
+
+if staff_sso_enabled
   issuer_url = ENV.fetch("SSO_ISSUER_URL", "https://test-idp.example.com")
   issuer_uri = URI.parse(issuer_url)
   use_http = issuer_url.start_with?("http://")
 
-  # For Docker: SSO_INTERNAL_HOST allows Rails to reach IdP via container name
-  # while browser uses localhost
   internal_host = ENV.fetch("SSO_INTERNAL_HOST") { issuer_uri.host }
   internal_base = "#{issuer_uri.scheme}://#{internal_host}:#{issuer_uri.port}#{issuer_uri.path}"
 
@@ -55,15 +82,14 @@ if Rails.application.config.sso[:enabled] || Rails.env.test?
       issuer: issuer_url,
       scope: ENV.fetch("SSO_SCOPES", "openid profile email").split,
       response_type: :code,
-      discovery: !use_http, # Use discovery for HTTPS, manual for HTTP
+      discovery: !use_http,
       client_options: {
         identifier: ENV.fetch("SSO_CLIENT_ID", "test-client"),
         secret: ENV.fetch("SSO_CLIENT_SECRET", "test-secret"),
-        redirect_uri: build_sso_redirect_uri
+        redirect_uri: build_oidc_redirect_uri("/auth/sso/callback")
       }
     }
 
-    # For HTTP (local Keycloak): manually specify endpoints since discovery won't work
     if use_http
       provider_options[:client_options].merge!(
         authorization_endpoint: "#{internal_base}/protocol/openid-connect/auth",
@@ -77,26 +103,59 @@ if Rails.application.config.sso[:enabled] || Rails.env.test?
   end
 end
 
-# OmniAuth configuration
+if member_oidc_enabled
+  member_issuer_url = ENV.fetch("MEMBER_OIDC_ISSUER_URL")
+  member_issuer_uri = URI.parse(member_issuer_url)
+  member_use_http = member_issuer_url.start_with?("http://")
+
+  member_internal_host = ENV.fetch("MEMBER_OIDC_INTERNAL_HOST") { member_issuer_uri.host }
+  member_internal_base = "#{member_issuer_uri.scheme}://#{member_internal_host}:#{member_issuer_uri.port}#{member_issuer_uri.path}"
+
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    member_provider_options = {
+      name: :member_oidc,
+      issuer: member_issuer_url,
+      scope: ENV.fetch("MEMBER_OIDC_SCOPES", "openid profile email").split,
+      response_type: :code,
+      discovery: !member_use_http,
+      client_options: {
+        identifier: ENV.fetch("MEMBER_OIDC_CLIENT_ID"),
+        secret: ENV.fetch("MEMBER_OIDC_CLIENT_SECRET"),
+        redirect_uri: build_oidc_redirect_uri("/auth/member_oidc/callback")
+      }
+    }
+
+    if member_use_http
+      member_provider_options[:client_options].merge!(
+        authorization_endpoint: "#{member_internal_base}/protocol/openid-connect/auth",
+        token_endpoint: "#{member_internal_base}/protocol/openid-connect/token",
+        userinfo_endpoint: "#{member_internal_base}/protocol/openid-connect/userinfo",
+        jwks_uri: "#{member_internal_base}/protocol/openid-connect/certs"
+      )
+    end
+
+    provider :openid_connect, **member_provider_options
+  end
+end
+
+# OmniAuth configuration (shared)
 OmniAuth.config.logger = Rails.logger
 # Only allow POST for security (CVE-2015-9284)
-# The /sso/login page auto-submits a form via POST with Rails CSRF token
 OmniAuth.config.allowed_request_methods = [ :post ]
-# The omniauth-rails_csrf_protection gem validates Rails CSRF token via before_request_phase
-# Disable OmniAuth's built-in Rack-based CSRF check (which uses different token format)
 OmniAuth.config.request_validation_phase = nil
 
 # WORKAROUND: Skip issuer verification for local HTTP development
-# The openid_connect gem doesn't properly pass issuer when discovery is disabled
-# This only applies to HTTP URLs (local dev), HTTPS production works normally
-if Rails.env.development? && ENV.fetch("SSO_ISSUER_URL", "").start_with?("http://")
+# Applies when SSO_ISSUER_URL or MEMBER_OIDC_ISSUER_URL is http:// (e.g. local Keycloak)
+if Rails.env.development? &&
+   (ENV.fetch("SSO_ISSUER_URL", "").start_with?("http://") ||
+    ENV.fetch("MEMBER_OIDC_ISSUER_URL", "").start_with?("http://"))
   OpenIDConnect::ResponseObject::IdToken.class_eval do
     alias_method :original_verify!, :verify!
 
     def verify!(expected = {})
       original_verify!(expected)
     rescue OpenIDConnect::ResponseObject::IdToken::InvalidIssuer => e
-      Rails.logger.warn "[SSO] Skipping issuer verification in dev: #{e.message}"
+      Rails.logger.warn "[OIDC] Skipping issuer verification in dev: #{e.message}"
     end
   end
 end

--- a/reporting-app/spec/requests/auth/sso_redirect_and_member_oidc_spec.rb
+++ b/reporting-app/spec/requests/auth/sso_redirect_and_member_oidc_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "OIDC redirect URI and member_oidc config (Story 1)", type: :request do
+  def with_env(overrides, &block)
+    old = {}
+    overrides.each do |key, value|
+      old[key] = ENV[key]
+      ENV[key] = value
+    end
+    block.call
+  ensure
+    old.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+
+  describe "build_oidc_redirect_uri" do
+    it "returns HTTPS URI with default host and port when DISABLE_HTTPS is not set" do
+      with_env("APP_HOST" => "app.example.com", "APP_PORT" => "443", "DISABLE_HTTPS" => "false") do
+        uri = build_oidc_redirect_uri("/auth/sso/callback")
+        expect(uri).to eq("https://app.example.com/auth/sso/callback")
+      end
+    end
+
+    it "includes port suffix when APP_PORT is non-standard for HTTPS" do
+      with_env("APP_HOST" => "localhost", "APP_PORT" => "3000", "DISABLE_HTTPS" => "false") do
+        uri = build_oidc_redirect_uri("/auth/sso/callback")
+        expect(uri).to eq("https://localhost:3000/auth/sso/callback")
+      end
+    end
+
+    it "uses HTTP and port 80 when DISABLE_HTTPS is true" do
+      with_env("APP_HOST" => "localhost", "APP_PORT" => "80", "DISABLE_HTTPS" => "true") do
+        uri = build_oidc_redirect_uri("/auth/sso/callback")
+        expect(uri).to eq("http://localhost/auth/sso/callback")
+      end
+    end
+
+    it "builds member_oidc callback path when given that path" do
+      with_env("APP_HOST" => "app.example.com", "APP_PORT" => "443", "DISABLE_HTTPS" => "false") do
+        uri = build_oidc_redirect_uri("/auth/member_oidc/callback")
+        expect(uri).to eq("https://app.example.com/auth/member_oidc/callback")
+      end
+    end
+
+    it "normalizes path to start with slash" do
+      with_env("APP_HOST" => "localhost", "APP_PORT" => "443", "DISABLE_HTTPS" => "false") do
+        uri = build_oidc_redirect_uri("auth/sso/callback")
+        expect(uri).to eq("https://localhost/auth/sso/callback")
+      end
+    end
+  end
+
+  describe "Rails.application.config.member_oidc" do
+    it "has enabled and claims keys" do
+      config = Rails.application.config.member_oidc
+      expect(config).to include(:enabled, :claims)
+    end
+
+    it "has enabled false by default (MEMBER_OIDC_ENABLED not set)" do
+      config = Rails.application.config.member_oidc
+      expect(config[:enabled]).to be(false)
+    end
+
+    it "has claims with email, name, and unique_id keys" do
+      config = Rails.application.config.member_oidc
+      expect(config[:claims]).to include(:email, :name, :unique_id)
+    end
+
+    it "uses default claim key names when env vars are not set" do
+      config = Rails.application.config.member_oidc
+      expect(config[:claims][:email]).to eq("email")
+      expect(config[:claims][:name]).to eq("name")
+      expect(config[:claims][:unique_id]).to eq("sub")
+    end
+  end
+end


### PR DESCRIPTION

## Overview

Implements: reusable OIDC redirect URI and member OIDC configuration so staff and member OIDC share the same pattern and no code is duplicated.

## Changes

### 1. Redirect URI refactor (`config/initializers/sso.rb`)

- **Replaced** `build_sso_redirect_uri` with **`build_oidc_redirect_uri(path)`**.
- `path` is the callback path (e.g. `"/auth/sso/callback"` or `"/auth/member_oidc/callback"`).
- Staff SSO now calls `build_oidc_redirect_uri("/auth/sso/callback")`.
- Path is normalized to start with `/` when needed.

### 2. Member OIDC config (`config/initializers/sso.rb`)

- **Added** `Rails.application.config.member_oidc` with:
  - `enabled`: from `MEMBER_OIDC_ENABLED` (default `false`).
  - `claims`: `email`, `name`, `unique_id` from env (`MEMBER_OIDC_CLAIM_EMAIL`, `MEMBER_OIDC_CLAIM_NAME`, `MEMBER_OIDC_CLAIM_UID`; defaults `email`, `name`, `sub`).

### 3. Second OmniAuth provider (`config/initializers/sso.rb`)

- When **`MEMBER_OIDC_ENABLED=true`**, registers a second OmniAuth provider **`:member_oidc`** with:
  - `MEMBER_OIDC_ISSUER_URL`, `MEMBER_OIDC_CLIENT_ID`, `MEMBER_OIDC_CLIENT_SECRET`.
  - `redirect_uri: build_oidc_redirect_uri("/auth/member_oidc/callback")`.
  - Same discovery vs manual-endpoint behavior as staff: for `http://` issuer (e.g. local Keycloak), discovery is disabled and authorization/token/userinfo/jwks are set manually; `MEMBER_OIDC_INTERNAL_HOST` supported for Docker.

### 4. Issuer verification workaround (dev)

- Extended the existing HTTP-issuer workaround so it applies when **either** `SSO_ISSUER_URL` **or** `MEMBER_OIDC_ISSUER_URL` is `http://` in development (e.g. local Keycloak for member testing).
- Log message updated to `[OIDC]` for both staff and member.

### 5. Tests

- **New:** `spec/requests/auth/sso_redirect_and_member_oidc_spec.rb`
  - `build_oidc_redirect_uri`: HTTPS/default host/port, non-standard port suffix, HTTP when `DISABLE_HTTPS=true`, member callback path, path normalization.
  - `Rails.application.config.member_oidc`: structure, `enabled` false by default, claims keys and default claim names.

## Environment variables (member OIDC)

| Variable | Required when enabled | Default |
|----------|------------------------|---------|
| `MEMBER_OIDC_ENABLED` | — | `false` |
| `MEMBER_OIDC_ISSUER_URL` | Yes | — |
| `MEMBER_OIDC_CLIENT_ID` | Yes | — |
| `MEMBER_OIDC_CLIENT_SECRET` | Yes | — |
| `MEMBER_OIDC_SCOPES` | No | `openid profile email` |
| `MEMBER_OIDC_INTERNAL_HOST` | No | issuer host |
| `MEMBER_OIDC_CLAIM_EMAIL` | No | `email` |
| `MEMBER_OIDC_CLAIM_NAME` | No | `name` |
| `MEMBER_OIDC_CLAIM_UID` | No | `sub` |

---


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->