### PR TITLE
Fix Dependabot Rails group and ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # Rails uses 4-segment versioning (e.g. 7.2.3.1) which causes Dependabot to
+      # misclassify major bumps as minor — 7.2.3.1 → 8.1.3 landed in the minor-and-patch
+      # group despite being a major upgrade. Using a hard version ceiling rather than
+      # update-types because Dependabot's semver classification is unreliable for Rails.
+      # Remove this rule when ready to plan the Rails 8 migration.
+      - dependency-name: "rails"
+        versions: [">=8.0.0"]
     groups:
+      rails:
+        patterns: ["rails", "active*", "action*", "railties"]
       minor-and-patch:
         update-types: ["minor", "patch"]
-        # Rails uses 4-segment versioning (e.g. 7.2.3.1) which caused Dependabot to
-        # misclassify a 7→8 major bump as minor. Excluding it from the group ensures
-        # Rails updates come as standalone PRs for intentional review.
-        exclude-patterns: ["rails"]
       major:
         update-types: ["major"]
 


### PR DESCRIPTION
## Summary

Follow-up to #467. The `exclude-patterns` approach was cosmetic only — Dependabot still updated the Rails Gemfile constraint to 8.x inside the grouped PR (#470).

- **Replace `exclude-patterns` with a hard version ceiling** (`versions: [">=8.0.0"]`) that doesn't rely on Dependabot's semver classification, which is unreliable for Rails' 4-segment versioning
- **Add a `rails` group** (`rails`, `active*`, `action*`, `railties`) so all Rails sub-gems update together in a single PR, following the pattern used by Discourse and RubyGems.org

## Test plan

- [ ] After merge, close PR #470 (still contains Rails 8 bump) and verify Dependabot reopens a clean bundler PR without Rails 8
- [ ] Verify Rails sub-gems are grouped into their own PR on next Dependabot run

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->