### PR TITLE
Add document preview panel for caseworker DocAI review

### DIFF
--- a/reporting-app/app/assets/stylesheets/application.scss
+++ b/reporting-app/app/assets/stylesheets/application.scss
@@ -93,6 +93,39 @@ div.exemption-screener {
 }
 
 // =========================================================
+// DocAI attribution field styles
+// =========================================================
+[class*="bg-attribution-"] {
+  // Make all nested elements transparent so the parent tint shows through
+  *:not(svg):not(use) {
+    background-color: transparent !important;
+    background: transparent !important;
+  }
+
+  // Keep form inputs white for readability
+  .usa-input,
+  .usa-select {
+    background-color: white !important;
+  }
+}
+
+.bg-attribution-primary {
+  background-color: color("blue-cool-5v") !important;
+}
+
+.bg-attribution-gold {
+  background-color: color("gold-5v") !important;
+}
+
+.bg-attribution-green {
+  background-color: color("green-cool-5v") !important;
+}
+
+.bg-attribution-error {
+  background-color: color("red-cool-5v") !important;
+}
+
+// =========================================================
 // Document scanning animation
 // =========================================================
 @keyframes scanning-progress {

--- a/reporting-app/app/helpers/activities_helper.rb
+++ b/reporting-app/app/helpers/activities_helper.rb
@@ -8,10 +8,22 @@ module ActivitiesHelper
     ActivityAttributions::AI_REJECTED_MEMBER_OVERRIDE => { icon: "warning", color: "text-error" }
   }.freeze
 
+  ATTRIBUTION_FIELD_CLASSES = {
+    ActivityAttributions::SELF_REPORTED => "border-1px border-primary bg-attribution-primary",
+    ActivityAttributions::AI_ASSISTED => "border-1px border-gold bg-attribution-gold",
+    ActivityAttributions::AI_ASSISTED_WITH_MEMBER_EDITS => "border-1px border-green bg-attribution-green",
+    ActivityAttributions::AI_REJECTED_MEMBER_OVERRIDE => "border-1px border-error bg-attribution-error"
+  }.freeze
+
+  def attribution_field_classes(evidence_source)
+    source = evidence_source || ActivityAttributions::SELF_REPORTED
+    ATTRIBUTION_FIELD_CLASSES.fetch(source, "")
+  end
+
   def evidence_source_icon(evidence_source)
-    source = evidence_source || "self_reported"
+    source = evidence_source || ActivityAttributions::SELF_REPORTED
     # Fall back both the icon config AND the source key for i18n lookup
-    source = "self_reported" unless EVIDENCE_SOURCE_ICONS.key?(source)
+    source = ActivityAttributions::SELF_REPORTED unless EVIDENCE_SOURCE_ICONS.key?(source)
     icon_config = EVIDENCE_SOURCE_ICONS[source]
 
     {

--- a/reporting-app/app/javascript/controllers/document_preview_controller.js
+++ b/reporting-app/app/javascript/controllers/document_preview_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["table", "previewArea", "prefillForm", "iframe", "image", "fallback", "fallbackLink", "heading"]
+
+  select(event) {
+    event.preventDefault()
+
+    const { url, filename, contentType, activityId } = event.params
+
+    this.#updateHeading(filename)
+    this.#showPrefillForm(activityId)
+    this.#showPreview(url, filename, contentType)
+    this.#openPreviewArea()
+  }
+
+  close() {
+    this.previewAreaTarget.classList.add("display-none")
+    this.tableTarget.classList.remove("display-none")
+  }
+
+  #openPreviewArea() {
+    this.tableTarget.classList.add("display-none")
+    this.previewAreaTarget.classList.remove("display-none")
+  }
+
+  #updateHeading(filename) {
+    this.headingTarget.textContent = this.#interpolate(this.headingTarget.dataset.template, filename)
+  }
+
+  #showPrefillForm(activityId) {
+    this.prefillFormTargets.forEach((form) => {
+      form.classList.toggle("display-none", form.dataset.activityId !== activityId)
+    })
+  }
+
+  #interpolate(template, filename) {
+    return (template || "").replace("%{filename}", filename)
+  }
+
+  #showPreview(url, filename, contentType) {
+    this.iframeTarget.classList.add("display-none")
+    this.imageTarget.classList.add("display-none")
+    this.fallbackTarget.classList.add("display-none")
+
+    if (contentType === "application/pdf") {
+      this.iframeTarget.src = url
+      this.iframeTarget.title = this.#interpolate(this.iframeTarget.dataset.titleTemplate, filename)
+      this.iframeTarget.classList.remove("display-none")
+    } else if ((contentType || "").startsWith("image/")) {
+      this.imageTarget.src = url
+      this.imageTarget.alt = this.#interpolate(this.imageTarget.dataset.altTemplate, filename)
+      this.imageTarget.classList.remove("display-none")
+    } else {
+      this.fallbackLinkTarget.href = url
+      this.fallbackTarget.classList.remove("display-none")
+    }
+  }
+}

