### PR TITLE
Fix staff activity report display bugs

### DIFF
--- a/reporting-app/app/views/activity_report_application_forms/_staff_activity_report.html.erb
+++ b/reporting-app/app/views/activity_report_application_forms/_staff_activity_report.html.erb
@@ -4,7 +4,7 @@
       <th scope="col"><%= t(".activity_type") %></th>
       <th scope="col"><%= t(".organization_name") %></th>
       <th scope="col"><%= t(".month") %></th>
-      <th scope="col" style="width: 90px"><%= t(".hours_income").html_safe %></th>
+      <th scope="col" style="width: 90px"><%= t(".hours_income") %></th>
       <th scope="col"><%= t(".supporting_documents") %></th>
       <% if feature_enabled?(:doc_ai) %>
         <th scope="col" class="text-right"><%= t(".confidence") %></th>
@@ -12,30 +12,36 @@
     </tr>
   </thead>
   <tbody>
-    <% for activity in activity_report.activities do %>
+    <% activity_report.activities.each do |activity| %>
       <tr>
         <td>
           <% if feature_enabled?(:doc_ai) %>
             <% icon_info = evidence_source_icon(activity.evidence_source) %>
             <%= uswds_icon(icon_info[:icon], label: icon_info[:label], css_class: icon_info[:color], style: "vertical-align: middle") %>
           <% end %>
-          Work
+          <%= activity.category.titleize %>
         </td>
         <td><%= activity.name %></td>
         <td><%= activity.month&.strftime("%b, %Y") %></td>
-        <td class="text-right"><%= activity.hours %></td>
+        <td class="text-right">
+          <% if activity.is_a?(IncomeActivity) %>
+            <%= number_to_currency(activity.income&.dollar_amount, precision: 0) %>
+          <% else %>
+            <%= activity.hours %>
+          <% end %>
+        </td>
         <td>
           <% if activity.supporting_documents.any? %>
             <ul class="usa-list usa-list--unstyled margin-0">
               <% activity.supporting_documents.each do |document| %>
-                <li c>
+                <li>
                   <%= link_to document.filename, rails_blob_path(document, disposition: "attachment"),
                       target: "_blank", class: "usa-link" %>
                 </li>
               <% end %>
             </ul>
           <% else %>
-            <p>No documents</p>
+            <p><%= t(".no_documents") %></p>
           <% end %>
         </td>
         <% if feature_enabled?(:doc_ai) %>

--- a/reporting-app/config/locales/views/activity_report_application_forms/en.yml
+++ b/reporting-app/config/locales/views/activity_report_application_forms/en.yml
@@ -84,3 +84,4 @@ en:
       hours_income: "Hours / Income"
       supporting_documents: Supporting documents
       confidence: "Confidence Level"
+      no_documents: No documents

--- a/reporting-app/spec/requests/tasks_spec.rb
+++ b/reporting-app/spec/requests/tasks_spec.rb
@@ -29,6 +29,85 @@ RSpec.describe "/staff/tasks", type: :request do
         expect(response).to be_successful
         expect(response.body).to include(activity_report_task.id)
       end
+
+      context "with work activities" do
+        let(:work_activity) do
+          create(
+            :work_activity,
+            activity_report_application_form_id: activity_report_application_form.id,
+            category: "employment",
+            hours: 40
+          )
+        end
+
+        before { work_activity }
+
+        it "displays activity category and hours" do
+          get "/staff/tasks/#{activity_report_task.id}"
+
+          expect(response.body).to include("Employment")
+          expect(response.body).to include("40")
+        end
+      end
+
+      context "with income activities" do
+        let(:income_activity) do
+          create(
+            :income_activity,
+            activity_report_application_form_id: activity_report_application_form.id,
+            category: "employment",
+            income: 150_000
+          )
+        end
+
+        before { income_activity }
+
+        it "displays activity category and formatted income" do
+          get "/staff/tasks/#{activity_report_task.id}"
+
+          expect(response.body).to include("Employment")
+          expect(response.body).to include("$1,500")
+        end
+      end
+
+      context "with activities that have supporting documents" do
+        let(:activity) do
+          create(
+            :work_activity,
+            activity_report_application_form_id: activity_report_application_form.id
+          )
+        end
+
+        before do
+          activity.supporting_documents.attach(
+            fixture_file_upload("spec/fixtures/files/test_document_1.pdf", "application/pdf")
+          )
+        end
+
+        it "displays document links" do
+          get "/staff/tasks/#{activity_report_task.id}"
+
+          expect(response.body).to include("test_document_1.pdf")
+          expect(response.body).to include("usa-link")
+        end
+      end
+
+      context "with activities that have no supporting documents" do
+        let(:activity) do
+          create(
+            :work_activity,
+            activity_report_application_form_id: activity_report_application_form.id
+          )
+        end
+
+        before { activity }
+
+        it "displays the no documents message" do
+          get "/staff/tasks/#{activity_report_task.id}"
+
+          expect(response.body).to include(I18n.t("activity_report_application_forms.staff_activity_report.no_documents"))
+        end
+      end
     end
 
     context "with ExemptionApplicationForm" do


### PR DESCRIPTION
Fix staff activity report display bugs

Early work for https://github.com/navapbc/oscer/issues/347. Fixes
several bugs in the staff activity report partial that would block the
upcoming document preview panel feature:

- Display actual activity category instead of hardcoded "Work"
- Render formatted currency for IncomeActivity, hours for work activities
- Fix `<li c>` HTML typo (stray attribute)
- Extract hardcoded "No documents" string to i18n
- Replace non-idiomatic `for..in` loop with `.each`
- Remove unnecessary `.html_safe` on plain-text translation

Adds request spec coverage for work activities, income activities,
supporting document links, and the no-documents fallback.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->