### PR TITLE
Clean up Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     ignore:
       # tfsec is deprecated (migrated to Trivy); the action can no longer download binaries.
       # Remove after migrating to Trivy. See https://github.com/navapbc/oscer/issues/456
@@ -21,9 +22,14 @@ updates:
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+        # Rails uses 4-segment versioning (e.g. 7.2.3.1) which caused Dependabot to
+        # misclassify a 7→8 major bump as minor. Excluding it from the group ensures
+        # Rails updates come as standalone PRs for intentional review.
+        exclude-patterns: ["rails"]
       major:
         update-types: ["major"]
 
@@ -31,6 +37,7 @@ updates:
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -41,6 +48,7 @@ updates:
     directory: "/e2e"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -51,6 +59,7 @@ updates:
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -61,6 +70,7 @@ updates:
     directory: "/e2e"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -68,9 +78,10 @@ updates:
         update-types: ["major"]
 
   - package-ecosystem: "terraform"
-    directory: "/infra"
+    directory: "/infra/reporting-app/service"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 3
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

Three changes to reduce noise and fix broken config:

- **Exclude Rails from bundler minor-and-patch group.** Dependabot misclassified the 7→8 major bump as minor due to Rails' 4-segment versioning (7.2.3.1). Rails updates now come as standalone PRs for intentional review while remaining visible in the major group.

- **Fix Terraform directory** from `/infra` to `/infra/reporting-app/service`, which is where the `.terraform.lock.hcl` actually lives. The previous entry was a no-op.

- **Add `open-pull-requests-limit: 3`** per ecosystem (down from the default of 5). With 7 ecosystem entries the default allows up to 35 concurrent Dependabot PRs.

## Test plan

- [ ] After merge, close PR #455 (contains Rails 7→8 misclassification) and verify Dependabot reopens a new bundler minor-and-patch PR without Rails
- [ ] Verify Rails minor/patch updates appear as standalone PRs on next Dependabot run
- [ ] Verify Terraform Dependabot entry detects lock file changes at the new path

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->