### PR TITLE
Remove flaky apt-get update from e2e Docker image

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,8 +1,7 @@
 # Use the official Playwright image as a base
 FROM mcr.microsoft.com/playwright:v1.59.1-noble
 
-# Install make and any other necessary dependencies
-RUN apt-get update
+# Skip apt unless you need extra packages; `apt-get update` flakes when Ubuntu mirrors are mid-sync.
 
 # Set the working directory to the root of the project inside the Docker container
 WORKDIR /e2e


### PR DESCRIPTION
## Ticket

Resolves [[OSCER-472](https://github.com/navapbc/oscer/issues/472)]

## Changes

- Removed the `RUN apt-get update` step from `e2e/Dockerfile`. It did not install any packages afterward, so it only added a dependency on Ubuntu mirrors.
- Added a brief comment that we should avoid `apt` in this image unless we need extra packages, because `apt-get update` can fail intermittently when mirrors are mid-sync (“unexpected size … mirror sync in progress”).

## Context for reviewers

`docker build` for the e2e image was occasionally failing during `apt-get update` with hash/size mismatches from `archive.ubuntu.com`. That is a known transient mirror issue, not a bug in our Dockerfile. Since the Playwright base image already supports `npm ci` / `npm test` and we were not installing anything with `apt`, dropping the step removes the flake and slightly speeds cold builds.

If we later need system packages (for example `make`), we should combine `apt-get update` and `apt-get install` in one `RUN`, clear `/var/lib/apt/lists/*`, and consider retries or CI-level build retries.

## Testing

- From the repo root: `docker build -t oscer-e2e -f ./e2e/Dockerfile .` (or `make e2e-build` per the root `Makefile`).
- Confirmed the image builds without running `apt-get update` and that `e2e/Dockerfile` still copies `package.json` / `package-lock.json`, runs `npm ci`, and sets `CMD` to `npm test` as before.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->