### PR TITLE
Configure Dependabot for automated dependency monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,26 @@ updates:
       major:
         update-types: ["major"]
 
+  - package-ecosystem: "docker"
+    directory: "/reporting-app"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
+  - package-ecosystem: "docker"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
   - package-ecosystem: "terraform"
     directory: "/infra"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
+  - package-ecosystem: "bundler"
+    directory: "/reporting-app"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
+  - package-ecosystem: "npm"
+    directory: "/reporting-app"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]
+
+  - package-ecosystem: "terraform"
+    directory: "/infra"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+      major:
+        update-types: ["major"]


### PR DESCRIPTION
## Summary

OSCER has no automated dependency monitoring. This adds a Dependabot configuration covering all dependency ecosystems in the repo.

### Ecosystems configured

| Ecosystem | Directory | Schedule |
|-----------|-----------|----------|
| `github-actions` | `.github/` | Weekly |
| `bundler` | `reporting-app/` | Weekly |
| `npm` | `reporting-app/` | Weekly |
| `npm` | `e2e/` | Weekly |
| `docker` | `reporting-app/` | Weekly |
| `docker` | `e2e/` | Weekly |
| `terraform` | `infra/` | Monthly |

### Grouping strategy

Each ecosystem groups updates into two PRs:
- **minor-and-patch** — safe to review and merge quickly
- **major** — requires breaking change review, but visible for planning

This keeps PR noise low (at most 2 PRs per ecosystem) while ensuring major version bumps don't go unnoticed.

### Docker ecosystem

Added per reviewer feedback. Monitors Dockerfile base images (`ruby` in reporting-app, `playwright` in e2e) for version updates. This addresses a gap where template repo syncs were failing silently on conflicts, leaving base image versions behind.

### Context

Six other navapbc repos already use Dependabot (grants-ingest, arpa-reporter, labs-asp, nava-finchy-nj, mass-eec, usedgov-fsa-observability). This config follows similar patterns. See the dependency hygiene epic (#435) for full context.

Resolves #430

## Test plan

- [ ] Dependabot starts opening PRs after merge (typically within 24 hours)
- [ ] Verify grouped PRs appear as expected (not individual PRs per dependency)
- [ ] Team triages first round of Dependabot PRs

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->