### PR TITLE
Fix E2E docs and reconcile guidance

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,11 +18,15 @@ Playwright end-to-end tests live in `e2e/` (TypeScript). Page Object pattern wit
 - Start: `make start-container` (Docker) or `make start-native` (native Ruby)
 - If app image needs rebuild first: `make build`
 
-### Running tests
+### Running E2E tests
+
+The canonical guide is [docs/e2e/e2e-checks.md](../../docs/e2e/e2e-checks.md). All `e2e-*` make targets run **from the repo root**, not `reporting-app/`. The suite requires `AUTH_ADAPTER=cognito` locally; mock auth cannot deliver verification emails.
+
+Run a single spec natively:
 
 ```bash
-cd oscer/e2e
-APP_NAME=reporting-app npx playwright test reporting-app/tests/<filename>.spec.ts
+make e2e-test-native APP_NAME=reporting-app \
+  E2E_ARGS=reporting-app/tests/<filename>.spec.ts
 ```
 
 ### Directory layout

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ This is the administrative interface where staff can review and process member c
 - **[Getting Started](docs/how-to-guides/getting-started.md)** - Instructions for getting started
 - **[System Architecture](docs/system-architecture.md)** - High-level system overview
 - **[Reporting App Documentation](docs/reporting-app/)** - Detailed application documentation
+- **[End-to-End (E2E) Tests](docs/e2e/e2e-checks.md)** - Running the Playwright suite locally and in CI
 - **[Infrastructure Guide](docs/infra/)** - Deployment and infrastructure management
 - **[Contributing Guidelines](CONTRIBUTING.md)** - How to contribute to the project
 - **[Security Policy](SECURITY.md)** - Security practices and reporting

--- a/claude.md
+++ b/claude.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository structure
 
-The Rails application lives in `reporting-app/`. **All `make` commands below must be run from that subdirectory**, not the repo root.
+The Rails application lives in `reporting-app/`. **Most `make` commands below run from that subdirectory**, not the repo root. E2E targets (`e2e-*`) are the exception: they live in the root `Makefile` and must be run from the repo root. See [E2E Tests](docs/e2e/e2e-checks.md).
 
 ```
 reporting-app/    # Rails 8.0 app (Ruby 3.4.9)

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -7,18 +7,14 @@ This repository uses [Playwright](https://playwright.dev/) to perform end-to-end
 By default in CI, tests are sharded across 3 concurrent runs to reduce total runtime. As the test suite grows, consider increasing the shard count to further optimize execution time. This is set in the [workflow file](../../.github/workflows/e2e-tests.yml#L22).
 
 ## Folder Structure
-In order to support e2e for multiple apps, the folder structure will include a base playwright config (`/e2e/playwright.config.js`), and app-specific derived playwright config that override the base config. See the example folder structure below:
+In order to support e2e for multiple apps, the folder structure will include a base playwright config (`/e2e/playwright.config.js`), and app-specific derived playwright config that override the base config. This project's folder structure:
 ```