--- a/reporting-app/app/views/activity_report_application_forms/_staff_activity_report.html.erb
+++ b/reporting-app/app/views/activity_report_application_forms/_staff_activity_report.html.erb
@@ -9,6 +9,9 @@
       <% if feature_enabled?(:doc_ai) %>
         <th scope="col" class="text-right"><%= t(".confidence") %></th>
       <% end %>
+      <% if local_assigns[:has_document_preview] %>
+        <th scope="col"><%= t(".preview") %></th>
+      <% end %>
     </tr>
   </thead>
   <tbody>
@@ -47,6 +50,24 @@
         <% if feature_enabled?(:doc_ai) %>
           <td class="text-right text-no-wrap">
             <%= confidence_cell_content(activity, @confidence_by_activity) %>
+          </td>
+        <% end %>
+        <% if local_assigns[:has_document_preview] %>
+          <td>
+            <% if activity.supporting_documents.any? %>
+              <% activity.supporting_documents.each do |document| %>
+                <button type="button"
+                        class="usa-button usa-button--unstyled"
+                        aria-label="<%= t(".preview_icon_label", filename: document.filename) %>"
+                        data-action="document-preview#select"
+                        data-document-preview-url-param="<%= rails_blob_path(document, disposition: "inline") %>"
+                        data-document-preview-filename-param="<%= document.filename %>"
+                        data-document-preview-content-type-param="<%= document.content_type %>"
+                        data-document-preview-activity-id-param="<%= activity.id %>">
+                  <%= uswds_icon("visibility", size: 3) %>
+                </button>
+              <% end %>
+            <% end %>
           </td>
         <% end %>
       </tr>

