### PR TITLE
OSCER-588: remove dead code from HoursComplianceDeterminationService

### DIFF
--- a/reporting-app/app/services/hours_compliance_determination_service.rb
+++ b/reporting-app/app/services/hours_compliance_determination_service.rb
@@ -6,39 +6,6 @@ class HoursComplianceDeterminationService
   class << self
     include ActivityAggregator
 
-    # NOTE: As of https://github.com/navapbc/oscer/pull/444 this method is no longer called
-    # Publishes different events based on whether external hours exist:
-    # - DeterminedActionRequired: No external hours found, member needs to report from scratch
-    # - DeterminedHoursInsufficient: Has some external hours but needs more
-    # @param kase [CertificationCase]
-    def determine(kase)
-      certification = Certification.find(kase.certification_id)
-      hours_data = aggregate_hours_for_certification(certification)
-      outcome = determine_outcome(hours_data[:total_hours])
-
-      kase.record_hours_compliance(outcome, hours_data)
-
-      if outcome == :compliant
-        Strata::EventManager.publish("DeterminedHoursMet", {
-          case_id: kase.id,
-          certification_id: certification.id
-        })
-      elsif hours_data[:hours_by_source][:external] > 0
-        # Has some external hours but needs more - send insufficient hours email
-        Strata::EventManager.publish("DeterminedHoursInsufficient", {
-          case_id: kase.id,
-          certification_id: certification.id,
-          hours_data: hours_data
-        })
-      else
-        # No external hours found - send action required email
-        Strata::EventManager.publish("DeterminedActionRequired", {
-          case_id: kase.id,
-          certification_id: certification.id
-        })
-      end
-    end
-
     # Called by CertificationBusinessProcess after ActivityReportApproved event
     # @param kase [CertificationCase]
     def determine_after_activity_report(kase)

--- a/reporting-app/app/services/notifications_event_listener.rb
+++ b/reporting-app/app/services/notifications_event_listener.rb
@@ -6,7 +6,7 @@
 # Subscribed events and their notifications:
 # - DeterminedExempt → exempt_email
 # - DeterminedHoursMet / DeterminedCommunityEngagementMet → compliant_email
-# - DeterminedActionRequired / DeterminedCommunityEngagementActionRequired → action_required_email
+# - DeterminedCommunityEngagementActionRequired → action_required_email
 # - DeterminedHoursInsufficient → insufficient_hours_email
 # - DeterminedCommunityEngagementInsufficient → insufficient_community_engagement_email (hours and/or income sections).
 #   Payload carries optional +hours_data+ / +income_data+ aggregates; mailer +show_*+ flags are derived in
@@ -20,7 +20,6 @@ class NotificationsEventListener
       Strata::EventManager.subscribe("DeterminedExempt", method(:handle_exempt))
       Strata::EventManager.subscribe("DeterminedHoursMet", method(:handle_compliant))
       Strata::EventManager.subscribe("DeterminedCommunityEngagementMet", method(:handle_compliant))
-      Strata::EventManager.subscribe("DeterminedActionRequired", method(:handle_action_required))
       Strata::EventManager.subscribe("DeterminedCommunityEngagementActionRequired", method(:handle_action_required))
       Strata::EventManager.subscribe("DeterminedHoursInsufficient", method(:handle_insufficient_hours))
       Strata::EventManager.subscribe("DeterminedCommunityEngagementInsufficient", method(:handle_insufficient_community_engagement))

--- a/reporting-app/spec/mailers/member_mailer_spec.rb
+++ b/reporting-app/spec/mailers/member_mailer_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe MemberMailer, type: :mailer do
   # Stub business process to prevent auto-triggering when creating certifications
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Determination, type: :model do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "/staff/certification_cases", type: :request do
     login_as user
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
+++ b/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
     login_as user
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
@@ -312,7 +311,6 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
       before do
         # Stub services to prevent auto-triggering during certification creation
         allow(Strata::EventManager).to receive(:publish).and_call_original
-        allow(HoursComplianceDeterminationService).to receive(:determine)
         allow(ExemptionDeterminationService).to receive(:determine)
         allow(NotificationService).to receive(:send_email_notification)
 

