### PR TITLE
Commit schema.rb dump alignment (Rails 8 + pg_catalog.plpgsql)

### DIFF
--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_31_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_31_000001) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
## Ticket

Resolves [OSCER-516](https://github.com/navapbc/oscer/issues/516)

## Changes

- Update `reporting-app/db/schema.rb` to match Rails 8 schema dump output: `ActiveRecord::Schema[8.0].define` and `enable_extension "pg_catalog.plpgsql"` instead of `[7.2]` / `"plpgsql"`.
- No migration version bump and no table or column DDL changes.

## Context for reviewers

- Pure housekeeping so `git status` stays clean after `make db-migrate` in Docker (Rails 8 app per `Gemfile`).
- Equivalent PostgreSQL extension; only the dumped literal changed.

## Testing

- `make db-migrate` (cwd `reporting-app/`): completes with no pending migrations; no extra diff on `schema.rb`.
- `make db-test-prepare`: succeeded.
- `make test`: 1869 examples, 0 failures.
- `make lint-ci`: no offenses.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->