### PR TITLE
OSCER-581: Update JWT test fixtures for 3.2.0 nil-key rejection

### DIFF
--- a/reporting-app/spec/controllers/users/mfa_controller_spec.rb
+++ b/reporting-app/spec/controllers/users/mfa_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Users::MfaController do
 
   describe "new" do
     it "renders the MFA setup form" do
-      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, nil))
+      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, "test"))
       sign_in user
 
       get :new, params: { locale: "en" }
@@ -66,7 +66,7 @@ RSpec.describe Users::MfaController do
     end
 
     it "redirects to the login page if the access token is close to expiring" do
-      user = create(:user, access_token: JWT.encode({ exp: 5.minutes.from_now.to_i }, nil))
+      user = create(:user, access_token: JWT.encode({ exp: 5.minutes.from_now.to_i }, "test"))
       sign_in user
 
       get :new, params: { locale: "en" }
@@ -80,7 +80,7 @@ RSpec.describe Users::MfaController do
       user = create(
         :user,
         mfa_preference: nil,
-        access_token: JWT.encode({ exp: 1.day.from_now.to_i }, nil)
+        access_token: JWT.encode({ exp: 1.day.from_now.to_i }, "test")
       )
       sign_in user
 
@@ -97,7 +97,7 @@ RSpec.describe Users::MfaController do
     end
 
     it "redirects back to the setup page if the code is invalid" do
-      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, nil))
+      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, "test"))
       sign_in user
 
       post :create, params: {
@@ -110,7 +110,7 @@ RSpec.describe Users::MfaController do
     end
 
     it "redirects back to the setup page if the code is incorrect" do
-      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, nil))
+      user = create(:user, access_token: JWT.encode({ exp: 1.day.from_now.to_i }, "test"))
       sign_in user
 
       post :create, params: {

--- a/reporting-app/spec/models/user_spec.rb
+++ b/reporting-app/spec/models/user_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe User, type: :model do
   describe "access_token_expires_within_minutes?" do
     let(:user) { build(:user) }
     let(:access_token) {
-      JWT.encode({ exp: 5.minutes.from_now.to_i }, nil)
+      # Fixture key — User#access_token_expires_within_minutes? decodes with
+      # verify=false, so the encoding secret has no production meaning here.
+      # JWT 3.2.0 (CVE-2026-45363) rejects nil HMAC keys at sign time.
+      JWT.encode({ exp: 5.minutes.from_now.to_i }, "test")
     }
 
     it "returns true if the access token expires within the designated minutes" do


### PR DESCRIPTION
## Summary

Updates 7 test fixture sites that pass `nil` as the HMAC key to `JWT.encode`. JWT 3.2.0's [CVE-2026-45363](https://www.cve.org/CVERecord?id=CVE-2026-45363) fix rejects nil/empty HMAC keys at sign time, blocking Dependabot PR [#576](https://github.com/navapbc/oscer/pull/576). Replacing `nil` with a `"test"` placeholder secret unblocks the bump.

## Changes

- **`reporting-app/spec/models/user_spec.rb`** (1 site, +5/-1) — fixture for `access_token_expires_within_minutes?`. Added a 3-line comment explaining why a placeholder secret is acceptable (consumer uses `verify=false` decode).
- **`reporting-app/spec/controllers/users/mfa_controller_spec.rb`** (5 sites, +5/-5) — fixtures for MFA flow tests.

All replacements are `JWT.encode(payload, nil)` → `JWT.encode(payload, "test")`.

## Why this is test-only

Production code is unaffected — the CVE only triggers when JWT signs or signature-verifies an HMAC token. Verified all four production call sites:

| Path | Pattern | Status |
|---|---|---|
| `app/models/user.rb:26` | `JWT.decode(access_token, nil, false)` | Safe (no-verify decode) |
| `app/adapters/auth/cognito_adapter.rb:287` | Same no-verify pattern | Safe |
| `app/adapters/auth/mock_adapter.rb:73` | Uses `"mock_secret_key"` (non-nil HMAC) | Safe |
| `app/services/va_token_manager.rb:62` | RS256 with RSA `private_key` (not HMAC) | Safe |

## Local verification

Verified against jwt 3.2.0 by temporarily bumping the lockfile in-container, running the affected specs + full suite, then reverting the Gemfile.lock change so this PR's diff is scoped to test code only.

- Affected specs (12 examples in 2 files): all pass against jwt 3.2.0
- Full suite (1940 examples, 1 pending pre-existing): 0 failures against jwt 3.2.0
- Coverage: 95.49% line / 80.09% branch (above 92%/70% thresholds)
- RuboCop: clean

## Sequencing

Land this PR first. Once merged, PR [#576](https://github.com/navapbc/oscer/pull/576) (Dependabot JWT bump) will rebase against new main, its tests will pass against the updated fixtures, and it can merge cleanly.

The actual JWT version bump from 3.1.2 to 3.2.0 is **out of scope here** — that's Dependabot's PR. This PR only updates the test fixtures to be compatible with both versions.

## Notes

- PR [#576](https://github.com/navapbc/oscer/pull/576)'s second failing check (`update-openapi-docs`) is unrelated — it's a `git push: HTTP 403` from a Dependabot/Actions permission limit, not a JWT issue. Worth confirming it resolves naturally; if it persists after #576 merges, that's a separate workflow-config item.

Resolves #581
Unblocks #576

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->