### PR TITLE
Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/build-release-image/action.yml
+++ b/.github/actions/build-release-image/action.yml
@@ -26,11 +26,11 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Restore from Cache
       id: cache-buildx
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /tmp/.buildx-cache
         key: container-build-${{ inputs.app_name }}-${{ inputs.commit_hash }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -89,7 +89,7 @@ runs:
         echo "AWS_REGION=${aws_region}" >> "$GITHUB_ENV"
       shell: bash
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -15,7 +15,7 @@ runs:
         echo "terraform_version=${terraform_version}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Set up Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: ${{ steps.get-terraform-version.outputs.terraform_version }}
         terraform_wrapper: false

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,7 +36,7 @@ jobs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -59,7 +59,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/check-ci-cd-auth.yml
+++ b/.github/workflows/check-ci-cd-auth.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -19,7 +19,7 @@ jobs:
       root_module_configs: ${{ steps.collect-infra-deploy-status-check-configs.outputs.root_module_configs }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Collect root module configurations
         id: collect-infra-deploy-status-check-configs
@@ -47,7 +47,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # This is the GitHub Actions-friendly port of the linter used in the Makefile.
       - uses: tcort/github-action-markdown-link-check@v1

--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
       - name: Cache Node.js dependencies
         id: cache-node
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: e2e/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download actionlint
         id: get_actionlint
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Shellcheck
         run: make infra-lint-scripts
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -76,9 +76,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run tfsec check
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0

--- a/.github/workflows/ci-reporting-app-infra-service.yml
+++ b/.github/workflows/ci-reporting-app-infra-service.yml
@@ -40,14 +40,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.version || github.ref }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "infra/test/go.mod"
 

--- a/.github/workflows/ci-reporting-app-openapi.yml
+++ b/.github/workflows/ci-reporting-app-openapi.yml
@@ -27,7 +27,7 @@ jobs:
       # Pass through env so shell steps are not script-injection vectors (github.head_ref in run:)
       HEAD_REF: ${{ github.head_ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Use PR head SHA so fork PRs work (branch name from head_ref may not exist on upstream)
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci-reporting-app.yml
+++ b/.github/workflows/ci-reporting-app.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # https://github.com/docker/compose/issues/1973
       - name: Create required env files
@@ -38,7 +38,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: make init-container
       - run: make precompile-assets
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: reporting-app/coverage/

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       service_endpoint: ${{ steps.deploy-release.outputs.service_endpoint }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -55,7 +55,7 @@ jobs:
           ls -R ./e2e/blob-report || echo "blob-report directory not found"
 
       - name: Upload blob report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: blob-report-shard-${{ matrix.shard }}
           path: ./e2e/blob-report
@@ -69,16 +69,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
       - name: Cache Node.js dependencies
         id: cache-node
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: e2e/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('e2e/package-lock.json') }}
@@ -88,7 +88,7 @@ jobs:
         run: make e2e-setup-ci
 
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./e2e/blob-report
           pattern: blob-report-shard-*
@@ -108,7 +108,7 @@ jobs:
           ls -R ./e2e/playwright-report || echo "No report found in ./e2e/playwright-report"
 
       - name: Upload merged HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-test-report
           path: ./e2e/playwright-report

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -41,7 +41,7 @@ jobs:
       service_endpoint: ${{ steps.update-environment.outputs.service_endpoint }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -27,7 +27,7 @@ jobs:
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/scan-orphaned-environments.yml
+++ b/.github/workflows/scan-orphaned-environments.yml
@@ -18,7 +18,7 @@ jobs:
       app_names: ${{ steps.get-app-names.outputs.app_names }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get app names
         id: get-app-names
@@ -48,7 +48,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/send-system-notification.yml
+++ b/.github/workflows/send-system-notification.yml
@@ -27,7 +27,7 @@ jobs:
     name: Notify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -63,7 +63,7 @@ jobs:
 
       - name: Send Slack message
         if: ${{ steps.get-channel-type.outputs.channel_type == 'slack' }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets[env.SLACK_TOKEN_SECRET_NAME] }}

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: hadolint-config
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: trivy-ignore
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: grype-config
@@ -102,7 +102,7 @@ jobs:
           app_name: ${{ inputs.app_name }}
 
       - name: Run Anchore vulnerability scan
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@v7
         with:
           image: ${{ steps.build-release-image.outputs.image }}
           output-format: table
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/first-file
         id: dockle-config


### PR DESCRIPTION
## Summary

GitHub will force Node.js 24 on Actions runners starting June 2, 2026 and remove Node.js 20 entirely on September 16, 2026. All 12 Node.js-based actions across 20 workflow files and 3 composite actions have been upgraded to their latest major versions with Node 24 support.

### Actions upgraded

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `aws-actions/configure-aws-credentials` | v4 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `hashicorp/setup-terraform` | v2 | v4 |
| `slackapi/slack-github-action` | v2.0.0 | v3.0.1 |
| `anchore/scan-action` | v6 | v7 |

### Not affected (Docker/composite-based)

checkov-action, hadolint-action, dockle-action, markdown-link-check — no Node.js runtime dependency.

### Breaking change review

- **checkout v6**: Credential persistence moved to separate file. `ci-reporting-app-openapi.yml` does `git push` after checkout — should work via `credential.helper` but monitoring on first run.
- **setup-node v6**: Auto-caching only activates with `packageManager` in `package.json` (not present). No conflict with explicit cache steps.
- **upload-artifact v7 / download-artifact v8**: `e2e-tests.yml` uses `merge-multiple` pattern download, unaffected by path behavior change in v5.
- **setup-terraform v4**: `terraform_wrapper: false` bypasses the STDOUT/STDERR change.
- **slack-github-action v3.0.1**: Web API method/token/payload pattern unchanged.
- **anchore/scan-action v7**: Grype update may report different findings but no `fail-build` threshold is set. `.grype.yml` uses standard config options.

## Test plan

- [ ] CI passes on this PR (covers: ci-reporting-app, ci-infra, ci-e2e-static-checks, ci-docs, ci-reporting-app-openapi, ci-reporting-app-infra-service)
- [ ] Monitor `ci-reporting-app-openapi` specifically for git push credential behavior
- [ ] After merge: verify deploy, e2e, vulnerability-scans, and notification workflows on next trigger

Resolves #436 

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->