### PR TITLE
OSCER-443 Upgrade Devise

### DIFF
--- a/reporting-app/.bundler-audit.yml
+++ b/reporting-app/.bundler-audit.yml
@@ -1,6 +1,0 @@
----
-ignore:
-  # Devise 4.9.4 → 5.0.3 (CVE-2026-32700): Confirmable "change email" race condition.
-  # Not exploitable — OSCER does not use Devise's confirmable module.
-  # Fix requires major version upgrade (4.x → 5.x) with auth flow testing.
-  - CVE-2026-32700

--- a/reporting-app/Gemfile
+++ b/reporting-app/Gemfile
@@ -67,7 +67,7 @@ gem "image_processing", "~> 1.14"
 
 # Authentication and Authorization
 gem "aws-sdk-cognitoidentityprovider", "~> 1.139"
-gem "devise"
+gem "devise", "~> 5.0"
 gem "jwt"
 gem "pundit"
 gem "pundit-matchers"

--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -177,10 +177,10 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     deep_merge (1.2.2)
-    devise (4.9.4)
+    devise (5.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
@@ -702,7 +702,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   csv
   debug
-  devise
+  devise (~> 5.0)
   dotenv
   factory_bot_rails
   faker (~> 3.7)


### PR DESCRIPTION
## Ticket

Resolves  #443 

## Changes

- Devise gem upgraded to 5.0+
- Bundle Audit ignore removed

## Context for reviewers

Devise 4.9.4 had a security issue that we were masking because we did not use that feature.

## Testing

### Local
- Logged in with new user
- Logged in with existing user
- Created user
- Logged out
- Forced unconfirmed
- Forced failure
- Forced MFA

### Sandbox
- Logged in as new staff
-- Verified sync'd attributes
-- Logged out
- Created Member User
-- Logged in
-- Logged out
-- Tested MFA

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->