### PR TITLE
Replace inline SVG icons with uswds_icon helper app-wide

### DIFF
--- a/reporting-app/app/views/activity_report_application_forms/doc_ai_upload.html.erb
+++ b/reporting-app/app/views/activity_report_application_forms/doc_ai_upload.html.erb
@@ -6,9 +6,7 @@
      translation_scope: "activity_report_application_forms.steps" %>
 
 <p>
-  <svg class="usa-icon usa-icon--size-3 text-primary margin-right-05" aria-hidden="true" focusable="false" role="img" style="vertical-align: middle;">
-    <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#arrow_back"></use>
-  </svg>
+  <%= uswds_icon("arrow_back", css_class: "text-primary margin-right-05", style: "vertical-align: middle;") %>
   <%= link_to t(".back_link"), edit_activity_report_application_form_path(@activity_report_application_form), class: "usa-link" %>
 </p>
 

--- a/reporting-app/app/views/dashboard/_compliance_status.html.erb
+++ b/reporting-app/app/views/dashboard/_compliance_status.html.erb
@@ -16,13 +16,9 @@
   <p class="margin-bottom-05 text-base"><%= t("dashboard.new_certification.current_period.total_hours_label") %></p>
   <p class="display-flex flex-align-center margin-top-0">
     <% if hours_needed > 0 %>
-      <svg class="usa-icon usa-icon--size-4 text-gold margin-right-1" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#warning"></use>
-      </svg>
+      <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
     <% else %>
-      <svg class="usa-icon usa-icon--size-4 text-green margin-right-1" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#check_circle"></use>
-      </svg>
+      <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-1") %>
     <% end %>
     <span class="font-body-lg text-bold"><%= t("dashboard.new_certification.current_period.hours_value", hours: total_hours_reported) %></span>
   </p>
@@ -33,16 +29,12 @@
   <p class="margin-bottom-05 text-base"><%= t("dashboard.new_certification.current_period.additional_hours_label", target_hours: target_hours) %></p>
   <% if hours_needed > 0 %>
     <p class="display-flex flex-align-center margin-top-0">
-      <svg class="usa-icon usa-icon--size-4 text-gold margin-right-1" aria-hidden="true" focusable="false" role="img">
-        <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#warning"></use>
-      </svg>
+      <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
       <span class="font-body-lg text-bold"><%= t("dashboard.new_certification.current_period.hours_value", hours: hours_needed) %></span>
     </p>
   <% else %>
     <div class="margin-top-0">
-      <svg class="usa-icon usa-icon--size-4 text-green margin-right-05" aria-hidden="true" focusable="false" role="img" style="vertical-align: middle;">
-        <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#check_circle"></use>
-      </svg>
+      <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-05", style: "vertical-align: middle;") %>
       <span class="font-body-lg text-bold" style="vertical-align: middle;"><%= t("dashboard.new_certification.current_period.requirements_met", period: current_period&.strftime("%B %Y")) %></span>
     </div>
   <% end %>

--- a/reporting-app/app/views/document_staging/_results.html.erb
+++ b/reporting-app/app/views/document_staging/_results.html.erb
@@ -19,9 +19,7 @@
                   class="usa-button usa-button--unstyled"
                   data-action="file-list#remove"
                   aria-label="<%= t("document_staging.results.remove_file") %>: <%= doc.file.filename %>">
-            <svg class="usa-icon usa-icon--size-3 text-primary" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#delete"></use>
-            </svg>
+            <%= uswds_icon("delete", css_class: "text-primary") %>
           </button>
         </span>
       </div>

--- a/reporting-app/app/views/document_staging/create.html.erb
+++ b/reporting-app/app/views/document_staging/create.html.erb
@@ -11,8 +11,6 @@
 <% end %>
 
 <p>
-  <svg class="usa-icon usa-icon--size-3 text-primary margin-right-05" aria-hidden="true" focusable="false" role="img" style="vertical-align: middle;">
-    <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#arrow_back"></use>
-  </svg>
+  <%= uswds_icon("arrow_back", css_class: "text-primary margin-right-05", style: "vertical-align: middle;") %>
   <%= link_to t(".back_to_upload"), dashboard_path, class: "usa-link" %>
 </p>

--- a/reporting-app/app/views/document_staging/doc_ai_upload_status.html.erb
+++ b/reporting-app/app/views/document_staging/doc_ai_upload_status.html.erb
@@ -6,9 +6,7 @@
      translation_scope: "activity_report_application_forms.steps" %>
 
 <p>
-  <svg class="usa-icon usa-icon--size-3 text-primary margin-right-05" aria-hidden="true" focusable="false" role="img" style="vertical-align: middle;">
-    <use xlink:href="<%= asset_path('@uswds/uswds/dist/img/sprite.svg') %>#arrow_back"></use>
-  </svg>
+  <%= uswds_icon("arrow_back", css_class: "text-primary margin-right-05", style: "vertical-align: middle;") %>
   <%= link_to t(".back_link"), dashboard_path, class: "usa-link" %>
 </p>
 

--- a/reporting-app/app/views/users/registrations/new.html.erb
+++ b/reporting-app/app/views/users/registrations/new.html.erb
@@ -4,9 +4,7 @@
 
 <div class="bg-white padding-top-3 padding-bottom-5 padding-x-5 border border-base-lighter">
   <div class="text-center margin-bottom-2 padding-bottom-2 border-bottom border-base-lighter">
-    <svg class="usa-icon usa-icon--size-6 text-<%= icon_color %>" aria-hidden="true" focusable="false" role="img">
-      <use xlink:href="<%= asset_path "@uswds/uswds/dist/img/sprite.svg##{icon}" %>"></use>
-    </svg>
+    <%= uswds_icon(icon, size: 6, css_class: "text-#{icon_color}") %>
 
     <h1 class="font-heading-xl margin-y-0"><%= t(".title") %></h1>
   </div>


### PR DESCRIPTION
Replaces all remaining inline USWDS sprite SVG markup with the
`uswds_icon` helper introduced in #343. Pure refactor — identical
HTML output, no behavior change.

**Stacked on:** PR #343 (`giverm/OSCER-339-staff-attribution-confidence`)

After #343 merges, the base can be changed to `main`.

## Changes
- `dashboard/_compliance_status` — 4 icons (warning ×2, check_circle ×2)
- `document_staging/doc_ai_upload_status` — arrow_back
- `document_staging/_results` — delete
- `document_staging/create` — arrow_back
- `activity_report_application_forms/doc_ai_upload` — arrow_back
- `users/registrations/new` — dynamic icon

## Impact
No functional change. Reduces view template verbosity and ensures
all USWDS icons are rendered consistently through one helper, making
future accessibility or markup changes a single-point edit.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->