### PR TITLE
Disable doc ai feature

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -37,6 +37,8 @@ export default defineConfig({
     screenshot: 'on',
     video: 'on-first-retry',
   },
+  // TODO: stop ignoring this test when DOC_AI Feature flag back on
+  testIgnore: '**/docAiUploadFlow.spec.ts',
   // Splits tests into chunks for distributed parallel execution
   shard: {
     // Total number of shards

--- a/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
@@ -18,7 +18,8 @@ export class BeforeYouStartPage extends BasePage {
 
   async clickStart() {
     // Skip DocAI for original document upload flow
-    await this.skipAiCheckbox.check();
+    // TODO: re-enable this action when DOC_AI Feature flag back on
+    // await this.skipAiCheckbox.check();
     await this.startButton.click();
 
     return new ChooseMonthsPage(this.page).waitForURLtoMatchPagePath();

--- a/infra/reporting-app/app-config/dev.tf
+++ b/infra/reporting-app/app-config/dev.tf
@@ -35,6 +35,6 @@ module "dev_config" {
     ENABLE_LOOKBOOK         = "true"
     FEATURE_BATCH_UPLOAD_V2 = "true"
     PERFORM_EMAIL_DELIVERY  = "false"
-    FEATURE_DOC_AI          = "true"
+    FEATURE_DOC_AI          = "false"
   }
 }

--- a/infra/reporting-app/app-config/sandbox.tf
+++ b/infra/reporting-app/app-config/sandbox.tf
@@ -26,6 +26,6 @@ module "sandbox_config" {
     ENABLE_LOOKBOOK         = "true"
     SSO_ENABLED             = "true"
     FEATURE_BATCH_UPLOAD_V2 = "true"
-    FEATURE_DOC_AI          = "true"
+    FEATURE_DOC_AI          = "false"
   }
 }


### PR DESCRIPTION
## Ticket

Resolves #596 

## Changes

- DOC_AI feature flag turned off
- e2e Doc AI tests ignored

## Context for reviewers

Turning off Doc AI functionality while we set up an OSCER doc ai processing server. The server we were using was temporary.

## Testing

- Locally passed e2e
- Logged in as member and did not have doc ai as option.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->