--- a/reporting-app/spec/services/activity_report_statistics_service_spec.rb
+++ b/reporting-app/spec/services/activity_report_statistics_service_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ActivityReportStatisticsService do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
@@ -13,133 +13,6 @@ RSpec.describe HoursComplianceDeterminationService do
            period_start: period_start, period_end: period_end, **attrs)
   end
 
-  describe ".determine" do
-    # Stub EventManager BEFORE creating certification to prevent auto-triggering business process
-    before do
-      allow(Strata::EventManager).to receive(:publish)
-      allow(NotificationService).to receive(:send_email_notification)
-    end
-
-    let(:certification) { create(:certification) }
-    let(:certification_case) { create(:certification_case, certification_id: certification.id) }
-
-    context "when hours meet target" do
-      before do
-        create_external_hourly_activity_for(certification, hours: 85)
-      end
-
-      it "publishes DeterminedHoursMet event" do
-        described_class.determine(certification_case)
-
-        expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedHoursMet",
-          hash_including(case_id: certification_case.id)
-        )
-      end
-
-      it "creates a compliant determination" do
-        described_class.determine(certification_case)
-
-        determination = Determination.where(subject_id: certification.id).last
-        expect(determination.outcome).to eq("compliant")
-        expect(determination.reasons).to include("hours_reported_compliant")
-      end
-
-      it "closes the case" do
-        described_class.determine(certification_case)
-
-        expect(certification_case.reload).to be_closed
-      end
-
-      it "includes determination_data with calculation details" do
-        described_class.determine(certification_case)
-
-        determination = Determination.where(subject_id: certification.id).last
-        data = determination.determination_data
-
-        expect(data["calculation_type"]).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
-        expect(data["total_hours"]).to eq(85.0)
-        expect(data["target_hours"]).to eq(80)
-      end
-    end
-
-    context "when hours are below target with external hours" do
-      before do
-        create_external_hourly_activity_for(certification, hours: 50)
-      end
-
-      it "publishes DeterminedHoursInsufficient event (has some hours but needs more)" do
-        described_class.determine(certification_case)
-
-        expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedHoursInsufficient",
-          hash_including(case_id: certification_case.id)
-        )
-      end
-
-      it "creates a not_compliant determination" do
-        described_class.determine(certification_case)
-
-        determination = Determination.where(subject_id: certification.id).last
-        expect(determination.outcome).to eq("not_compliant")
-        expect(determination.reasons).to include("hours_reported_insufficient")
-      end
-
-      it "does not close the case" do
-        described_class.determine(certification_case)
-
-        expect(certification_case.reload).not_to be_closed
-      end
-    end
-
-    context "when hours are below target with NO external hours" do
-      # No external hourly activities created - member needs to report from scratch
-
-      it "publishes DeterminedActionRequired event (no hours found)" do
-        described_class.determine(certification_case)
-
-        expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedActionRequired",
-          hash_including(case_id: certification_case.id)
-        )
-      end
-
-      it "creates a not_compliant determination" do
-        described_class.determine(certification_case)
-
-        determination = Determination.where(subject_id: certification.id).last
-        expect(determination.outcome).to eq("not_compliant")
-        expect(determination.reasons).to include("hours_reported_insufficient")
-      end
-    end
-
-    context "when hours exactly meet target" do
-      before do
-        create_external_hourly_activity_for(certification, hours: 80)
-      end
-
-      it "publishes DeterminedHoursMet event" do
-        described_class.determine(certification_case)
-
-        expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedHoursMet",
-          hash_including(case_id: certification_case.id)
-        )
-      end
-    end
-
-    context "with no hours data" do
-      it "publishes DeterminedActionRequired event" do
-        described_class.determine(certification_case)
-
-        expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedActionRequired",
-          hash_including(case_id: certification_case.id)
-        )
-      end
-    end
-  end
-
   describe ".calculate" do
     before do
       allow(Strata::EventManager).to receive(:publish)
@@ -197,6 +70,25 @@ RSpec.describe HoursComplianceDeterminationService do
         expect(determination.outcome).to eq("not_compliant")
         expect(determination.reasons).to include("hours_reported_insufficient")
       end
