### PR TITLE
Enable doc ai via config

### DIFF
--- a/reporting-app/config/initializers/feature_flags.rb
+++ b/reporting-app/config/initializers/feature_flags.rb
@@ -17,7 +17,7 @@ module Features
   FEATURE_FLAGS = {
     doc_ai: {
       env_var: "FEATURE_DOC_AI",
-      default: false,
+      default: true,
       description: "Enable DocAI document analysis for income verification"
     }
     # Example of adding more flags:


### PR DESCRIPTION
# ENV var is not picked up correctly for doc ai feature
# Testing on dev with config file

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->