### PR TITLE
OSCER- 464: Add external income options to demo form

### DIFF
--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -5,7 +5,8 @@ module Demo
     class CreateForm < BaseCreateForm
       EX_PARTE_SCENARIO_OPTIONS = [
         "No data", "Partially met work hours requirement", "Fully met work hours requirement",
-        "Meets age-based exemption requirement"
+        "Meets age-based exemption requirement", "Partially met income requirement",
+        "Fully met income requirement"
       ].freeze
 
       attribute :ex_parte_scenario, :enum, options: EX_PARTE_SCENARIO_OPTIONS
@@ -48,6 +49,18 @@ module Demo
           member_data.merge!(
             FactoryBot.build(
               :certification_member_data, :meets_age_based_exemption_requirement, cert_date: certification_date
+            ).attributes.compact
+          )
+        when "Partially met income requirement"
+          member_data.merge!(
+            FactoryBot.build(
+              :certification_member_data, :partially_met_income_requirement, cert_date: certification_date
+            ).attributes.compact
+          )
+        when "Fully met income requirement"
+          member_data.merge!(
+            FactoryBot.build(
+              :certification_member_data, :fully_met_income_requirement, cert_date: certification_date
             ).attributes.compact
           )
         end

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
     trait :partially_met_income_requirement do
       with_no_exemptions
       activities {
-        num_months.times.map { |i|
+        [
           {
             "type": "income",
             "category": "employment",
@@ -92,14 +92,14 @@ FactoryBot.define do
             "employer": "Acme Corp",
             "verification_status": "verified"
           }
-        }
+        ]
       }
     end
 
     trait :fully_met_income_requirement do
       with_no_exemptions
       activities {
-        num_months.times.map { |i|
+        [
           {
             "type": "income",
             "category": "employment",
@@ -110,7 +110,7 @@ FactoryBot.define do
             "employer": "Acme Corp",
             "verification_status": "verified"
           }
-        }
+        ]
       }
     end
 

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -78,6 +78,42 @@ FactoryBot.define do
       date_of_birth { cert_date - rand(1..18).years } # random age between 1 and 18 years old (eligible for age exemption)
     end
 
+    trait :partially_met_income_requirement do
+      with_no_exemptions
+      activities {
+        num_months.times.map { |i|
+          {
+            "type": "income",
+            "category": "employment",
+            "gross_income": IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2.0,
+            "period_start": cert_date.beginning_of_month,
+            "period_end": cert_date.end_of_month,
+            "source": "api",
+            "employer": "Acme Corp",
+            "verification_status": "verified"
+          }
+        }
+      }
+    end
+
+    trait :fully_met_income_requirement do
+      with_no_exemptions
+      activities {
+        num_months.times.map { |i|
+          {
+            "type": "income",
+            "category": "employment",
+            "gross_income": IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY,
+            "period_start": cert_date.beginning_of_month,
+            "period_end": cert_date.end_of_month,
+            "source": "api",
+            "employer": "Acme Corp",
+            "verification_status": "verified"
+          }
+        }
+      }
+    end
+
     trait :with_activities do
       activities {
         [

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -179,6 +179,66 @@ RSpec.describe "/demo/certifications", type: :request do
         )
       end
 
+      it "creates Certification with 'Partially met income requirement'" do
+        create_attrs = valid_request_attributes.merge({ ex_parte_scenario: "Partially met income requirement" })
+
+        expect {
+          post demo_certifications_url,
+              params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+          .and change(Income, :count).by(1)
+
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.case_number).to eq(create_attrs[:case_number])
+        expect(cert.certification_requirements.certification_date).to eq(Date.new(2025, 9, 25))
+        expect(cert.certification_requirements.due_date).not_to be_nil
+        expect(cert.member_name).to eq(Strata::Name.new({
+          "first": create_attrs[:member_name_first],
+          "last": create_attrs[:member_name_last]
+        }))
+        expect(cert.member_data.activities).not_to be_nil
+        expect(cert.member_data.activities.sum(&:gross_income)).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2.0)
+
+        activity = Income.last
+        expect(activity.member_id).to eq(cert.member_id)
+        expect(activity.category).to eq("employment")
+        expect(activity.gross_income).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2.0)
+        expect(activity.source_type).to eq("api")
+        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
+        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        expect(activity.source_id).to be_nil
+      end
+
+      it "creates Certification with 'Fully met income requirement'" do
+        create_attrs = valid_request_attributes.merge({ ex_parte_scenario: "Fully met income requirement" })
+
+        expect {
+          post demo_certifications_url,
+              params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+          .and change(Income, :count).by(1)
+
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.case_number).to eq(create_attrs[:case_number])
+        expect(cert.certification_requirements.certification_date).to eq(Date.new(2025, 9, 25))
+        expect(cert.certification_requirements.due_date).not_to be_nil
+        expect(cert.member_name).to eq(Strata::Name.new({
+          "first": create_attrs[:member_name_first],
+          "last": create_attrs[:member_name_last]
+        }))
+        expect(cert.member_data.activities).not_to be_nil
+        expect(cert.member_data.activities.sum(&:gross_income)).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY)
+
+        activity = Income.last
+        expect(activity.member_id).to eq(cert.member_id)
+        expect(activity.category).to eq("employment")
+        expect(activity.gross_income).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY)
+        expect(activity.source_type).to eq("api")
+        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
+        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        expect(activity.source_id).to be_nil
+      end
+
       it "creates a new Certification with 'Meets age-based exemption requirement' scenario and uses form DOB over scenario DOB" do
         create_attrs = valid_request_attributes.merge({ ex_parte_scenario: "Meets age-based exemption requirement" })
 


### PR DESCRIPTION
## Ticket

Resolves #464

## Changes

- Added partial and full ex parte options to demo form

## Context for reviewers

I followed the same pattern as for partial and full hours of using the member_data_factory to build the appropriate member data.

## Testing

Added spec cases.

### Form Screenshot

<img width="548" height="405" alt="Form" src="https://github.com/user-attachments/assets/bb022a7e-daad-4666-8aef-5902a2a05fcf" />

### Full case
Note: screenshot using #515 in order to show activity
<img width="976" height="281" alt="Full case" src="https://github.com/user-attachments/assets/ff0bf6e4-5c1b-442e-af15-2df5a3cddd28" />

### Partial case
Note: screenshot using #515 in order to show activity
<img width="976" height="281" alt="Partial case" src="https://github.com/user-attachments/assets/2b6c5709-bcc4-461b-be16-623e233245b9" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->