### PR TITLE
update income service to behave like hours service

### DIFF
--- a/docs/architecture/income-data/income-data.md
+++ b/docs/architecture/income-data/income-data.md
@@ -232,10 +232,11 @@ end
   "calculation_type": "income_based",
   "total_income": 620.0,
   "target_income": 580.0,
-  "income_by_source": { "income": 620.0, "activity": 0 },
+  "income_by_source": { "external": 620.0, "activity": 0 },
   "period_start": "2025-01-01",
   "period_end": "2025-01-31",
-  "income_ids": ["uuid1"],
+  "external_income_activity_ids": ["uuid1"],
+  "activity_ids": [],
   "calculation_method": "automated_income_intake"
 }
 ```
@@ -258,7 +259,7 @@ Mirror hours: income is saved **before** certification creation, and the busines
    - Other flows (e.g. hours-only paths elsewhere) may still use `DeterminedHoursMet` / `DeterminedHoursInsufficient`; see `NotificationsEventListener`.
 5. For existing certifications: `CalculateComplianceJob` (or equivalent) may call `IncomeComplianceDeterminationService.calculate(certification_id)` for silent income-only recalculation (no workflow events) when new income arrives.
 
-**Testing / QE:** `spec/services/community_engagement_check_service_spec.rb` runs **real** `CommunityEngagementCheckService.determine` with factories (primary integration coverage for the combined CE step). Many specs (e.g. `certification_case_spec`, `certification_business_process_spec`) **stub** `CommunityEngagementCheckService.determine` on `CertificationCreated` so bootstrap does not persist an accidental compliant CE determination or send mail. Combined CE income uses `aggregate_income_for_certification`; **`member_reported_income_total` is stubbed to `0` until OSCER-405**, so only external-sourced income counts toward the threshold today. For ops triage, log/monitor **`DeterminedCommunityEngagementMet`**, **`DeterminedCommunityEngagementInsufficient`**, and **`DeterminedCommunityEngagementActionRequired`** alongside legacy `DeterminedHours*` where applicable.
+**Testing / QE:** `spec/services/community_engagement_check_service_spec.rb` runs **real** `CommunityEngagementCheckService.determine` with factories (primary integration coverage for the combined CE step). Many specs (e.g. `certification_case_spec`, `certification_business_process_spec`) **stub** `CommunityEngagementCheckService.determine` on `CertificationCreated` so bootstrap does not persist an accidental compliant CE determination or send mail. Combined CE income uses `aggregate_income_for_certification`; **`member_reported_income[:total]` is stubbed to `0` until OSCER-405**, so only external-sourced income counts toward the threshold today. For ops triage, log/monitor **`DeterminedCommunityEngagementMet`**, **`DeterminedCommunityEngagementInsufficient`**, and **`DeterminedCommunityEngagementActionRequired`** alongside legacy `DeterminedHours*` where applicable.
 
 ---
 

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -255,12 +255,13 @@ class CertificationCase < Strata::Case
       total_income: income_data[:total_income].to_f,
       target_income: IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY.to_f,
       income_by_source: {
-        income: income_by[:income].to_f,
+        external: income_by[:external].to_f,
         activity: income_by[:activity].to_f
       },
       period_start: period_start&.respond_to?(:iso8601) ? period_start.iso8601 : period_start&.to_s,
       period_end: period_end&.respond_to?(:iso8601) ? period_end.iso8601 : period_end&.to_s,
-      income_ids: income_data[:income_ids],
+      external_income_activity_ids: income_data[:external_income_activity_ids],
+      activity_ids: income_data[:activity_ids],
       calculation_method: Determination::CALCULATION_METHOD_AUTOMATED_INCOME_INTAKE,
       calculated_at: Time.current.iso8601
     }

--- a/reporting-app/app/services/concerns/activity_aggregator.rb
+++ b/reporting-app/app/services/concerns/activity_aggregator.rb
@@ -8,6 +8,12 @@ module ActivityAggregator
     ExternalHourlyActivity.for_member(certification.member_id).within_period(lookback_period)
   end
 
+  def fetch_external_income_activities(certification, lookback_period)
+    return ExternalIncomeActivity.none unless certification&.member_id
+
+    ExternalIncomeActivity.for_member(certification.member_id).within_period(lookback_period)
+  end
+
   def fetch_member_activities(certification)
     certification_case = CertificationCase.find_by(certification_id: certification.id)
     return Activity.none unless certification_case
@@ -30,6 +36,13 @@ module ActivityAggregator
     {
       total: activities.sum(:hours).to_f,
       by_category: activities.group(:category).sum(:hours).transform_values(&:to_f),
+      ids: activities.pluck(:id)
+    }
+  end
+
+  def summarize_income(activities)
+    {
+      total: BigDecimal(activities.sum(:gross_income).to_s),
       ids: activities.pluck(:id)
     }
   end

--- a/reporting-app/app/services/income_compliance_determination_service.rb
+++ b/reporting-app/app/services/income_compliance_determination_service.rb
@@ -13,6 +13,8 @@ class IncomeComplianceDeterminationService
   TARGET_INCOME_MONTHLY = Rails.application.config.ce_compliance[:income_threshold_monthly]
 
   class << self
+    include ActivityAggregator
+
     # Shared threshold check for combined CE (+CommunityEngagementCheckService+) and +#calculate+.
     # @param total_income [Numeric]
     # @return [Boolean]
@@ -42,21 +44,22 @@ class IncomeComplianceDeterminationService
     # @param certification [Certification]
     # @return [Hash]
     def aggregate_income_for_certification(certification)
-      lookback = certification.certification_requirements.continuous_lookback_period
-      rows = ExternalIncomeActivity.for_member(certification.member_id).within_period(lookback)
+      lookback_period = certification.certification_requirements.continuous_lookback_period
+      external_income_activities = fetch_external_income_activities(certification, lookback_period)
 
-      ex_total = BigDecimal(rows.sum(:gross_income).to_s)
-      member_total = member_reported_income_total(certification)
+      external_income = summarize_income(external_income_activities)
+      member_income = member_reported_income(certification)
 
       {
-        total_income: ex_total + member_total,
+        total_income: external_income[:total] + member_income[:total],
         income_by_source: {
-          income: ex_total,
-          activity: member_total
+          external: external_income[:total],
+          activity: member_income[:total]
         },
-        income_ids: rows.pluck(:id),
-        period_start: lookback&.start,
-        period_end: lookback&.end
+        external_income_activity_ids: external_income[:ids],
+        activity_ids: member_income[:ids],
+        period_start: lookback_period&.start,
+        period_end: lookback_period&.end
       }
     end
 
@@ -69,9 +72,12 @@ class IncomeComplianceDeterminationService
     # Approved member-reported income (e.g. from activity report) — stub until modeled.
     # @param _certification [Certification]
     # @return [BigDecimal]
-    def member_reported_income_total(_certification)
+    def member_reported_income(_certification)
       # TODO(OSCER-405): Sum approved member income activities when that model/workflow exists.
-      BigDecimal("0")
+      {
+        total: BigDecimal("0"),
+        ids: []
+      }
     end
   end
 end

--- a/reporting-app/spec/mailers/member_mailer_spec.rb
+++ b/reporting-app/spec/mailers/member_mailer_spec.rb
@@ -139,8 +139,9 @@ RSpec.describe MemberMailer, type: :mailer do
     let(:income_data) do
       {
         total_income: BigDecimal("400"),
-        income_by_source: { income: BigDecimal("400"), activity: BigDecimal("0") },
-        income_ids: [],
+        income_by_source: { external: BigDecimal("400"), activity: BigDecimal("0") },
+        external_income_activity_ids: [],
+        activity_ids: [],
         period_start: Date.current,
         period_end: Date.current
       }

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -228,8 +228,9 @@ RSpec.describe CertificationCase, type: :model do
     let(:income_data) do
       {
         total_income: BigDecimal("400"),
-        income_by_source: { income: BigDecimal("400"), activity: BigDecimal("0") },
-        income_ids: [],
+        income_by_source: { external: BigDecimal("400"), activity: BigDecimal("0") },
+        external_income_activity_ids: [],
+        activity_ids: [],
         period_start: Date.current,
         period_end: Date.current
       }

--- a/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
+++ b/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
@@ -3,11 +3,15 @@
 require "rails_helper"
 
 RSpec.describe ActivityAggregator, type: :concern do
-  class TestDeterminationService
-    include ActivityAggregator
+  subject(:service) { TestDeterminationService.new }
+
+  before do
+    stub_const(
+      "TestDeterminationService",
+      Class.new { include ActivityAggregator }
+    )
   end
 
-  let(:service) { TestDeterminationService.new }
 
   describe ".fetch_external_income_activities" do
     let(:certification) { create(:certification) }

--- a/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
+++ b/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActivityAggregator, type: :concern do
+  class TestDeterminationService
+    include ActivityAggregator
+  end
+
+  let(:service) { TestDeterminationService.new }
+
+  describe ".fetch_external_income_activities" do
+    let(:certification) { create(:certification) }
+
+    context "with member_id" do
+      before do
+        lookback = certification.certification_requirements.continuous_lookback_period
+        create(:external_income_activity,
+               member_id: certification.member_id,
+               gross_income: 100,
+               period_start: lookback.start.to_date,
+               period_end: lookback.start.to_date.end_of_month)
+      end
+
+      it "returns activities for the member within the lookback period" do
+        activities = service.fetch_external_income_activities(
+          certification,
+          certification.certification_requirements.continuous_lookback_period
+        )
+
+        expect(activities.count).to eq(1)
+        expect(activities.first.member_id).to eq(certification.member_id)
+      end
+    end
+
+    context "with nil member_id" do
+      let(:certification) { create(:certification, member_id: nil) }
+
+      it "returns empty relation" do
+        activities = service.fetch_external_income_activities(
+          certification,
+          certification.certification_requirements.continuous_lookback_period
+        )
+
+        expect(activities).to be_empty
+        expect(activities.count).to eq(0)
+      end
+    end
+  end
+
+  describe ".summarize_income" do
+    context "with activities" do
+      let(:num_activities) { 2 }
+      let(:gross_income) { 100 }
+      let(:activities) { create_list(:external_income_activity, num_activities, gross_income: gross_income) }
+
+      it "returns total and ids" do
+        summary = service.summarize_income(ExternalIncomeActivity.where(id: activities.map(&:id)))
+
+        expect(summary[:total]).to eq(BigDecimal(gross_income * num_activities))
+        expect(summary[:ids].length).to eq(num_activities)
+      end
+    end
+
+    context "with no activities" do
+      it "returns zeroed values" do
+        summary = service.summarize_income(ExternalIncomeActivity.none)
+
+        expect(summary[:total]).to eq(BigDecimal(0))
+        expect(summary[:ids].length).to eq(0)
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/income_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/income_compliance_determination_service_spec.rb
@@ -116,11 +116,18 @@ RSpec.describe IncomeComplianceDeterminationService do
         expect(determination.determination_data["total_income"]).to eq(580.25)
       end
 
-      it "includes income_ids" do
+      it "includes external_income_activity_ids" do
         described_class.calculate(certification.id)
 
         determination = Determination.where(subject_id: certification.id).last
-        expect(determination.determination_data["income_ids"].length).to eq(2)
+        expect(determination.determination_data["external_income_activity_ids"].length).to eq(2)
+      end
+
+      it "includes activity_ids (empty until member-reported income is implemented)" do
+        described_class.calculate(certification.id)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.determination_data["activity_ids"]).to eq([])
       end
     end
 
@@ -152,13 +159,31 @@ RSpec.describe IncomeComplianceDeterminationService do
 
     let(:certification) { create(:certification) }
 
-    it "exposes member_reported_income_total as zero until modeled (stub)" do
+    it "exposes member_reported_income[:total] as zero until modeled (stub)" do
       create_income_for(certification, gross_income: 100)
       agg = described_class.aggregate_income_for_certification(certification)
 
       expect(agg[:income_by_source][:activity]).to eq(BigDecimal("0"))
       expect(agg[:total_income]).to eq(BigDecimal("100"))
       expect_no_ce_workflow_events_published
+    end
+
+    it "returns expected aggregate structure" do
+      create_income_for(certification, gross_income: 100)
+      agg = described_class.aggregate_income_for_certification(certification)
+
+      expect(agg).to have_key(:total_income)
+      expect(agg).to have_key(:income_by_source)
+      expect(agg).to have_key(:external_income_activity_ids)
+      expect(agg).to have_key(:activity_ids)
+      expect(agg).to have_key(:period_start)
+      expect(agg).to have_key(:period_end)
+
+      expect(agg[:income_by_source]).to have_key(:external)
+      expect(agg[:income_by_source]).to have_key(:activity)
+
+      expect(agg[:external_income_activity_ids].length).to eq(1)
+      expect(agg[:activity_ids].length).to eq(0)
     end
   end
 end

--- a/reporting-app/spec/services/notifications_event_listener_spec.rb
+++ b/reporting-app/spec/services/notifications_event_listener_spec.rb
@@ -131,8 +131,9 @@ RSpec.describe NotificationsEventListener, type: :service do
 
         income_data = {
           total_income: BigDecimal("400"),
-          income_by_source: { income: BigDecimal("400"), activity: BigDecimal("0") },
-          income_ids: [],
+          income_by_source: { external: BigDecimal("400"), activity: BigDecimal("0") },
+          external_income_activity_ids: [],
+          activity_ids: [],
           period_start: Date.current,
           period_end: Date.current
         }
@@ -171,8 +172,9 @@ RSpec.describe NotificationsEventListener, type: :service do
 
         income_data = {
           total_income: BigDecimal("400"),
-          income_by_source: { income: BigDecimal("400"), activity: BigDecimal("0") },
-          income_ids: [],
+          income_by_source: { external: BigDecimal("400"), activity: BigDecimal("0") },
+          external_income_activity_ids: [],
+          activity_ids: [],
           period_start: Date.current,
           period_end: Date.current
         }
@@ -217,8 +219,9 @@ RSpec.describe NotificationsEventListener, type: :service do
         }
         income_data = {
           total_income: BigDecimal("0"),
-          income_by_source: { income: BigDecimal("0"), activity: BigDecimal("0") },
-          income_ids: [],
+          income_by_source: { external: BigDecimal("0"), activity: BigDecimal("0") },
+          external_income_activity_ids: [],
+          activity_ids: [],
           period_start: Date.current,
           period_end: Date.current
         }


### PR DESCRIPTION
## Ticket

Related to [OSCER-417](https://github.com/navapbc/oscer/issues/417)

## Changes

As per [this comment](https://github.com/navapbc/oscer/pull/529#discussion_r3198204343) on #529, updates `IncomeComplianceDeterminationService.aggregate_income_for_certification()` to produce data in a structure and through a process more closely resembling `HoursComplianceDeterminationService.aggregate_hours_for_certification()`. Specifically:

* updates naming and values in returned data structure:
  * `income_by_source["income"]` renamed to `income_by_source["external"]`
  * `income_ids` renamed to `external_income_activity_ids`
  *  `activity_ids` added
* changes names and methods for retrieving and transforming data:
  * includes `ActivityAggregator` with new `fetch_external_income_activities` and `summarize_income` methods
* updates and adds tests

## Testing

```bash
cd reporting-app && make lint && make test
```

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->