--- a/reporting-app/app/views/tasks/details/_activity_prefill_form.html.erb
+++ b/reporting-app/app/views/tasks/details/_activity_prefill_form.html.erb
@@ -1,0 +1,103 @@
+<%# Read-only prefill form showing an activity's fields with attribution labels.
+     Rendered once per activity (hidden by default, shown by Stimulus controller).
+     Uses strata_form_with for USWDS form components with all fields disabled. %>
+<% icon_info = evidence_source_icon(activity.evidence_source) %>
+<% attribution_label = icon_info[:label] %>
+<% field_classes = attribution_field_classes(activity.evidence_source) %>
+
+<div class="padding-2">
+  <button type="button"
+          class="usa-button usa-button--unstyled margin-bottom-4"
+          data-action="document-preview#close">
+    <%= uswds_icon("arrow_back", css_class: "text-primary margin-right-05", style: "vertical-align: middle;") %>
+    <%= t("details.review_activity_report_task.document_preview.back_to_table") %>
+  </button>
+  <h3 class="margin-top-0 margin-bottom-2"><%= t("details.review_activity_report_task.document_preview.prefill_heading") %></h3>
+
+  <%= strata_form_with(url: "#", method: :get) do |f| %>
+    <%# Activity type %>
+    <div class="<%= field_classes %> padding-1 margin-bottom-2 radius-md">
+      <div class="display-flex flex-justify flex-align-start">
+        <div class="flex-fill">
+          <%= f.fieldset t("activities.edit.doc_ai_review.activity_type_label") do %>
+            <% ActivityCategories::ALL.each do |cat| %>
+              <%= f.radio_button :category, cat,
+                  label: t("activities.form.#{cat}_label"),
+                  checked: activity.category == cat,
+                  disabled: true,
+                  tile: false %>
+            <% end %>
+          <% end %>
+        </div>
+        <%= render "tasks/details/attribution_tag", icon_info: icon_info, label: attribution_label %>
+      </div>
+    </div>
+
+    <%# Reporting method %>
+    <div class="<%= field_classes %> padding-1 margin-bottom-2 radius-md">
+      <div class="display-flex flex-justify flex-align-start">
+        <div class="flex-fill">
+          <%= f.fieldset t("activities.edit.doc_ai_review.reporting_method_label") do %>
+            <%= f.radio_button :reporting_method, "hours",
+                label: t("activities.form.hours_label"),
+                checked: !activity.is_a?(IncomeActivity),
+                disabled: true,
+                tile: false %>
+            <%= f.radio_button :reporting_method, "income",
+                label: t("activities.edit.doc_ai_review.report_income_label"),
+                checked: activity.is_a?(IncomeActivity),
+                disabled: true,
+                tile: false %>
+          <% end %>
+        </div>
+        <%= render "tasks/details/attribution_tag", icon_info: icon_info, label: attribution_label %>
+      </div>
+    </div>
+
+    <%# Organization name %>
+    <div class="<%= field_classes %> padding-1 margin-bottom-2 radius-md">
+      <div class="display-flex flex-justify flex-align-start">
+        <div class="flex-fill">
+          <%= f.text_field :name,
+              label: t("activities.form.name"),
+              value: activity.name,
+              disabled: true %>
+        </div>
+        <%= render "tasks/details/attribution_tag", icon_info: icon_info, label: attribution_label %>
+      </div>
+    </div>
+
+    <%# Month %>
+    <div class="<%= field_classes %> padding-1 margin-bottom-2 radius-md">
+      <div class="display-flex flex-justify flex-align-start">
+        <div class="flex-fill">
+          <%= f.select :month,
+              [[activity.month&.strftime("%B %Y"), activity.month]],
+              { selected: activity.month },
+              { disabled: true, label: t("details.review_activity_report_task.document_preview.month_label") } %>
+        </div>
+        <%= render "tasks/details/attribution_tag", icon_info: icon_info, label: attribution_label %>
+      </div>
+    </div>
+
+    <%# Hours or Income %>
+    <div class="<%= field_classes %> padding-1 margin-bottom-2 radius-md">
+      <div class="display-flex flex-justify flex-align-start">
+        <div class="flex-fill">
+          <% if activity.is_a?(IncomeActivity) %>
+            <%= f.text_field :income,
+                label: t("activities.form.income_label"),
+                value: number_to_currency(activity.income&.dollar_amount, precision: 0),
+                disabled: true %>
+          <% else %>
+            <%= f.text_field :hours,
+                label: t("activities.form.hours_label"),
+                value: activity.hours,
+                disabled: true %>
+          <% end %>
+        </div>
+        <%= render "tasks/details/attribution_tag", icon_info: icon_info, label: attribution_label %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/reporting-app/app/views/tasks/details/_attribution_tag.html.erb
+++ b/reporting-app/app/views/tasks/details/_attribution_tag.html.erb
@@ -1,0 +1,5 @@
+<%# Displays an evidence source attribution label (icon + text) at the top-right of a field group. %>
+<div class="text-no-wrap margin-left-1">
+  <%= uswds_icon(icon_info[:icon], label: label, css_class: "#{icon_info[:color]} margin-right-05", size: 2, style: "vertical-align: middle") %>
+  <span class="font-sans-2xs <%= icon_info[:color] %>"><%= label %></span>
+</div>

