### PR TITLE
Skip broken checkov and tfsec Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # tfsec is deprecated (migrated to Trivy); the action can no longer download binaries.
+      # Remove after migrating to Trivy. See https://github.com/navapbc/oscer/issues/456
+      - dependency-name: "aquasecurity/tfsec-pr-commenter-action"
+      # checkov v12.3096.0+ introduces 14 new findings against existing infra.
+      # Remove after addressing findings. See https://github.com/navapbc/oscer/issues/457
+      - dependency-name: "bridgecrewio/checkov-action"
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]


### PR DESCRIPTION
## Ticket

Part of #451 (unblocking Dependabot grouped PRs)

## Changes

- Added `ignore` rules in `.github/dependabot.yml` for `aquasecurity/tfsec-pr-commenter-action` and `bridgecrewio/checkov-action`
- Each ignore rule includes a comment linking to its tracking issue

## Context for reviewers

Dependabot PR #451 bumps 4 GitHub Actions in the minor-and-patch group. Two of the upgrades break CI:

**tfsec** (`v1.2.0` → `v1.3.1`): tfsec is deprecated (migrated to Trivy). The action tries to download tfsec binaries from `aquasecurity/tfsec/releases/latest`, but the release assets are gone. Fails with `jq: error ... Cannot iterate over null`. Tracked in #456.

**checkov** (`v12.2296.0` → `v12.3096.0`): The new version introduces 14 new compliance findings against existing infra (KMS key policies, CloudWatch retention, deprecated Lambda runtime, etc.). The infra hasn't changed — the scanner got stricter. Tracked in #457.

The other two actions in the group (hadolint, dockle) are safe to upgrade but can't be merged independently because Dependabot bundles them. Ignoring the broken ones lets future grouped PRs proceed without being blocked.

## Testing

- CI should pass (no infra code changes, only dependabot config)
- Verify: future Dependabot PRs for `github-actions` group exclude checkov and tfsec

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->