### PR TITLE
Create Automated CE Income Verification spec

### DIFF
--- a/docs/architecture/income-data/income-data.md
+++ b/docs/architecture/income-data/income-data.md
@@ -194,7 +194,7 @@ end
 
 - `source_type`: `"api"`, `"batch_upload"`, `"quarterly_wage_data"` (stored for attribution)
 - `source_id`: batch upload ID or external reference
-- Immutable after creation; never updated or deleted
+- **Data governance:** Append-only in normal intake flows. Updates or deletes are exceptional (e.g., corrections, backfills) and must be recorded in an audit log. See [Audit trail over hard immutability](#audit-trail-over-hard-immutability) below.
 
 ---
 
@@ -269,6 +269,16 @@ Use `CE_INCOME_THRESHOLD_MONTHLY` (default 580) so states can adjust. Tradeoff: 
 
 Store `source_type` and `source_id` on each `ExParteIncome` for audit. Tradeoff: redundant source data; required for traceability.
 
+### Audit trail over hard immutability
+
+Use an **audit trail** to satisfy the business requirement for traceable, trustworthy income data instead of enforcing strict immutability (e.g., DB triggers or model hooks that block updates/deletes).
+
+**Rationale:** Strict immutability is difficult to enforce reliably (triggers and hooks can be bypassed; raw SQL, console, or other services may change data). It also blocks legitimate cases: corrections after a bad load, transient states (e.g., pending verification), merges, backfills, or compliance-driven updates. The business need is **traceability**—who changed what, when, and why—plus **origin metadata** (source_type, source_id, reported_at). An audit log provides both and accommodates edge cases.
+
+**Approach:** Record all create/update/delete events for `ExParteIncome` in an audit store (e.g., `ex_parte_income_audit` or a generic audit table): old/new values, `changed_at`, `changed_by` (user or system), optional reason/context, and origin fields at time of event. Normal flows are append-only (create only); any update or delete goes through a defined process and is always audited. Optionally, model-level guards (e.g., `before_update` / `before_destroy` that raise or log) may be used as defense-in-depth; the primary guarantee is the audit log.
+
+**Tradeoff:** Policy-based "do not update in normal flows" instead of technical enforcement. Mitigated by audit, code review, and optional model guards.
+
 ### No income-to-hours conversion (out of scope)
 
 Do not convert income to hours (e.g., income / federal min wage). CER allows either hours or income; income path is independent. Tradeoff: none for this scope.
@@ -278,7 +288,7 @@ Do not convert income to hours (e.g., income / federal min wage). CER allows eit
 ## Constraints
 
 - OSCER does not pull or query external systems; states send data to OSCER.
-- Income records are immutable after creation.
+- Income data is **append-only in normal flows**; updates or deletes are exceptional and must be fully audited (see [Audit trail over hard immutability](#audit-trail-over-hard-immutability)). No silent changes.
 - Determinations are versioned (new record on recalculation).
 - Source attribution is required for all income records.
 - API authentication matches hours API (API key or HMAC).


### PR DESCRIPTION

## Overview

This PR adds (or updates) the **architecture specification** for automated Community Engagement (CE) income verification in OSCER: [income-data.md](../architecture/income-data/income-data.md). The doc defines how OSCER accepts income data from state systems, stores it in a parallel `ExParteIncome` model, and uses it to produce automated CE compliance determinations against a configurable threshold ($580/month default).

**Scope:** Documentation only. Implementation will follow this spec (API extension, model, compliance service, business process integration).

---

## What's in the Doc

### Problem

CER under H.R. 1 requires members to show 80 hours/month or **$580/month** of qualifying activity. OSCER already supports hours from state sources; it cannot accept or use **income** data today. Members with documented employment may still self-report manually. States have no path to send income data to OSCER.

### Approach

1. Extend external data intake to accept **income** via API (batch later), reusing hours intake patterns.
2. Use income to produce automated CE compliance against configurable threshold (default $580/month).
3. Support multiple income source types (QWD, state UI wage records, payroll APIs) with source attribution.
4. Aggregate income, compare to threshold, produce determination records (`decision_method = automated`, auditable reason codes).
5. Surface income-based attribution in staff case view and member status.

### C4

- **Context:** State systems (eligibility, QWD, UI wage records, future payroll API) send income to OSCER API; OSCER does not pull or query. App serves caseworkers and members.
- **Component:** CertAPI → ExParteIncomeService → ExParteIncome; CertAPI → IncomeComplianceDeterminationService → Determination; MemberStatusService for presentation.

### Data Model (ADR)

**Decision:** **Parallel `ExParteIncome` table** (Option B), not extending `ExParteActivity`.

- New `ex_parte_incomes` table: `member_id`, `certification_id`, `category`, `gross_income`, `period_start`, `period_end`, `source_type`, `source_id`, `reported_at`, `metadata`.
- Income semantics differ (dollars, pay period, source cadence); keeps hours table focused; allows independent rules (e.g. freshness by source).
- **Tradeoff:** Two intake paths; mitigated by reusing controller/service/job patterns from hours epic.
- Records **immutable** after creation.

### API Design

- Extend `POST /api/certifications` `member_data.activities` with `type: "income"` (same array as hours).
- **Income activity fields:** type, category, gross_income, period_start, period_end, source, reported_at, employer.
- **Source types (MVP):** `quarterly_wage_data`, `api`, `batch_upload`; future: state_ui_wage_records, payroll_api_*.

### Compliance Logic

- **Threshold:** `CE_INCOME_THRESHOLD_MONTHLY` (default 580).
- **Aggregation:** Sum `gross_income` in certification lookback; include approved manual income if present; compare to threshold.
- **Outcomes:** >= $580 → compliant; < $580 → awaiting_report or not_compliant.
- **Determination payload:** calculation_type, total_income, target_income, income_by_source, period, ex_parte_income_ids, calculation_method.

### Business Process Integration

- Income saved **before** certification creation.
- At `EX_PARTE_COMMUNITY_ENGAGEMENT_CHECK_STEP`: if hours sufficient → hours path; else if income sufficient → `IncomeComplianceDeterminationService.determine(kase)`.
- Recalculation when new income arrives (e.g. `CalculateComplianceJob`).

---

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->