-- e2e
-  - playwright.config.js
-  - app/
-    - playwright.config.js
-    - tests/
-      - index.spec.js
-  - app2/
-    - playwright.config.js
-    - tests/
-      - index.spec.js
+e2e/
+  playwright.config.js
+  reporting-app/
+    playwright.config.js
+    tests/
+      *.spec.ts
 ```
 
 Some highlights:
@@ -29,54 +25,74 @@ Some highlights:
 
 ## Run tests locally
 
-### Run tests with docker (preferred)
+> **All E2E `make` targets live in the root `Makefile` and must be run from the repository root**, not from `reporting-app/`. The `e2e/` directory is a sibling of `reporting-app/`.
 
-First, make sure the application you want to test is running.
+### Prerequisites
 
-Then, run end-to-end tests using Docker with:
+1. **The application must be running** at `http://localhost:3000`. See [Getting Started](../how-to-guides/getting-started.md).
+2. **Auth adapter must be `cognito`** in `reporting-app/.env`. The mock adapter (`AUTH_ADAPTER=mock`) advances past registration but cannot deliver verification emails, so every auth-gated test will hang for ~3 minutes per test. See [Authentication](../reporting-app/auth.md#e2e-tests-require-cognito) for the AWS prerequisites (provisioned IAM user, AWS CLI configured locally, user pool ID, client ID, and client secret).
+3. **Set `SKIP_PUBLIC_REQUEST_HOST=true`** on the Rails process. Uncomment the line in `reporting-app/.env`:
+   ```bash
+   SKIP_PUBLIC_REQUEST_HOST=true
+   ```
+   Without this, Rails redirects rewrite to `APP_HOST` and Playwright (which talks to `host.docker.internal` or another origin) lands on a different host mid-test. Omit this only in real deployments where canonical-host rewriting is intended.
+
+### Run the suite in Docker (preferred)
+
+From the repository root:
+
 ```bash
-make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000
 ```
 
->*Note that `BASE_URL` cannot be `localhost`
+> `BASE_URL` cannot be `localhost` when running in Docker, because the e2e container reaches the host via `host.docker.internal`.
 
-**Reporting-app (`APP_HOST` vs Playwright origin):** If the Rails process has `APP_HOST` set (for example for OIDC redirect URIs) but `BASE_URL` uses another host such as `host.docker.internal`, canonical host middleware would otherwise make redirects use `APP_HOST` and leave the test origin. Start Rails with **`SKIP_PUBLIC_REQUEST_HOST=true`** on that process only so redirects stay on the URL Playwright uses. Omit this in real deployments where you depend on canonical host rewriting.
+### Run the suite natively
 
-### Run tests natively
-
-First, make sure the application you want to test is running.
-
-To run end-to-end tests natively, first install Playwright with:
+First install Playwright (one time):
 
 ```bash
 make e2e-setup
 ```
 
-Then, run the tests with your app name and base url:
+Then run:
+
 ```bash
-make e2e-test-native APP_NAME=app
+make e2e-test-native APP_NAME=reporting-app
 ```
 
->* `BASE_URL` is optional for both `e2e-test-native` and `e2e-test-native-ui` targets. It will by default use the app-specific (`/e2e/<APP_NAME>/playwright.config.js`) `baseURL`
+> `BASE_URL` is optional for `e2e-test-native` and `e2e-test-native-ui`; it defaults to the `baseURL` in `e2e/reporting-app/playwright.config.js` (`http://localhost:3000`).
 
-### Run tests in UI mode
+### Run a single test
 
-When developing or debugging tests, it’s often helpful to see them running in real-time. You can achieve this by running the e2e tests in UI mode:
+Pass the spec path via `E2E_ARGS`. Paths are relative to `e2e/`.
 
+```bash
+# Docker
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 \
+  E2E_ARGS=reporting-app/tests/exemptionApplication.spec.ts
+
+# Native
+make e2e-test-native APP_NAME=reporting-app \
+  E2E_ARGS=reporting-app/tests/exemptionApplication.spec.ts
 ```
-make e2e-test-native-ui APP_NAME=app
-```
 
+### Run tests in UI mode (native)
+
+```bash
+make e2e-test-native-ui APP_NAME=reporting-app
+```
 
 #### Run tests in parallel
 
 The following commands split test execution into 3 separate shards, with results consolidated into a merged report located in `/e2e/blob-report`. This setup emulates how the sharded tests run in CI.
+
 ```
 # ensure app is running on port 3000
 
-make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=1 CI=true && \
-make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=2 CI=true && \
-make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=3 CI=true
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=1 CI=true && \
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=2 CI=true && \
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 TOTAL_SHARDS=3 CURRENT_SHARD=3 CI=true
 
 make e2e-merge-reports REPORT_PATH=blob-report # merge the blob reports into html
 make e2e-show-report # open the html report in browser
@@ -123,4 +139,4 @@ The E2E tests are configured using the following files:
 
 The app-specific configuration files extend the common base configuration.
 
-By default when running `make e2e-test APP_NAME=app BASE_URL=http://localhost:3000 ` - you don't necessarily need to pass an `BASE_URL` since the default is defined in the app-specific playwright config (`/e2e/<APP_NAME>/playwright.config.js`).
+`BASE_URL` is optional for native runs because the app-specific config (`/e2e/<APP_NAME>/playwright.config.js`) provides a default. In Docker, `BASE_URL` is required and must use a host the container can reach (typically `http://host.docker.internal:3000`).

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -30,8 +30,9 @@ Some highlights:
 ### Prerequisites
 
 1. **The application must be running** at `http://localhost:3000`. See [Getting Started](../how-to-guides/getting-started.md).
-2. **Auth adapter must be `cognito`** in `reporting-app/.env`. The mock adapter (`AUTH_ADAPTER=mock`) advances past registration but cannot deliver verification emails, so every auth-gated test will hang for ~3 minutes per test. See [Authentication](../reporting-app/auth.md#e2e-tests-require-cognito) for the AWS prerequisites (provisioned IAM user, AWS CLI configured locally, user pool ID, client ID, and client secret).
-3. **Set `SKIP_PUBLIC_REQUEST_HOST=true`** on the Rails process. Uncomment the line in `reporting-app/.env`:
+2. **Auth adapter must be `cognito`** in `reporting-app/.env`. The mock adapter (`AUTH_ADAPTER=mock`) advances past registration but cannot deliver verification emails, so every auth-gated test will hang for ~3 minutes per test. See [Authentication](../reporting-app/auth.md#cognito-adapter-production-e2e) for the AWS prerequisites (provisioned IAM user, AWS CLI configured locally, user pool ID, client ID, and client secret).
+3. **DocAI must be configured and enabled** in `reporting-app/.env`. E2E flows that exercise document staging and activity pre-fill depend on the DocAI service. See [Configuring DocAI](../how-to-guides/configuring-doc-ai.md) for the full variable set and feature-flag toggle.
+4. **Set `SKIP_PUBLIC_REQUEST_HOST=true`** on the Rails process. Uncomment the line in `reporting-app/.env`:
    ```bash
    SKIP_PUBLIC_REQUEST_HOST=true
    ```

--- a/docs/reporting-app/auth.md
+++ b/docs/reporting-app/auth.md
@@ -9,6 +9,40 @@ Authentication is the process of verifying the credentials of a user. We use AWS
 - Custom pages are built for the AWS Cognito flows (login, signup, forgot password, etc.). We aren't using the hosted UI that Cognito provides since we need more control over the UI and content.
 - [Devise](https://www.rubydoc.info/github/heartcombo/devise/main) and [Warden](https://github.com/wardencommunity/warden/wiki) facilitate auth and session management
 
+The application switches between two auth adapters via the `AUTH_ADAPTER` environment variable: `cognito` for production and any flow that needs real verification emails, `mock` for local development and most tests.
+
+### Cognito Adapter (production, E2E)
+
+The Cognito adapter is the production path. Use it locally when you need real Cognito flows, most notably during E2E tests. Mock auth does not deliver real verification emails. To run the full E2E suite locally you must:
+
+1. Have an AWS account with a provisioned IAM user that can read the Cognito user pool.
+2. Have the AWS CLI installed, configured (`aws configure`), and authenticated (`aws login`).
+3. Use the information in `~/.aws/config` and `~/.aws/credentials` to set the following in `reporting-app/.env`:
+   - `AWS_ACCESS_KEY_ID`
+   - `AWS_SECRET_ACCESS_KEY`
+   - `AWS_DEFAULT_REGION`
+4. Also configure these values in `reporting-app/.env`. You will need to obtain these through the AWS console:
+   - `AUTH_ADAPTER=cognito`
+   - `COGNITO_USER_POOL_ID`
+   - `COGNITO_CLIENT_ID`
+   - `COGNITO_CLIENT_SECRET`
+
+See [E2E Tests](../e2e/e2e-checks.md) for more information.
+
+### Mock Adapter (development, test)
+
+When running in test environments (or `dev` with `AUTH_ADAPTER=mock`), the application uses a mock authentication adapter to simulate interactions with an external auth provider. This allows you to test various authentication flows and error states without needing real external infrastructure.
+
+#### How to Trigger Different Auth Scenarios
+The mock adapter looks for specific keywords in the email or password fields during login to simulate different outcomes:
+
+| Scenario | How to Trigger | Result |
+| -------- | -------------- | ------ |
+| Unconfirmed account |	Use an email containing the word unconfirmed | Raises Auth::Errors::UserNotConfirmed |
+| Invalid credentials |	Use the password wrong	                     | Raises Auth::Errors::InvalidCredentials
+| MFA challenge       |	Use an email containing the word mfa	     | Returns a response with challenge_name: SOFTWARE_TOKEN_MFA
+| Successful login    |	Use any other email and password combination | Returns a mock token and UID
+
 ## Authorization
 
 Authorization is the process of determining whether a user has access to a specific resource. We use [Pundit](https://github.com/varvet/pundit) for authorization.
@@ -35,33 +69,3 @@ We use a few `after_action` Pundit callbacks in the application controller to ve
 - If you forget to call `policy_scope` in a controller action, you'll see an exception like `PolicyScopingNotPerformedError`.
 
 To opt out of these checks on actions that don't need them, you can add `skip_after_action :verify_authorized` or `skip_after_action :verify_policy_scoped` to your controller. Alternatively, you can add `skip_authorization` or `skip_policy_scope` to your controller action.
-
-### Mock Auth Adapter Behavior (Development & Test)
-
-When running in test environments (or `dev` with `AUTH_ADAPTER=mock`), the application uses a mock authentication adapter to simulate interactions with an external auth provider. This allows you to test various authentication flows and error states without needing real external infrastructure.
-
-An important exception is local E2E runs. `AUTH_ADAPTER=mock` will reach registration but hang at the email-verification step, because mock auth does not deliver real verification emails. To run the full E2E suite locally you must:
-
-1. Have an AWS account with a provisioned IAM user that can read the Cognito user pool.
-2. Have the AWS CLI installed, configured, (`aws configure`), and authenticated (`aws login`). Use the information in ~/.aws/config and ~/.aws/credentials to set the following in `reporting-app/.env`:
-
-- AWS_ACCESS_KEY_ID
-- AWS_SECRET_ACCESS_KEY
-- AWS_DEFAULT_REGION
-3. Set the following in `reporting-app/.env`:
-   - `AUTH_ADAPTER=cognito`
-   - `COGNITO_USER_POOL_ID`
-   - `COGNITO_CLIENT_ID`
-   - `COGNITO_CLIENT_SECRET`
-
-See [E2E Tests](../e2e/e2e-checks.md) for more information.
-
-#### How to Trigger Different Auth Scenarios
-The mock adapter looks for specific keywords in the email or password fields during login to simulate different outcomes:
-
-| Scenario | How to Trigger | Result |
-| -------- | -------------- | ------ |
-| Unconfirmed account |	Use an email containing the word unconfirmed | Raises Auth::Errors::UserNotConfirmed |
-| Invalid credentials |	Use the password wrong	                     | Raises Auth::Errors::InvalidCredentials
-| MFA challenge       |	Use an email containing the word mfa	     | Returns a response with challenge_name: SOFTWARE_TOKEN_MFA
-| Successful login    |	Use any other email and password combination | Returns a mock token and UID

--- a/docs/reporting-app/auth.md
+++ b/docs/reporting-app/auth.md
@@ -43,7 +43,11 @@ When running in test environments (or `dev` with `AUTH_ADAPTER=mock`), the appli
 An important exception is local E2E runs. `AUTH_ADAPTER=mock` will reach registration but hang at the email-verification step, because mock auth does not deliver real verification emails. To run the full E2E suite locally you must:
 
 1. Have an AWS account with a provisioned IAM user that can read the Cognito user pool.
-2. Have the AWS CLI installed and configured locally (`aws configure`).
+2. Have the AWS CLI installed, configured, (`aws configure`), and authenticated (`aws login`). Use the information in ~/.aws/config and ~/.aws/credentials to set the following in `reporting-app/.env`:
+
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_DEFAULT_REGION
 3. Set the following in `reporting-app/.env`:
    - `AUTH_ADAPTER=cognito`
    - `COGNITO_USER_POOL_ID`

--- a/docs/reporting-app/auth.md
+++ b/docs/reporting-app/auth.md
@@ -40,6 +40,18 @@ To opt out of these checks on actions that don't need them, you can add `skip_af
 
 When running in test environments (or `dev` with `AUTH_ADAPTER=mock`), the application uses a mock authentication adapter to simulate interactions with an external auth provider. This allows you to test various authentication flows and error states without needing real external infrastructure.
 
+An important exception is local E2E runs. `AUTH_ADAPTER=mock` will reach registration but hang at the email-verification step, because mock auth does not deliver real verification emails. To run the full E2E suite locally you must:
+
+1. Have an AWS account with a provisioned IAM user that can read the Cognito user pool.
+2. Have the AWS CLI installed and configured locally (`aws configure`).
+3. Set the following in `reporting-app/.env`:
+   - `AUTH_ADAPTER=cognito`
+   - `COGNITO_USER_POOL_ID`
+   - `COGNITO_CLIENT_ID`
+   - `COGNITO_CLIENT_SECRET`
+
+See [E2E Tests](../e2e/e2e-checks.md) for more information.
+
 #### How to Trigger Different Auth Scenarios
 The mock adapter looks for specific keywords in the email or password fields during login to simulate different outcomes:
 

--- a/docs/reporting-app/auth.md
+++ b/docs/reporting-app/auth.md
@@ -13,7 +13,7 @@ The application switches between two auth adapters via the `AUTH_ADAPTER` enviro
 
 ### Cognito Adapter (production, E2E)
 
-The Cognito adapter is the production path. Use it locally when you need real Cognito flows, most notably during E2E tests. Mock auth does not deliver real verification emails. To run the full E2E suite locally you must:
+The Cognito adapter is the production path. Use it locally when you need real Cognito flows, most notably during E2E tests. Mock auth does not deliver real verification emails. To use the cognito adapter locally you must:
 
 1. Have an AWS account with a provisioned IAM user that can read the Cognito user pool.
 2. Have the AWS CLI installed, configured (`aws configure`), and authenticated (`aws login`).

--- a/reporting-app/local.env.example
+++ b/reporting-app/local.env.example
@@ -84,6 +84,24 @@ SSO_ENABLED=false
 # SSO_CLAIM_UID=sub
 
 ############################
+# DocAI
+############################
+
+# Enable document staging and activity pre-fill from DocAI extraction.
+# See docs/how-to-guides/configuring-doc-ai.md for full configuration details.
+FEATURE_DOC_AI=false
+
+# Required when FEATURE_DOC_AI=true. URL of the DocAI API service.
+# DOC_AI_API_HOST=<FILL ME IN>
+
+# Optional: API request timeout in seconds (default: 60).
+# DOC_AI_TIMEOUT_SECONDS=60
+
+# Optional: confidence threshold for task queue prioritization (range 0.0-1.0, default: 0.7).
+# Activities with average confidence below this are flagged for higher caseworker priority.
+# DOC_AI_LOW_CONFIDENCE_THRESHOLD=0.7
+
+############################
 # Lookbook
 ############################
 


### PR DESCRIPTION
## Summary

Following `docs/e2e/e2e-checks.md` failed locally. Stale `APP_NAME=app` examples, missing prereqs, and conflicting guidance in `CLAUDE.md` and `.claude/rules/testing.md` sent contributors down wrong paths.

Establish `docs/e2e/e2e-checks.md` as the canonical guide:

- Replace every `APP_NAME=app` with `APP_NAME=reporting-app`.
- Document prereqs: running app, `AUTH_ADAPTER=cognito` with AWS creds, `SKIP_PUBLIC_REQUEST_HOST=true`.
- Add a single-test invocation example (Docker and native) via `E2E_ARGS`.
- Note that `e2e-*` make targets run from the repo root, not `reporting-app/`.
- Link from `README` so the canonical doc is discoverable.
- Update `CLAUDE.md` and `.claude/rules/testing.md` to defer to the canonical guide.
- Add an "E2E tests require Cognito" note to `docs/reporting-app/auth.md`.

Closes #572.

## Test plan

- [x] Render the diff and skim each doc top to bottom.
- [ ] From repo root: `make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000` reaches Playwright (with prereqs satisfied).
- [ ] From repo root: `make e2e-test-native APP_NAME=reporting-app E2E_ARGS=reporting-app/tests/index.spec.ts` runs a single spec.
- [x] Verify the auth.md anchor link from e2e-checks.md (`#e2e-tests-require-cognito`) resolves on the rendered page.
- [x] Confirm no `APP_NAME=app` strings remain: `git grep -n 'APP_NAME=app[^-]' docs/`.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->