### PR TITLE
Fix the infra Readme

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -89,19 +89,6 @@ Generally, you should use the Make targets or the underlying bin scripts, but yo
 
 To set up this project for the first time (i.e., it has never been deployed to the target AWS account):
 
-<<<<<<< before updating
-1. [Review and optionally update your project configuration](/infra/project-config/main.tf) <!-- markdown-link-check-disable-line -->
-2. [Set up infrastructure developer tools](/docs/infra/set-up-infrastructure-tools.md)
-3. [Set up AWS account](/docs/infra/set-up-aws-account.md)
-4. [Set up the virtual network (VPC)](/docs/infra/set-up-network.md)
-5. Optionally [set up system notifications for CI/CD workflows](/docs/infra/system-notifications.md)
-6. For each application:
-    1. [Set up application build repository](/docs/infra/set-up-app-build-repository.md)
-    2. [Set up application database](/docs/infra/set-up-database.md)
-    3. [Set up application environment](/docs/infra/set-up-app-env.md)
-    4. [Configure environment variables and secrets](/docs/infra/environment-variables-and-secrets.md)
-    5. [Set up background jobs](/docs/infra/background-jobs.md)
-=======
 1. Make sure you have an application that meets [the application requirements for using this infrastructure](https://github.com/navapbc/template-infra/blob/main/template-only-docs/application-requirements.md).
 
    **Tip:** You don't need an actual application to deploy until you want to set up the application environment (the last step).
@@ -129,7 +116,6 @@ To set up this project for the first time (i.e., it has never been deployed to t
 ### Add an application to an existing repo
 
 [Use the Platform CLI to add another application to an existing repo](https://navapbc.github.io/platform-cli/adding-an-app/)
->>>>>>> after updating
 
 ### 🆕 New developer
 


### PR DESCRIPTION
## Ticket

Resolves [OSCER-424](https://github.com/navapbc/oscer/issues/424)

## Changes

- Removed accidentally committed Git merge conflict markers and duplicate “before updating” steps from `infra/README.md`, leaving the intended “Getting started” instructions intact.

## Context for reviewers

- This was a bad merge artifact (`<<<<<<<` / `=======` / `>>>>>>>`) in the infra README; no Terraform or application code changes.
- Here is the commit that I think confirms I am removing the right section and lines up with what it looks like in the infra-template. https://github.com/navapbc/template-infra/commit/5ca16d3403053e42c52e123563d6adf0e3318335

## Testing

- Open `infra/README.md` in the repo and confirm the “Getting started” section renders as normal Markdown with no conflict markers and a single coherent numbered list.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->