### PR TITLE
Simplify Dependabot config: drop semver groups and ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,92 +4,52 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      # tfsec is deprecated (migrated to Trivy); the action can no longer download binaries.
-      # Remove after migrating to Trivy. See https://github.com/navapbc/oscer/issues/456
-      - dependency-name: "aquasecurity/tfsec-pr-commenter-action"
-      # checkov v12.3096.0+ introduces 14 new findings against existing infra.
-      # Remove after addressing findings. See https://github.com/navapbc/oscer/issues/457
-      - dependency-name: "bridgecrewio/checkov-action"
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
 
   - package-ecosystem: "bundler"
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      # Rails uses 4-segment versioning (e.g. 7.2.3.1) which causes Dependabot to
-      # misclassify major bumps as minor — 7.2.3.1 → 8.1.3 landed in the minor-and-patch
-      # group despite being a major upgrade. Using a hard version ceiling rather than
-      # update-types because Dependabot's semver classification is unreliable for Rails.
-      # Remove this rule when ready to plan the Rails 8 migration.
-      - dependency-name: "rails"
-        versions: [">=8.0.0"]
     groups:
       rails:
-        patterns: ["rails", "active*", "action*", "railties"]
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
+        patterns:
+          - "rails"
+          - "active*"
+          - "action*"
+          - "railties"
+      rubocop:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
+      rspec:
+        patterns:
+          - "rspec"
+          - "rspec-*"
+      aws-sdk:
+        patterns:
+          - "aws-sdk-*"
+          - "aws-actionmailer-*"
 
   - package-ecosystem: "npm"
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
 
   - package-ecosystem: "npm"
     directory: "/e2e"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
 
   - package-ecosystem: "docker"
     directory: "/reporting-app"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
 
   - package-ecosystem: "docker"
     directory: "/e2e"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]
 
   - package-ecosystem: "terraform"
     directory: "/infra/reporting-app/service"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-      major:
-        update-types: ["major"]


### PR DESCRIPTION
Follow-up to PR #474's post-mortem. The previous config used semver-based grouping (`minor-and-patch` / `major` via `update-types`) across all ecosystems plus `ignore` rules for Rails major bumps, tfsec, and checkov. PR #474 surfaced two problems that make this approach unreliable:

1. **Transitive cascade.** The bundler `minor-and-patch` group is vulnerable to it: a legitimate patch bump (turbo-rails 2.0.20 → 2.0.23) demanded a major bump of another gem (`railties >= 8.0.0`), and Bundler's resolver pulled Rails 8 into the minor-and-patch PR. This required a manual revert before #474 could merge.
2. **Half-broken ignore rule.** The `rails` `ignore` rule from PR #471 (`versions: [">=8.0.0"]`) did NOT prevent #474. Dependabot's `ignore` only excludes a gem from being *explicitly proposed*; Bundler can still pull an "ignored" version in as a transitive requirement.

## Changes

- Drop all semver groups (`minor-and-patch`, `major`) from every ecosystem. Everything arrives as individual PRs by default.
- Keep narrow plugin-family groups in bundler only: `rails`, `rubocop`, `rspec`, `aws-sdk`. These are the cases where grouping materially helps review ergonomics (security sub-gem patches, plugin-version coupling with core).
- Drop `ignore` rules (rails >= 8.0.0, tfsec, checkov). In the new individual-PR world, closing an unwanted PR is surgical with no collateral damage, so the value of codified ignores is minimal. Recurring tfsec/checkov PRs will be closed manually until the tracking issues (#456, #457) resolve.
- Drop `open-pull-requests-limit: 3`. The default (5) is fine.

## Trade-off

More individual PRs per week. Mostly up to date today, so the initial spike should be small. If volume proves overwhelming after 2–3 weeks, reintroduce a narrow `minor-and-patch` group for the noisiest ecosystem — but NOT for bundler without pairing Gemfile-level pins on cascade-prone gems like turbo-rails.

## When the cascade happens again

The playbook from #474 remains:

1. Check out the Dependabot branch locally.
2. Revert the Rails constraint in `Gemfile`.
3. `bundle install` (Bundler cascades the revert to any Rails-8-only transitive deps).
4. Commit and push back to the Dependabot branch.

## Test plan

- [ ] GitHub's Dependabot config validation (auto-run on `.github/dependabot.yml` change) passes.
- [ ] On the next Dependabot run (weekly, usually Monday), confirm: (a) rubocop/rspec/aws-sdk family bumps arrive as grouped PRs, (b) other gems arrive as individual PRs, (c) no PR contains Rails 8 (or if one does, apply the playbook above).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->