### PR TITLE
silence StagedDocumentCleanupService stdout during tests

### DIFF
--- a/reporting-app/app/services/staged_document_cleanup_service.rb
+++ b/reporting-app/app/services/staged_document_cleanup_service.rb
@@ -63,7 +63,7 @@ class StagedDocumentCleanupService
   end
 
   def log_both(message)
-    puts message
+    puts message unless Rails.env.test?
     Rails.logger.info(message)
   end
 end


### PR DESCRIPTION
## Ticket

Resolves #579 

## Changes

StagedDocumentCleanupService only writes to stdout if not in test environment.

## Context for reviewers

Easier to test from `make test-watch`, which runs tests in progress format.

## Testing

Searched for logging message "StagedDocument cleanup skipped" in ci output and do not see it, although it is present in [runs without this fix](https://github.com/navapbc/oscer/actions/runs/25871607867/job/76028037606).

Ran rake task locally and had information printed to stdout.
```
> bundle exec rake doc_ai:cleanup_staged_documents -- --dry-run
[dry-run] Would delete 0 staged document(s); approximate storage freed: 0 Bytes
> bundle exec rake doc_ai:cleanup_staged_documents
Deleted 0 staged document(s); approximate storage freed: 0 Bytes
```

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->