--- a/reporting-app/app/views/tasks/details/_document_preview_panel.html.erb
+++ b/reporting-app/app/views/tasks/details/_document_preview_panel.html.erb
@@ -1,0 +1,28 @@
+<div class="position-sticky top-2">
+  <h3 data-document-preview-target="heading"
+      data-template="<%= t('details.review_activity_report_task.document_preview.heading', filename: '%{filename}') %>">
+  </h3>
+
+  <iframe data-document-preview-target="iframe"
+          class="width-full border-1px border-base-light display-none"
+          style="min-height: 70vh;"
+          title=""
+          data-title-template="<%= t('details.review_activity_report_task.document_preview.iframe_title', filename: '%{filename}') %>">
+  </iframe>
+
+  <img data-document-preview-target="image"
+       class="width-full border-1px border-base-light display-none"
+       src=""
+       alt=""
+       data-alt-template="<%= t('details.review_activity_report_task.document_preview.image_alt', filename: '%{filename}') %>" />
+
+  <div data-document-preview-target="fallback"
+       class="padding-4 border-1px border-base-light bg-base-lightest display-none">
+    <p><%= t("details.review_activity_report_task.document_preview.no_preview") %></p>
+    <a data-document-preview-target="fallbackLink"
+       href="#"
+       class="usa-link">
+      <%= t("details.review_activity_report_task.document_preview.download_link") %>
+    </a>
+  </div>
+</div>

--- a/reporting-app/app/views/tasks/details/_review_activity_report_task.html.erb
+++ b/reporting-app/app/views/tasks/details/_review_activity_report_task.html.erb
@@ -1,15 +1,50 @@
 <%= render partial: 'application/flash' %>
-<h2><%= t(".intro") %></h2>
-<p><%= t(".instructions") %></p>
-<%= render partial: 'activity_report_application_forms/staff_activity_report', locals: { activity_report: application_form } %>
-<%= render partial: 'information_requests/information_requests_list',
-  locals: { application_form: application_form, information_requests: information_requests } %>
-<% if task.pending? %>
-  <h2><%= t(".activity_report_decision.heading") %></h2>
-  <%= strata_form_with(model: task) do |f| %>
-    <%= f.radio_button :activity_report_decision, "yes", { label: t(".activity_report_decision.options.yes_acceptable"), tile: false } %>
-    <%= f.radio_button :activity_report_decision, "no-additional-info", { label: t(".activity_report_decision.options.no_additional_info"), tile: false } %>
-    <%= f.radio_button :activity_report_decision, "no-not-acceptable", { label: t(".activity_report_decision.options.no_not_acceptable"), tile: false } %>
-    <%= f.submit t(".activity_report_decision.submit_button") %>
+<% has_document_preview = feature_enabled?(:doc_ai) && application_form.activities.any? { |a| a.supporting_documents.any? } %>
+
+<%= tag.div(data: has_document_preview ? { controller: "document-preview" } : {}) do %>
+  <%# Table view (visible by default, hidden when preview is open) %>
+  <%= tag.div(data: has_document_preview ? { document_preview_target: "table" } : {}) do %>
+    <h2><%= t(".intro") %></h2>
+    <p><%= t(".instructions") %></p>
+    <%= render partial: 'activity_report_application_forms/staff_activity_report',
+      locals: { activity_report: application_form, has_document_preview: has_document_preview } %>
+
+    <%# Information requests %>
+    <%= render partial: 'information_requests/information_requests_list',
+      locals: { application_form: application_form, information_requests: information_requests } %>
+
+    <%# Decision form %>
+    <% if task.pending? %>
+      <h2><%= t(".activity_report_decision.heading") %></h2>
+      <%= strata_form_with(model: task) do |f| %>
+        <%= f.radio_button :activity_report_decision, "yes", { label: t(".activity_report_decision.options.yes_acceptable"), tile: false } %>
+        <%= f.radio_button :activity_report_decision, "no-additional-info", { label: t(".activity_report_decision.options.no_additional_info"), tile: false } %>
+        <%= f.radio_button :activity_report_decision, "no-not-acceptable", { label: t(".activity_report_decision.options.no_not_acceptable"), tile: false } %>
+        <%= f.submit t(".activity_report_decision.submit_button") %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if has_document_preview %>
+    <%# Two-column preview area (hidden by default, shown when eye icon is clicked) %>
+    <div class="grid-row grid-gap-4 display-none" data-document-preview-target="previewArea">
+      <%# Left column: per-activity prefill forms (one shown at a time) %>
+      <div class="desktop:grid-col-6">
+        <% application_form.activities.each do |activity| %>
+          <% next unless activity.supporting_documents.any? %>
+          <div class="display-none"
+               data-document-preview-target="prefillForm"
+               data-activity-id="<%= activity.id %>">
+            <%= render partial: 'tasks/details/activity_prefill_form',
+              locals: { activity: activity } %>
+          </div>
+        <% end %>
+      </div>
+
+      <%# Right column: document preview (iframe/img/fallback) %>
+      <div class="desktop:grid-col-6">
+        <%= render partial: 'tasks/details/document_preview_panel' %>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/reporting-app/config/locales/views/activity_report_application_forms/en.yml
+++ b/reporting-app/config/locales/views/activity_report_application_forms/en.yml
@@ -85,3 +85,5 @@ en:
       supporting_documents: Supporting documents
       confidence: "Confidence Level"
       no_documents: No documents
