### PR TITLE
Force reporting period step if no reporting period for activity report application form

### DIFF
--- a/reporting-app/app/controllers/activity_report_application_forms_controller.rb
+++ b/reporting-app/app/controllers/activity_report_application_forms_controller.rb
@@ -18,7 +18,7 @@ class ActivityReportApplicationFormsController < ApplicationController
 
   # GET /activity_report_application_forms/1 or /activity_report_application_forms/1.json
   def show
-    edit if @activity_report_application_form.reporting_periods.empty?
+    redirect_to edit_activity_report_application_form_path(@activity_report_application_form) if @activity_report_application_form.reporting_periods.empty?
   end
 
   # GET /activity_report_application_forms/new
@@ -57,7 +57,7 @@ class ActivityReportApplicationFormsController < ApplicationController
     @certification_requirements = @certification_case.certification.certification_requirements
 
     respond_to do |format|
-      format.html { render :edit }
+      format.html
       format.json { render json: @activity_report_application_form.as_json }
     end
   end

--- a/reporting-app/app/controllers/activity_report_application_forms_controller.rb
+++ b/reporting-app/app/controllers/activity_report_application_forms_controller.rb
@@ -18,6 +18,7 @@ class ActivityReportApplicationFormsController < ApplicationController
 
   # GET /activity_report_application_forms/1 or /activity_report_application_forms/1.json
   def show
+    edit if @activity_report_application_form.reporting_periods.empty?
   end
 
   # GET /activity_report_application_forms/new
@@ -56,7 +57,7 @@ class ActivityReportApplicationFormsController < ApplicationController
     @certification_requirements = @certification_case.certification.certification_requirements
 
     respond_to do |format|
-      format.html
+      format.html { render :edit }
       format.json { render json: @activity_report_application_form.as_json }
     end
   end

--- a/reporting-app/spec/requests/activity_report_application_forms_spec.rb
+++ b/reporting-app/spec/requests/activity_report_application_forms_spec.rb
@@ -74,8 +74,7 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
       it 'has user submit reporting periods' do
         activity_report_application_form = ActivityReportApplicationForm.create! valid_db_attributes.merge(reporting_periods: [])
         get activity_report_application_form_url(activity_report_application_form)
-        expect(response).to be_successful
-        expect(response.body).to include("Choose which month to report")
+        expect(response).to redirect_to(edit_activity_report_application_form_url(activity_report_application_form))
       end
     end
 

--- a/reporting-app/spec/requests/activity_report_application_forms_spec.rb
+++ b/reporting-app/spec/requests/activity_report_application_forms_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
       expect(response).to be_client_error
     end
 
+    context "when user skipped edit page" do
+      it 'has user submit reporting periods' do
+        activity_report_application_form = ActivityReportApplicationForm.create! valid_db_attributes.merge(reporting_periods: [])
+        get activity_report_application_form_url(activity_report_application_form)
+        expect(response).to be_successful
+        expect(response.body).to include("Choose which month to report")
+      end
+    end
+
     context "with ex_parte activities" do
       let(:member_id) { "MEMBER123" }
       let(:certification_with_member) do
@@ -186,7 +195,7 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
           expect(response).to redirect_to(edit_activity_report_application_form_url(ActivityReportApplicationForm.last))
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include("Select reporting period")
+          expect(response.body).to include("Choose which month to report")
         end
       end
 
@@ -235,6 +244,7 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
     it "renders a successful response" do
       get edit_activity_report_application_form_url(activity_report_application_form)
       expect(response).to be_successful
+      expect(response.body).to include("Choose which month to report")
     end
 
     it "renders an error response for non-owning user" do


### PR DESCRIPTION
## Ticket

Resolves [OSCER-238](https://github.com/navapbc/oscer/issues/238)
## Changes

- ActivityReportApplicationFormsController#show renders edit if no reporting periods

## Context for reviewers

Update all spec for /edit to use "Choose which month to report" instead of "Select reporting period" because "Select reporting period" in step header.

## Testing

`make lint` and `make test` pass

https://github.com/user-attachments/assets/423ec49a-2aab-46cb-9a0e-bc71872f6be6



<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->