### PR TITLE
Migrate from tfsec to Trivy for infrastructure scanning

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -94,18 +94,39 @@ jobs:
           framework: terraform
           quiet: true # only displays failed checks
 
-  check-compliance-with-tfsec:
-    name: Check compliance with tfsec
+  check-compliance-with-trivy:
+    name: Check IaC compliance with Trivy
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      pull-requests: write
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run tfsec check
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+      - name: Run Trivy IaC scan
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
-          github_token: ${{ github.token }}
+          scan-type: config
+          scan-ref: infra
+          format: table
+          exit-code: 1
+          severity: HIGH,CRITICAL
+
+      - name: Run Trivy IaC scan (SARIF for code scanning)
+        if: always() && github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          scan-type: config
+          scan-ref: infra
+          format: sarif
+          output: trivy-iac-results.sarif
+          severity: HIGH,CRITICAL
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && github.event_name == 'pull_request'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-iac-results.sarif
+          category: trivy-iac

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -65,7 +65,7 @@ jobs:
           app_name: ${{ inputs.app_name }}
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: image
           image-ref: ${{ steps.build-release-image.outputs.image }}


### PR DESCRIPTION
## Summary

tfsec has been deprecated and merged into Trivy. The `aquasecurity/tfsec-pr-commenter-action` hasn't been updated since 2023. This PR replaces it with `trivy-action` configured for IaC scanning.

### Changes

- **`ci-infra.yml`**: Replace `check-compliance-with-tfsec` job with `check-compliance-with-trivy`. Trivy scans `infra/` for Terraform misconfigurations, fails on HIGH/CRITICAL findings, and uploads SARIF results to GitHub Security for inline PR annotations.
- **`vulnerability-scans.yml`**: Pin existing `trivy-action` from `@master` to `@v0.35.0` to eliminate supply-chain risk.

### How the new scan works

1. **Table output** — human-readable findings in CI logs. Job fails on HIGH/CRITICAL severity (`exit-code: 1`).
2. **SARIF upload** (PR only) — uploads findings to GitHub Security tab, which shows inline annotations on changed files. This replaces tfsec's PR comment approach with better persistence and visibility.

### Note on permissions

The job permission changes from `pull-requests: write` (tfsec commented on PRs) to `security-events: write` (SARIF upload uses the code scanning API).

Resolves #429

## Test plan

- [ ] CI `check-compliance-with-trivy` job runs successfully on this PR
- [ ] Verify Trivy IaC findings appear in the Security tab (if any findings exist)
- [ ] Compare Trivy findings against a manual tfsec run on `infra/` to verify equivalent coverage
- [ ] Confirm `trivy-action@v0.35.0` pin works in vulnerability-scans workflow

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->