### PR TITLE
Impliment Routes and Member Login UI for Member SSO

### DIFF
--- a/reporting-app/app/controllers/auth/sso_controller.rb
+++ b/reporting-app/app/controllers/auth/sso_controller.rb
@@ -55,12 +55,18 @@ class Auth::SsoController < ApplicationController
     redirect_to root_path, alert: e.message
   end
 
-  # GET /auth/sso/failure
-  # Handles OmniAuth authentication failures
+  # GET /auth/failure (OmniAuth default; also /auth/sso/failure if routed)
+  # Handles OmniAuth authentication failures for staff SSO and delegates member_oidc to member sign-in.
   def failure
-    message = sanitized_failure_message(params[:message])
-    Rails.logger.error("SSO authentication failed: #{message}")
-    redirect_to root_path, alert: t("auth.sso.authentication_failed")
+    if params[:strategy].to_s == "member_oidc"
+      message = sanitized_failure_message(params[:message])
+      Rails.logger.error("Member OIDC authentication failed: #{message}")
+      redirect_to new_user_session_path, alert: t("auth.member_oidc.authentication_failed")
+    else
+      message = sanitized_failure_message(params[:message])
+      Rails.logger.error("SSO authentication failed: #{message}")
+      redirect_to root_path, alert: t("auth.sso.authentication_failed")
+    end
   end
 
   # DELETE /auth/sso/logout

--- a/reporting-app/app/controllers/users/sessions_controller.rb
+++ b/reporting-app/app/controllers/users/sessions_controller.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  include SsoHelper
+
   layout "users"
   skip_after_action :verify_authorized
 
   def new
+    if member_oidc_member_auth_only?
+      redirect_to member_oidc_login_path and return
+    end
+
     @form = Users::NewSessionForm.new
   end
 

--- a/reporting-app/app/helpers/sso_helper.rb
+++ b/reporting-app/app/helpers/sso_helper.rb
@@ -10,4 +10,20 @@ module SsoHelper
     # SSO config not loaded (e.g., in tests without SSO setup)
     false
   end
+
+  # Member OIDC (citizen IdP) — see docs/architecture/staff-sso/member-sso.md
+  def member_oidc_enabled?
+    Rails.application.config.member_oidc[:enabled] == true
+  rescue NoMethodError
+    false
+  end
+
+  # When true, member sign-in URL redirects to member OIDC (no Cognito email/password on that page).
+  def member_oidc_member_auth_only?
+    return false unless member_oidc_enabled?
+
+    Rails.application.config.member_oidc[:member_auth_only] == true
+  rescue NoMethodError
+    false
+  end
 end

--- a/reporting-app/app/views/users/sessions/new.html.erb
+++ b/reporting-app/app/views/users/sessions/new.html.erb
@@ -5,11 +5,14 @@
     <%= t(".title") %>
   </h1>
 
-  <% if sso_enabled? %>
+  <% if member_oidc_enabled? %>
     <div class="margin-bottom-4">
-      <%= link_to t(".sso_button"), sso_login_path, class: "usa-button usa-button--outline width-full", data: { turbo: false } %>
+      <%= link_to t("auth.member_oidc.sign_in_button"),
+          member_oidc_login_path,
+          class: "usa-button usa-button--outline width-full",
+          data: { turbo: false } %>
       <p class="text-center margin-top-2 text-base">
-        <%= t(".sso_description") %>
+        <%= t("auth.member_oidc.sign_in_description") %>
       </p>
     </div>
 

