### PR TITLE
Fix e2e TypeScript 6 tsconfig (OSCER-502)

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -2,9 +2,10 @@
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
-    "baseUrl": ".",
     "target": "es2016",
     "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
## Ticket

Resolves [OSCER-502](https://github.com/navapbc/oscer/issues/502)

## Changes

- Updated `e2e/tsconfig.json` for TypeScript 6: removed deprecated `baseUrl` (unused without `paths`).
- Set `moduleResolution` to `NodeNext` and `types` to `["node"]` so `tsc --noEmit` succeeds and Node built-ins / `__dirname` in specs type-check under `module: NodeNext`.

## Context for reviewers

- TypeScript 6 fails the build with TS5101 when `baseUrl` is set; see [TypeScript 6 migration notes](https://aka.ms/ts6).
- Dropping `baseUrl` allows the compiler to reach program checks; `types: ["node"]` avoids latent `path` / `__dirname` errors under NodeNext.
- No runtime or Playwright behavior change—config only.

## Testing

- `cd e2e && npm ci && npm run type-check` — pass.
- CI: `make e2e-type-check-native` (or Docker `make e2e-type-check` when the e2e image is available).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->