### PR TITLE
Add spacing between activity type and reporting method sections

### DIFF
--- a/reporting-app/app/views/activities/new.html.erb
+++ b/reporting-app/app/views/activities/new.html.erb
@@ -10,7 +10,7 @@
     </div>
   <% end %>
 
-  <p><strong><%= t(".reporting_method_help_text") %></strong></p>
+  <p class="margin-top-4"><strong><%= t(".reporting_method_help_text") %></strong></p>
   <div class="usa-form__item">
     <%= f.radio_button :activity_type, "work_activity", { label: t(".hours_label"), tile: true } %>
   </div>


### PR DESCRIPTION
Add USWDS margin-top-4 utility class to the reporting method help text
on the activity type selection page. This creates visual separation
between the two radio button groups (activity category and reporting
method), improving readability per usability research findings.

Part of #246

## screenshots
**Before:**
<img width="603" height="728" alt="Screenshot 2026-04-14 at 1 30 55 PM" src="https://github.com/user-attachments/assets/c5439788-dfd7-4b2c-8f7e-e2b226d32670" />

**After:** 
<img width="606" height="621" alt="Screenshot 2026-04-14 at 1 30 36 PM" src="https://github.com/user-attachments/assets/9a38a8a8-4516-4f28-a005-257c95142c42" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->