### PR TITLE
Ship Layer 4/5 customization hook scaffolds (OSCER-567)

### DIFF
--- a/reporting-app/app/models/concerns/custom/README.md
+++ b/reporting-app/app/models/concerns/custom/README.md
@@ -21,6 +21,9 @@ Wire it into the base model with one `include` line:
     # app/models/certification.rb
     include Custom::CertificationExtensions
 
+Concerns under `Custom::` are plain Ruby modules — they can also be included
+in deployment-owned models, not only OSCER's base models.
+
 For the full pattern, see CUSTOMIZATION.md "Layer 5: Model Customization"
 (in progress: [#539](https://github.com/navapbc/oscer/issues/539)).
 

--- a/reporting-app/app/models/concerns/custom/README.md
+++ b/reporting-app/app/models/concerns/custom/README.md
@@ -21,7 +21,8 @@ Wire it into the base model with one `include` line:
     # app/models/certification.rb
     include Custom::CertificationExtensions
 
-For the full pattern, see CUSTOMIZATION.md "Layer 5: Model Customization".
+For the full pattern, see CUSTOMIZATION.md "Layer 5: Model Customization"
+(in progress: [#539](https://github.com/navapbc/oscer/issues/539)).
 
 ## Ownership
 

--- a/reporting-app/app/models/concerns/custom/README.md
+++ b/reporting-app/app/models/concerns/custom/README.md
@@ -1,0 +1,29 @@
+# Deployment-Specific Model Concerns
+
+Holds concerns that extend OSCER's base models with deployment-specific
+validations, scopes, or methods. Namespaced under `Custom::`.
+
+## Example
+
+    # app/models/concerns/custom/certification_extensions.rb
+    module Custom
+      module CertificationExtensions
+        extend ActiveSupport::Concern
+
+        included do
+          validates :county, presence: true
+        end
+      end
+    end
+
+Wire it into the base model with one `include` line:
+
+    # app/models/certification.rb
+    include Custom::CertificationExtensions
+
+For the full pattern, see CUSTOMIZATION.md "Layer 5: Model Customization".
+
+## Ownership
+
+`.rb` files here are deployment-owned and untouched by `nava-platform app
+update`. `README.md` and `.keep` are template-owned and refresh on update.

--- a/reporting-app/app/models/concerns/custom/README.md
+++ b/reporting-app/app/models/concerns/custom/README.md
@@ -30,4 +30,4 @@ For the full pattern, see CUSTOMIZATION.md "Layer 5: Model Customization"
 ## Ownership
 
 `.rb` files here are deployment-owned and untouched by `nava-platform app
-update`. `README.md` and `.keep` are template-owned and refresh on update.
+update`. `README.md` is template-owned and refreshes on update.

--- a/reporting-app/app/models/custom/README.md
+++ b/reporting-app/app/models/custom/README.md
@@ -12,8 +12,12 @@ namespaced under `Custom::`.
       end
     end
 
-Ship a corresponding migration. To wire a custom model into existing flows,
-see CUSTOMIZATION.md "Layer 5: Model Customization".
+Ship a corresponding migration. Models exposed to controllers also need a
+Pundit policy (`make new-authz-policy MODEL=...`) — `ApplicationController`
+raises if `authorize`/`policy_scope` are skipped.
+
+To wire a custom model into existing flows, see CUSTOMIZATION.md
+"Layer 5: Model Customization".
 
 ## Ownership
 

--- a/reporting-app/app/models/custom/README.md
+++ b/reporting-app/app/models/custom/README.md
@@ -23,4 +23,4 @@ To wire a custom model into existing flows, see CUSTOMIZATION.md
 ## Ownership
 
 `.rb` files here are deployment-owned and untouched by `nava-platform app
-update`. `README.md` and `.keep` are template-owned and refresh on update.
+update`. `README.md` is template-owned and refreshes on update.

--- a/reporting-app/app/models/custom/README.md
+++ b/reporting-app/app/models/custom/README.md
@@ -17,7 +17,8 @@ Pundit policy (`make new-authz-policy MODEL=...`) — `ApplicationController`
 raises if `authorize`/`policy_scope` are skipped.
 
 To wire a custom model into existing flows, see CUSTOMIZATION.md
-"Layer 5: Model Customization".
+"Layer 5: Model Customization" (in progress:
+[#539](https://github.com/navapbc/oscer/issues/539)).
 
 ## Ownership
 

--- a/reporting-app/app/models/custom/README.md
+++ b/reporting-app/app/models/custom/README.md
@@ -1,0 +1,21 @@
+# Deployment-Specific Models
+
+Holds models unique to this deployment. Place new ActiveRecord models here,
+namespaced under `Custom::`.
+
+## Example
+
+    # app/models/custom/disaster_declaration.rb
+    module Custom
+      class DisasterDeclaration < ApplicationRecord
+        # deployment-specific fields and behavior
+      end
+    end
+
+Ship a corresponding migration. To wire a custom model into existing flows,
+see CUSTOMIZATION.md "Layer 5: Model Customization".
+
+## Ownership
+
+`.rb` files here are deployment-owned and untouched by `nava-platform app
+update`. `README.md` and `.keep` are template-owned and refresh on update.

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -16,13 +16,13 @@ here, namespaced under `Rules::Custom::`.
 
 ## Federally-required exemptions
 
-Deployments may grant additional exemptions beyond OSCER's defaults but
-must not narrow or remove the exemptions federal Medicaid law requires
-(disability, pregnancy, Native American / Alaska Native, age). The base
-rulesets encode that minimum.
+Deployments may grant additional exemptions but must not narrow or remove
+the exemptions federal Medicaid law requires (disability, pregnancy, Native
+American / Alaska Native, age). The base rulesets encode that minimum.
 
 To wire a custom ruleset into evaluation, see CUSTOMIZATION.md
-"Layer 4: Service and Ruleset Customization".
+"Layer 4: Service and Ruleset Customization" (in progress:
+[#539](https://github.com/navapbc/oscer/issues/539)).
 
 ## Ownership
 

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -14,11 +14,12 @@ here, namespaced under `Rules::Custom::`.
       end
     end
 
-## Federal-floor invariants
+## Federally-required exemptions
 
-Composition overrides may **add** exemption paths or **tighten** eligibility
-beyond OSCER's defaults, but must not relax federally-required rules. The
-base rulesets encode the federal floor.
+Deployments may grant additional exemptions beyond OSCER's defaults but
+must not narrow or remove the exemptions federal Medicaid law requires
+(disability, pregnancy, Native American / Alaska Native, age). The base
+rulesets encode that minimum.
 
 To wire a custom ruleset into evaluation, see CUSTOMIZATION.md
 "Layer 4: Service and Ruleset Customization".

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -14,6 +14,12 @@ here, namespaced under `Rules::Custom::`.
       end
     end
 
+## Federal-floor invariants
+
+Composition overrides may **add** exemption paths or **tighten** eligibility
+beyond OSCER's defaults, but must not relax federally-required rules. The
+base rulesets encode the federal floor.
+
 To wire a custom ruleset into evaluation, see CUSTOMIZATION.md
 "Layer 4: Service and Ruleset Customization".
 

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -27,4 +27,4 @@ To wire a custom ruleset into evaluation, see CUSTOMIZATION.md
 ## Ownership
 
 `.rb` files here are deployment-owned and untouched by `nava-platform app
-update`. `README.md` and `.keep` are template-owned and refresh on update.
+update`. `README.md` is template-owned and refreshes on update.

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -1,0 +1,23 @@
+# Deployment-Specific Rulesets
+
+Holds rulesets unique to this deployment. Place subclasses of base rulesets
+here, namespaced under `Rules::Custom::`.
+
+## Example
+
+    # app/models/rules/custom/exemption_ruleset.rb
+    module Rules
+      module Custom
+        class ExemptionRuleset < Rules::ExemptionRuleset
+          # deployment-specific rule methods + composition override
+        end
+      end
+    end
+
+To wire a custom ruleset into evaluation, see CUSTOMIZATION.md
+"Layer 4: Service and Ruleset Customization".
+
+## Ownership
+
+`.rb` files here are deployment-owned and untouched by `nava-platform app
+update`. `README.md` and `.keep` are template-owned and refresh on update.

--- a/reporting-app/app/services/custom/README.md
+++ b/reporting-app/app/services/custom/README.md
@@ -1,0 +1,21 @@
+# Deployment-Specific Services
+
+Holds services unique to this deployment. Place subclasses of base services
+here, namespaced under `Custom::`.
+
+## Example
+
+    # app/services/custom/exemption_determination_service.rb
+    module Custom
+      class ExemptionDeterminationService < ::ExemptionDeterminationService
+        # deployment-specific overrides
+      end
+    end
+
+To wire a custom service into existing flows, see CUSTOMIZATION.md
+"Layer 4: Service and Ruleset Customization".
+
+## Ownership
+
+`.rb` files here are deployment-owned and untouched by `nava-platform app
+update`. `README.md` and `.keep` are template-owned and refresh on update.

--- a/reporting-app/app/services/custom/README.md
+++ b/reporting-app/app/services/custom/README.md
@@ -12,6 +12,13 @@ here, namespaced under `Custom::`.
       end
     end
 
+Note: OSCER's services live flat under `app/services/` with no `Services::`
+namespace, so the parent class is referenced as
+`::ExemptionDeterminationService` (not `::Services::ExemptionDeterminationService`).
+By contrast, `Rules::` and `Custom::` ARE proper namespaces. The full
+namespacing guidance will live in CUSTOMIZATION.md
+([#539](https://github.com/navapbc/oscer/issues/539)).
+
 To wire a custom service into existing flows, see CUSTOMIZATION.md
 "Layer 4: Service and Ruleset Customization" (in progress:
 [#539](https://github.com/navapbc/oscer/issues/539)).

--- a/reporting-app/app/services/custom/README.md
+++ b/reporting-app/app/services/custom/README.md
@@ -26,4 +26,4 @@ To wire a custom service into existing flows, see CUSTOMIZATION.md
 ## Ownership
 
 `.rb` files here are deployment-owned and untouched by `nava-platform app
-update`. `README.md` and `.keep` are template-owned and refresh on update.
+update`. `README.md` is template-owned and refreshes on update.

--- a/reporting-app/app/services/custom/README.md
+++ b/reporting-app/app/services/custom/README.md
@@ -13,7 +13,8 @@ here, namespaced under `Custom::`.
     end
 
 To wire a custom service into existing flows, see CUSTOMIZATION.md
-"Layer 4: Service and Ruleset Customization".
+"Layer 4: Service and Ruleset Customization" (in progress:
+[#539](https://github.com/navapbc/oscer/issues/539)).
 
 ## Ownership
 

--- a/reporting-app/app/views/overrides/README.md
+++ b/reporting-app/app/views/overrides/README.md
@@ -12,9 +12,16 @@ Override the certification show page by mirroring its path:
 
 Override a mailer template the same way:
 
-    # app/views/overrides/member_mailer/welcome.html.erb
+    # app/views/overrides/member_mailer/exempt_email.html.erb
 
-For the full pattern, see CUSTOMIZATION.md.
+## Override with care
+
+Security-critical templates (Devise sessions/MFA, destructive-action
+confirmations, CSRF-bearing forms) silently win when overridden. Preserve
+auth, CSRF tokens, and MFA prompts in any override you ship.
+
+For the full pattern, see CUSTOMIZATION.md "Layer 4: View and Mailer
+Overrides".
 
 ## Ownership
 

--- a/reporting-app/app/views/overrides/README.md
+++ b/reporting-app/app/views/overrides/README.md
@@ -1,0 +1,22 @@
+# View and Mailer Overrides
+
+Holds override versions of templates shipped by OSCER. Files here win over
+their template-shipped counterparts via `prepend_view_path` (wired in
+`ApplicationController` and `ApplicationMailer`).
+
+## Example
+
+Override the certification show page by mirroring its path:
+
+    # app/views/overrides/certifications/show.html.erb
+
+Override a mailer template the same way:
+
+    # app/views/overrides/member_mailer/welcome.html.erb
+
+For the full pattern, see CUSTOMIZATION.md.
+
+## Ownership
+
+`.erb` files here are deployment-owned and untouched by `nava-platform app
+update`. `README.md` and `.keep` are template-owned and refresh on update.

--- a/reporting-app/app/views/overrides/README.md
+++ b/reporting-app/app/views/overrides/README.md
@@ -21,7 +21,8 @@ confirmations, CSRF-bearing forms) silently win when overridden. Preserve
 auth, CSRF tokens, and MFA prompts in any override you ship.
 
 For the full pattern, see CUSTOMIZATION.md "Layer 4: View and Mailer
-Overrides".
+Overrides" (in progress:
+[#539](https://github.com/navapbc/oscer/issues/539)).
 
 ## Ownership
 


### PR DESCRIPTION
Resolves #567
Part of #527

Adds first-`ls` discoverability for state implementers customizing OSCER's Ruby code beyond Tier 1 (YAML config) and Tier 2 (locale overrides). Each scaffold's README serves as a brief in-tree pointer to the canonical CUSTOMIZATION.md ([#539](https://github.com/navapbc/oscer/issues/539) — in progress) and to the namespaced drop-in convention for that layer.

## Scaffolds shipped

| Path | Namespace | Purpose |
|------|-----------|---------|
| `app/services/custom/` | `Custom::` | Service subclasses |
| `app/models/custom/` | `Custom::` | Deployment-specific models |
| `app/models/concerns/custom/` | `Custom::` | Model concerns |
| `app/models/rules/custom/` | `Rules::Custom::` | Ruleset subclasses |
| `app/views/overrides/` | (n/a) | View + mailer overrides (`.keep` from PR [#522](https://github.com/navapbc/oscer/pull/522); this PR adds README only) |

Each README is <=30 lines and follows the discoverability pattern PR [#564](https://github.com/navapbc/oscer/pull/564) established for Tier 2: purpose statement, namespace convention, minimal example, pointer to CUSTOMIZATION.md, and an ownership note distinguishing template-owned (README + `.keep`) from deployment-owned (everything else).

## Harmonization decision (applied 2026-05-19)

All four Ruby customization paths use the same `custom/` subdirectory pattern with `Custom::`-style class namespacing. Ruleset customization previously specified a file-prefix design at fork-and-customize-spec.md §188 (`app/models/rules/custom_exemption_ruleset.rb` + class `Rules::CustomExemptionRuleset`). Harmonized before implementation because the 3+1 asymmetry would have been load-bearing for [#528](https://github.com/navapbc/oscer/issues/528)'s Copier directory-rename rules and for CUSTOMIZATION.md ([#539](https://github.com/navapbc/oscer/issues/539)).

Updated in lockstep with the scaffold commit:
- fork-and-customize-spec.md (§188, §219, §237, §382)
- OSS update strategy doc roadmap row for [#567](https://github.com/navapbc/oscer/issues/567)
- [#567](https://github.com/navapbc/oscer/issues/567) body
- [#528](https://github.com/navapbc/oscer/issues/528) body

## Future work — deployment-namespace substitution

This PR ships fixed `custom/` paths in OSCER's `reporting-app/`. [#528](https://github.com/navapbc/oscer/issues/528) takes filter-repo'd OSCER into the `template-strata-oscer-app` Copier template and Jinja-fies the scaffolds: `app/services/custom/` -> `app/services/{{ deployment_namespace_snake }}/`, with README namespace references substituted from `Custom::` to `{{ deployment_namespace }}::`. Default deployments still render as `custom/`/`Custom::`; deployments choosing e.g. `Arkansas` render as `arkansas/`/`Arkansas::`. The literal `Custom::` namespaces shipped here are placeholders for that substitution.

## Implementer guardrails (from `/review` iterations)

README examples carry explicit notes on common footguns:
- Pundit policies required for new models exposed to controllers (`app/models/custom/README.md`)
- Federally-required exemptions cannot be narrowed via ruleset composition (`app/models/rules/custom/README.md`)
- Security-critical templates (Devise/MFA/CSRF-bearing) require care when overridden (`app/views/overrides/README.md`)

## Verification

The view_paths regression-guard spec the ticket called for already exists from PR [#522](https://github.com/navapbc/oscer/pull/522) (`spec/controllers/application_controller_spec.rb`, `spec/mailers/application_mailer_spec.rb`). Both tests continue to pass against the now-populated overrides directory (3 examples, 0 failures). App boot via `bundle exec rails runner` confirms Zeitwerk accepts the empty `Custom::` namespace directories. [#567](https://github.com/navapbc/oscer/issues/567)'s body was updated to reflect that the verification spec already exists rather than ship a duplicate.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->