### PR TITLE
Fix ci-e2e-static-checks cache key to invalidate on lockfile change

### DIFF
--- a/.github/workflows/ci-e2e-static-checks.yml
+++ b/.github/workflows/ci-e2e-static-checks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: e2e/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('e2e/package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node.outputs.cache-hit != 'true'


### PR DESCRIPTION
The cache key used `hashFiles('package-lock.json')` — a bare pattern that doesn't anchor to either lockfile in the repo (`e2e/` or `reporting-app/`). Combined with `actions/cache@v5`'s prefix-match fallback, every run served whatever blob was last written under any `Linux-node-*` key, so PR-time typechecks ran against stale `node_modules` regardless of lockfile state.

This is what silently hid the dependabot TS 5→6 bumps (#450, #486) at PR time and surfaced as `TS5101: Option 'baseUrl' is deprecated` failures on `main` days later, after the cache rotated to TS 6 contents. #503 patched the tsconfig but the cache-key bug remained.

Anchoring the path to `e2e/package-lock.json` matches the convention already in `e2e-tests.yml:84`. After merge, the next run will compute a fresh key, miss the cache, install lockfile-specified deps, and save under the new key — restoring the intended invalidation behavior.

Resolves #519

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->