+
+      it "does not close the case" do
+        described_class.calculate(certification.id)
+        kase = CertificationCase.find_by!(certification_id: certification.id)
+
+        expect(kase).to be_open
+      end
+    end
+
+    context "when hours are below target with NO external hours" do
+      # No external hourly activities created - member needs to report from scratch
+
+      it "creates a not_compliant determination" do
+        described_class.calculate(certification.id)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.outcome).to eq("not_compliant")
+        expect(determination.reasons).to include("hours_reported_insufficient")
+      end
     end
   end
 
@@ -217,14 +109,14 @@ RSpec.describe HoursComplianceDeterminationService do
       end
 
       it "sums hours across all entries" do
-        described_class.determine(certification_case)
+        described_class.calculate(certification_case.certification_id)
 
         determination = Determination.where(subject_id: certification.id).last
         expect(determination.determination_data["total_hours"]).to eq(85.0)
       end
 
       it "groups hours by category" do
-        described_class.determine(certification_case)
+        described_class.calculate(certification_case.certification_id)
 
         determination = Determination.where(subject_id: certification.id).last
         by_category = determination.determination_data["hours_by_category"]
@@ -235,7 +127,7 @@ RSpec.describe HoursComplianceDeterminationService do
       end
 
       it "tracks hours by source" do
-        described_class.determine(certification_case)
+        described_class.calculate(certification_case.certification_id)
 
         determination = Determination.where(subject_id: certification.id).last
         by_source = determination.determination_data["hours_by_source"]
@@ -245,7 +137,7 @@ RSpec.describe HoursComplianceDeterminationService do
       end
 
       it "includes entry IDs in determination_data" do
-        described_class.determine(certification_case)
+        described_class.calculate(certification_case.certification_id)
 
         determination = Determination.where(subject_id: certification.id).last
         expect(determination.determination_data["external_hourly_activity_ids"].length).to eq(3)
@@ -266,7 +158,7 @@ RSpec.describe HoursComplianceDeterminationService do
       end
 
       it "only counts hours within the lookback period" do
-        described_class.determine(certification_case)
+        described_class.calculate(certification_case.certification_id)
 
         determination = Determination.where(subject_id: certification.id).last
         # Should only count 50 hours (within period), not 150 (50 + 100)

--- a/reporting-app/spec/services/income_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/income_compliance_determination_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe IncomeComplianceDeterminationService do
   def expect_no_ce_workflow_events_published
     expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedHoursMet", anything)
     expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedHoursInsufficient", anything)
-    expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedActionRequired", anything)
     expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedCommunityEngagementMet", anything)
     expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedCommunityEngagementInsufficient", anything)
     expect(Strata::EventManager).not_to have_received(:publish).with("DeterminedCommunityEngagementActionRequired", anything)

--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe MemberDashboardComplianceService do
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/services/member_status_service_spec.rb
+++ b/reporting-app/spec/services/member_status_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe MemberStatusService do
   # Stub business process to prevent auto-triggering determinations when creating certifications
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end

--- a/reporting-app/spec/services/notifications_event_listener_spec.rb
+++ b/reporting-app/spec/services/notifications_event_listener_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe NotificationsEventListener, type: :service do
   before do
     allow(NotificationService).to receive(:send_email_notification)
     # Stub services that may publish events during certification creation
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
   end
 

--- a/reporting-app/spec/services/notifications_event_listener_spec.rb
+++ b/reporting-app/spec/services/notifications_event_listener_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe NotificationsEventListener, type: :service do
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedExempt", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedHoursMet", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementMet", anything)
-      expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedActionRequired", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementActionRequired", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedHoursInsufficient", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementInsufficient", anything)

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "dashboard/index", type: :view do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(HoursComplianceDeterminationService).to receive(:determine)
     allow(ExemptionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
 


### PR DESCRIPTION
## Ticket

Resolves #588 

## Changes

- `HoursComplianceDeterminationService#determine` removed
- Specs for `HoursComplianceDeterminationService#determine` removed or moved to `HoursComplianceDeterminationService#calculate`
- Spec `allow` for `HoursComplianceDeterminationService#determine` removed from specs

## Context for reviewers

#444 removed calls to this method. This PR just cleans up the code.

Removed specs validated as already being checked in `calculate`

## Testing

All tests pass.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->