### PR TITLE
OSCER-389 create audit log table

### DIFF
--- a/reporting-app/db/migrate/20260518150145_create_strata_audit_lines.rb
+++ b/reporting-app/db/migrate/20260518150145_create_strata_audit_lines.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateStrataAuditLines < ActiveRecord::Migration[7.2]
+class CreateStrataAuditLines < ActiveRecord::Migration[8.0]
   def change
     create_table :strata_audit_lines, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
       # Required: what happened

--- a/reporting-app/db/migrate/20260518150145_create_strata_audit_lines.rb
+++ b/reporting-app/db/migrate/20260518150145_create_strata_audit_lines.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateStrataAuditLines < ActiveRecord::Migration[7.2]
+  def change
+    create_table :strata_audit_lines, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      # Required: what happened
+      t.string :action, null: false
+
+      # Optional polymorphic subject (the record this event is about)
+      t.uuid   :subject_id
+      t.string :subject_type
+
+      # Optional polymorphic actor (who did it)
+      t.uuid   :actor_id
+      t.string :actor_type
+
+      # Free-form jsonb payload for caller-supplied details
+      t.jsonb :data, null: false, default: {}
+
+      # Audit lines are immutable: created_at only, no updated_at
+      t.datetime :created_at, null: false
+    end
+
+    # Composite index ordered by created_at DESC serves the dominant read
+    # pattern: "most recent audit lines for this subject"
+    add_index :strata_audit_lines, [ :subject_type, :subject_id, :created_at ],
+              order: { created_at: :desc },
+              name: "index_strata_audit_lines_on_subject_and_created_at"
+
+    add_index :strata_audit_lines, [ :actor_type, :actor_id ],
+              name: "index_strata_audit_lines_on_polymorphic_actor"
+
+    add_index :strata_audit_lines, :created_at
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_162150) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_18_150145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -303,6 +303,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_162150) do
     t.index ["stageable_type", "stageable_id"], name: "index_staged_documents_on_stageable"
     t.index ["status"], name: "index_staged_documents_on_status"
     t.index ["user_id"], name: "index_staged_documents_on_user_id"
+  end
+
+  create_table "strata_audit_lines", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "action", null: false
+    t.uuid "subject_id"
+    t.string "subject_type"
+    t.uuid "actor_id"
+    t.string "actor_type"
+    t.jsonb "data", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.index ["actor_type", "actor_id"], name: "index_strata_audit_lines_on_polymorphic_actor"
+    t.index ["created_at"], name: "index_strata_audit_lines_on_created_at"
+    t.index ["subject_type", "subject_id", "created_at"], name: "index_strata_audit_lines_on_subject_and_created_at", order: { created_at: :desc }
   end
 
   create_table "strata_determinations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Ticket

Enables #389 

## Changes

Migration for Strata::AuditLine added

## Context for reviewers

For audit logging, we want to use the new [Strata::AuditLog,](https://github.com/navapbc/strata-sdk-rails/blob/main/docs/strata-audit-log.md) which requires this table.
Adding audit logging functionality will be a separate pull request.

## Testing

Essentially a no-op, and automated tests pass.
Local testing of audit log functionality branched from this branch were successful.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->