--- a/reporting-app/config/initializers/sso.rb
+++ b/reporting-app/config/initializers/sso.rb
@@ -54,9 +54,12 @@ Rails.application.config.sso = {
 #   MEMBER_OIDC_CLAIM_EMAIL    - Claim key for email (default: "email")
 #   MEMBER_OIDC_CLAIM_NAME     - Claim key for name (default: "name")
 #   MEMBER_OIDC_CLAIM_UID     - Claim key for unique id (default: "sub")
+#   MEMBER_OIDC_MEMBER_AUTH_ONLY - When true with MEMBER_OIDC_ENABLED, unauthenticated visits to
+#                                  the member sign-in page redirect to the member OIDC flow (no email/password form).
 
 Rails.application.config.member_oidc = {
   enabled: ENV.fetch("MEMBER_OIDC_ENABLED", "false") == "true",
+  member_auth_only: ENV.fetch("MEMBER_OIDC_MEMBER_AUTH_ONLY", "false") == "true",
   claims: {
     email: ENV.fetch("MEMBER_OIDC_CLAIM_EMAIL", "email"),
     name: ENV.fetch("MEMBER_OIDC_CLAIM_NAME", "name"),

--- a/reporting-app/config/locales/defaults/en.yml
+++ b/reporting-app/config/locales/defaults/en.yml
@@ -52,6 +52,8 @@ en:
       javascript_required: "JavaScript is required for automatic redirect. Click below to continue."
       continue_button: "Continue to Sign In"
     member_oidc:
+      sign_in_button: "Sign in with your account"
+      sign_in_description: "Use the account you use for other state services."
       login_success: "Successfully signed in"
       authentication_failed: "Authentication failed. Please try again."
       not_enabled: "Sign in with your account is not available."

--- a/reporting-app/config/locales/views/users/en.yml
+++ b/reporting-app/config/locales/views/users/en.yml
@@ -34,8 +34,6 @@ en:
         submit: "Log in"
         no_account: "Don't have an account?"
         create_account: "Create your account now"
-        sso_button: "Sign in with State Account"
-        sso_description: "Use your state employee credentials"
         or_divider: "or"
       challenge:
         title: "Enter your authentication app code"

--- a/reporting-app/spec/controllers/users/sessions_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/sessions_controller_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe Users::SessionsController do
 
       expect(response.body).to have_selector("h1", text: /sign in/i)
     end
+
+    context "when member OIDC is the only configured member auth" do
+      before do
+        allow(Rails.application.config).to receive(:member_oidc).and_return(
+          {
+            enabled: true,
+            member_auth_only: true,
+            claims: { email: "email", name: "name", unique_id: "sub" }
+          }
+        )
+      end
+
+      it "redirects to member OIDC login" do
+        get :new, params: { locale: "en" }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.location).to match(/member_oidc\/login/)
+      end
+    end
   end
 
   describe "POST create" do

--- a/reporting-app/spec/helpers/sso_helper_spec.rb
+++ b/reporting-app/spec/helpers/sso_helper_spec.rb
@@ -53,4 +53,52 @@ RSpec.describe SsoHelper, type: :helper do
       end
     end
   end
+
+  describe "#member_oidc_enabled?" do
+    context "when member OIDC is enabled" do
+      before do
+        allow(Rails.application.config).to receive(:member_oidc).and_return({ enabled: true })
+      end
+
+      it "returns true" do
+        expect(helper.member_oidc_enabled?).to be true
+      end
+    end
+
+    context "when member OIDC is disabled" do
+      before do
+        allow(Rails.application.config).to receive(:member_oidc).and_return({ enabled: false })
+      end
+
+      it "returns false" do
+        expect(helper.member_oidc_enabled?).to be false
+      end
+    end
+  end
+
+  describe "#member_oidc_member_auth_only?" do
+    context "when member OIDC is enabled and member_auth_only is true" do
+      before do
+        allow(Rails.application.config).to receive(:member_oidc).and_return(
+          { enabled: true, member_auth_only: true }
+        )
+      end
+
+      it "returns true" do
+        expect(helper.member_oidc_member_auth_only?).to be true
+      end
+    end
+
+    context "when member OIDC is disabled" do
+      before do
+        allow(Rails.application.config).to receive(:member_oidc).and_return(
+          { enabled: false, member_auth_only: true }
+        )
+      end
+
+      it "returns false" do
+        expect(helper.member_oidc_member_auth_only?).to be false
+      end
+    end
+  end
 end

--- a/reporting-app/spec/requests/auth/sso_redirect_and_member_oidc_spec.rb
+++ b/reporting-app/spec/requests/auth/sso_redirect_and_member_oidc_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe "OIDC redirect URI and member_oidc config (Story 1)", type: :requ
   end
 
   describe "Rails.application.config.member_oidc" do
-    it "has enabled and claims keys" do
+    it "has enabled, member_auth_only, and claims keys" do
       config = Rails.application.config.member_oidc
-      expect(config).to include(:enabled, :claims)
+      expect(config).to include(:enabled, :member_auth_only, :claims)
     end
 
     it "has enabled false by default (MEMBER_OIDC_ENABLED not set)" do

--- a/reporting-app/spec/requests/auth/sso_spec.rb
+++ b/reporting-app/spec/requests/auth/sso_spec.rb
@@ -162,6 +162,17 @@ RSpec.describe "Auth::Sso", type: :request do
       follow_redirect!
       expect(response.body).to include("Authentication failed")
     end
+
+    context "when OmniAuth failure is for member_oidc" do
+      it "redirects to member sign-in with member OIDC message" do
+        get "/auth/failure", params: { message: "invalid_credentials", strategy: "member_oidc" }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.location).to match(/sign_in/)
+        follow_redirect!
+        expect(response.body).to include("Authentication failed")
+      end
+    end
   end
 
   describe "DELETE /auth/sso/logout" do

--- a/reporting-app/spec/support/sso_helpers.rb
+++ b/reporting-app/spec/support/sso_helpers.rb
@@ -126,6 +126,7 @@ module SsoHelpers
   def mock_member_oidc_config(overrides = {})
     {
       enabled: true,
+      member_auth_only: false,
       claims: {
         email: "email",
         name: "name",

--- a/reporting-app/spec/views/users/sessions/new.html.erb_spec.rb
+++ b/reporting-app/spec/views/users/sessions/new.html.erb_spec.rb
@@ -15,27 +15,27 @@ RSpec.describe "users/sessions/new", type: :view do
     )
   end
 
-  context "when SSO is enabled" do
+  context "when member OIDC is enabled" do
     before do
       allow(view).to receive_messages(
-        sso_enabled?: true,
-        sso_login_path: "/sso/login"
+        member_oidc_enabled?: true,
+        member_oidc_login_path: "/member_oidc/login"
       )
     end
 
-    it "displays the SSO login button" do
+    it "displays the member OIDC login button" do
       render
 
       expect(rendered).to have_link(
-        I18n.t("users.sessions.new.sso_button"),
-        href: "/sso/login"
+        I18n.t("auth.member_oidc.sign_in_button"),
+        href: "/member_oidc/login"
       )
     end
 
-    it "displays the SSO description" do
+    it "displays the member OIDC description" do
       render
 
-      expect(rendered).to have_content(I18n.t("users.sessions.new.sso_description"))
+      expect(rendered).to have_content(I18n.t("auth.member_oidc.sign_in_description"))
     end
 
     it "displays the divider" do
@@ -52,21 +52,21 @@ RSpec.describe "users/sessions/new", type: :view do
     end
   end
 
-  context "when SSO is disabled" do
+  context "when member OIDC is disabled" do
     before do
-      allow(view).to receive(:sso_enabled?).and_return(false)
+      allow(view).to receive(:member_oidc_enabled?).and_return(false)
     end
 
-    it "does not display the SSO login button" do
+    it "does not display the member OIDC login button" do
       render
 
-      expect(rendered).not_to have_link(I18n.t("users.sessions.new.sso_button"))
+      expect(rendered).not_to have_link(I18n.t("auth.member_oidc.sign_in_button"))
     end
 
-    it "does not display the SSO description" do
+    it "does not display the member OIDC description" do
       render
 
-      expect(rendered).not_to have_content(I18n.t("users.sessions.new.sso_description"))
+      expect(rendered).not_to have_content(I18n.t("auth.member_oidc.sign_in_description"))
     end
 
     it "does not display the divider" do


### PR DESCRIPTION
# PR Summary: Member SSO – Story 4 (Routes and Member Login UI)

## Overview

Implements **Story 4** from the [Member SSO Implementation Stories](../architecture/staff-sso/member-sso-stories.md): member-facing sign-in discovers **citizen IdP** sign-in when configured, optional **OIDC-only** mode that skips the email/password page, and correct **OmniAuth failure** handling for the `member_oidc` strategy via the shared `/auth/failure` route.

**Story:** As a **member**, I want a “Sign in with your account” option on the member login page when my state configures a citizen IdP so that I can use one account for OSCER and other services.

## Changes

### Routes (Story 3; unchanged in this story)

Member OIDC routes were added in Story 3 and remain the integration point for the new UI:

- `member_oidc_login` → `auth/member_oidc#new`
- `member_oidc_callback` / `member_oidc_failure` as before

## Implementation Details

### Member login page

- **Dual mode:** `MEMBER_OIDC_ENABLED` (without “auth only”) → button to `member_oidc_login_path` plus email/password and registration links.
- **OIDC-only mode:** `MEMBER_OIDC_ENABLED=true` and `MEMBER_OIDC_MEMBER_AUTH_ONLY=true` → `GET` Devise sign-in redirects straight to `member_oidc_login_path` (no password form on that URL).

### OmniAuth failures

OmniAuth uses `GET /auth/failure` with query params (e.g. `message`, `strategy`). `Auth::SsoController#failure` branches on `strategy == "member_oidc"` so members get the member flash copy and land on `new_user_session_path` instead of `root_path` with staff SSO messaging.

### Environment variables

| Variable | Purpose |
|----------|---------|
| `MEMBER_OIDC_ENABLED` | Enables member OIDC (existing) |
| `MEMBER_OIDC_MEMBER_AUTH_ONLY` | When `true`, member sign-in URL redirects to member OIDC flow only |


## Acceptance Criteria (Story 4)

| Criterion | Status |
|-----------|--------|
| Routes for member OIDC login / callback / failure | Done (Story 3); this PR completes UI + failure + auth-only redirect |
| Member login shows generic “Sign in with your account” when member OIDC enabled | Done (`auth.member_oidc.sign_in_*`) |
| OIDC control hidden when member OIDC disabled | Done |
| Email/password + OIDC visible when both Cognito and member OIDC are enabled (non–auth-only) | Done |
| Bypass member login when OIDC is the only member auth (`MEMBER_OIDC_MEMBER_AUTH_ONLY`) | Done |

## How to Test

```bash
cd reporting-app
bundle exec rspec \
  spec/helpers/sso_helper_spec.rb \
  spec/views/users/sessions/new.html.erb_spec.rb \
  spec/controllers/users/sessions_controller_spec.rb \
  spec/requests/auth/sso_spec.rb \
  spec/requests/auth/sso_redirect_and_member_oidc_spec.rb
```

Manual smoke:

1. Enable `MEMBER_OIDC_ENABLED` (and IdP env vars); open member sign-in → see OIDC button and password form.
2. Set `MEMBER_OIDC_MEMBER_AUTH_ONLY=true` → open member sign-in → redirect to `/member_oidc/login` auto-submit flow.


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->