+      preview: Preview
+      preview_icon_label: "Preview %{filename}"

--- a/reporting-app/config/locales/views/tasks/en.yml
+++ b/reporting-app/config/locales/views/tasks/en.yml
@@ -34,6 +34,16 @@ en:
           no_additional_info: "No, additional information is needed"
           no_not_acceptable: "No, the documentation is not acceptable"
         submit_button: "Submit"
+      document_preview:
+        heading: "Document: %{filename}"
+        iframe_title: "Preview of %{filename}"
+        image_alt: "Preview of %{filename}"
+        no_preview: "Preview not available for this file type."
+        download_link: "Download document"
+        close: "Close preview"
+        back_to_table: "Back to table"
+        prefill_heading: "Prefill"
+        month_label: "Month"
     review_exemption_claim_task:
       intro: Review the exemption form
       denied_message: "Exemption not accepted"

--- a/reporting-app/db/seeds/development.rb
+++ b/reporting-app/db/seeds/development.rb
@@ -43,12 +43,16 @@ user = User.first || FactoryBot.create(:user, :as_admin, region: "Southeast", em
 
   next if index == 0 # Skip adding activities for the first form to test empty state
 
+  # Each activity gets a different evidence_source to test attribution color-coding in the preview panel:
+  #   self_reported = blue, ai_assisted = gold, ai_assisted_with_member_edits = green,
+  #   ai_rejected_member_override = red, nil = defaults to self_reported (blue)
   app_form.activities.create!(
     name: "Community Meeting",
     type: "HourlyActivity",
     category: "community_service",
     month: Date.today.prev_month.beginning_of_month,
     hours: rand(1..5),
+    evidence_source: ActivityAttributions::SELF_REPORTED,
     supporting_documents: [
       { io: File.open(Rails.root.join("db/seeds/files/fake_paystub.png")), filename: "Courthouse Clerk Paystub.png", content_type: "image/png" }
     ]
@@ -59,6 +63,7 @@ user = User.first || FactoryBot.create(:user, :as_admin, region: "Southeast", em
     category: "community_service",
     month: Date.today.prev_month.beginning_of_month,
     hours: rand(1..5),
+    evidence_source: ActivityAttributions::AI_ASSISTED,
     supporting_documents: [
       { io: File.open(Rails.root.join("db/seeds/files/fake_paystub.pdf")), filename: "Paystub1.pdf", content_type: "application/pdf" },
       { io: File.open(Rails.root.join("db/seeds/files/fake_paystub.png")), filename: "Paystub2.png", content_type: "image/png" },
@@ -71,6 +76,7 @@ user = User.first || FactoryBot.create(:user, :as_admin, region: "Southeast", em
     category: "education",
     month: Date.today.prev_month.beginning_of_month,
     income: rand(15..300),
+    evidence_source: ActivityAttributions::AI_ASSISTED_WITH_MEMBER_EDITS,
     supporting_documents: [
       { io: File.open(Rails.root.join("db/seeds/files/fake_training_certificate.pdf")), filename: "Training Certificate.pdf", content_type: "application/pdf" }
     ]
@@ -80,7 +86,8 @@ user = User.first || FactoryBot.create(:user, :as_admin, region: "Southeast", em
     type: "HourlyActivity",
     category: "community_service",
     month: Date.today.prev_month.prev_month.beginning_of_month,
-    hours: rand(1..10)
+    hours: rand(1..10),
+    evidence_source: ActivityAttributions::AI_REJECTED_MEMBER_OVERRIDE
   )
   app_form.activities.create!(
     name: "Volunteer Coordination",
@@ -88,6 +95,7 @@ user = User.first || FactoryBot.create(:user, :as_admin, region: "Southeast", em
     category: "community_service",
     month: Date.today.prev_month.prev_month.beginning_of_month,
     hours: rand(15..60),
+    evidence_source: ActivityAttributions::AI_ASSISTED,
     supporting_documents: [
       { io: File.open(Rails.root.join("db/seeds/files/fake_paystub.pdf")), filename: "Administrative Paystub.pdf", content_type: "application/pdf" },
       { io: File.open(Rails.root.join("db/seeds/files/fake_paystub.pdf")), filename: "Art Event Coordination Paystub.pdf", content_type: "application/pdf" },

--- a/reporting-app/spec/helpers/activities_helper_spec.rb
+++ b/reporting-app/spec/helpers/activities_helper_spec.rb
@@ -53,6 +53,44 @@ RSpec.describe ActivitiesHelper, type: :helper do
     end
   end
 
+  describe "ATTRIBUTION_FIELD_CLASSES" do
+    it "has a class mapping for every Activity evidence source" do
+      expect(ActivitiesHelper::ATTRIBUTION_FIELD_CLASSES.keys).to match_array(Activity::EVIDENCE_SOURCES)
+    end
+  end
+
+  describe "#attribution_field_classes" do
+    it "returns primary classes for nil evidence source" do
+      result = helper.attribution_field_classes(nil)
+      expect(result).to eq("border-1px border-primary bg-attribution-primary")
+    end
+
+    it "returns primary classes for self_reported" do
+      result = helper.attribution_field_classes(ActivityAttributions::SELF_REPORTED)
+      expect(result).to eq("border-1px border-primary bg-attribution-primary")
+    end
+
+    it "returns gold classes for ai_assisted" do
+      result = helper.attribution_field_classes(ActivityAttributions::AI_ASSISTED)
+      expect(result).to eq("border-1px border-gold bg-attribution-gold")
+    end
+
+    it "returns green classes for ai_assisted_with_member_edits" do
+      result = helper.attribution_field_classes(ActivityAttributions::AI_ASSISTED_WITH_MEMBER_EDITS)
+      expect(result).to eq("border-1px border-green bg-attribution-green")
+    end
+
+    it "returns error classes for ai_rejected_member_override" do
+      result = helper.attribution_field_classes(ActivityAttributions::AI_REJECTED_MEMBER_OVERRIDE)
+      expect(result).to eq("border-1px border-error bg-attribution-error")
+    end
+
+    it "returns empty string for unknown evidence source" do
+      result = helper.attribution_field_classes("unknown_source")
+      expect(result).to eq("")
+    end
+  end
+
   describe "#confidence_display" do
     before do
       allow(Rails.application.config).to receive(:doc_ai).and_return({ low_confidence_threshold: 0.7 })

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -176,7 +176,8 @@ RSpec.describe "/staff/certification_cases", type: :request do
           with_doc_ai_enabled do
             get "/staff/certification_cases/#{certification_case.id}"
             expect(response.body).to include("#person")
-            expect(response.body).not_to include("0%")
+            # Self-reported activities show "—" (em dash) instead of a percentage
+            expect(response.body).to include("—")
           end
         end
       end

--- a/reporting-app/spec/requests/tasks_spec.rb
+++ b/reporting-app/spec/requests/tasks_spec.rb
@@ -90,6 +90,75 @@ RSpec.describe "/staff/tasks", type: :request do
           expect(response.body).to include("test_document_1.pdf")
           expect(response.body).to include("usa-link")
         end
+
+        it "renders the document preview panel with Stimulus targets" do
+          with_doc_ai_enabled do
+            get "/staff/tasks/#{activity_report_task.id}"
+
+            expect(response.body).to include('data-controller="document-preview"')
+            expect(response.body).to include('data-document-preview-target="previewArea"')
+            expect(response.body).to include('data-document-preview-target="table"')
+            expect(response.body).to include('data-action="document-preview#select"')
+            expect(response.body).to include('aria-label="Preview test_document_1.pdf"')
+            expect(response.body).to include(I18n.t("activity_report_application_forms.staff_activity_report.preview"))
+          end
+        end
+
+        it "renders the prefill form with close button for the activity" do
+          with_doc_ai_enabled do
+            get "/staff/tasks/#{activity_report_task.id}"
+
+            expect(response.body).to include('data-document-preview-target="prefillForm"')
+            expect(response.body).to include("data-activity-id=\"#{activity.id}\"")
+            expect(response.body).to include(activity.name)
+            expect(response.body).to include('data-action="document-preview#close"')
+          end
+        end
+
+        it "renders document links without preview panel when doc_ai is disabled" do
+          with_doc_ai_disabled do
+            get "/staff/tasks/#{activity_report_task.id}"
+
+            expect(response.body).to include("test_document_1.pdf")
+            expect(response.body).to include("usa-link")
+            expect(response.body).not_to include('data-controller="document-preview"')
+          end
+        end
+      end
+
+      context "with mixed activities (some with documents, some without)" do
+        let(:activity_with_doc) do
+          create(
+            :work_activity,
+            activity_report_application_form_id: activity_report_application_form.id,
+            name: "Documented Work"
+          )
+        end
+        let(:activity_without_doc) do
+          create(
+            :work_activity,
+            activity_report_application_form_id: activity_report_application_form.id,
+            name: "Undocumented Work"
+          )
+        end
+
+        before do
+          activity_with_doc.supporting_documents.attach(
+            fixture_file_upload("spec/fixtures/files/test_document_1.pdf", "application/pdf")
+          )
+          activity_without_doc
+        end
+
+        it "renders prefill form only for activity with documents" do
+          with_doc_ai_enabled do
+            get "/staff/tasks/#{activity_report_task.id}"
+
+            expect(response.body).to include("data-activity-id=\"#{activity_with_doc.id}\"")
+            expect(response.body).to include("Documented Work")
+            expect(response.body).to include("Undocumented Work")
+            expect(response.body).not_to include("data-activity-id=\"#{activity_without_doc.id}\"")
+          end
+        end
       end
 
       context "with activities that have no supporting documents" do
@@ -106,6 +175,15 @@ RSpec.describe "/staff/tasks", type: :request do
           get "/staff/tasks/#{activity_report_task.id}"
 
           expect(response.body).to include(I18n.t("activity_report_application_forms.staff_activity_report.no_documents"))
+        end
+
+        it "renders the activity table without preview panel when doc_ai is enabled" do
+          with_doc_ai_enabled do
+            get "/staff/tasks/#{activity_report_task.id}"
+
+            expect(response.body).to include(activity.name)
+            expect(response.body).not_to include('data-document-preview-target="previewArea"')
+          end
         end
       end
     end


### PR DESCRIPTION
Resolves #347
Part of #361

Adds a document preview panel to the staff task detail page for
reviewing DocAI-processed activity reports. Clicking the eye icon
on a supporting document replaces the activity table with a
two-column view: a read-only prefill form (left) showing the
activity's fields with color-coded attribution labels, and an
inline document preview (right) for PDFs, images, or a download
fallback. "Back to table" returns to the full review page including
the decision form and information requests.

Attribution styling uses per-field color-coding to indicate how
evidence was obtained: blue (self-reported), gold (AI-assisted),
green (AI-assisted with member edits), and red (AI-rejected, member
override). The entire preview feature is gated behind the :doc_ai
feature flag, consistent with other DocAI UI elements.

Key implementation details:
- Stimulus controller toggles between table and preview views
- tag.div block wrapper eliminates fragile split if/end ERB pattern
- Prefill form uses strata_form_with for USWDS component consistency
- Decision form and info requests hide when preview is open
- Development seeds include all four evidence sources for visual testing

Potential follow-up work:
- Document navigation (Previous / Save and continue buttons)
- Per-document decisions with persistence

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->