### PR TITLE
OSCER-606: Add verification window start & end dates to certification cases

### DIFF
--- a/reporting-app/db/migrate/20260601163009_add_verification_window_to_certification_cases.rb
+++ b/reporting-app/db/migrate/20260601163009_add_verification_window_to_certification_cases.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddVerificationWindowToCertificationCases < ActiveRecord::Migration[8.0]
+  def change
+    add_column :certification_cases, :verification_window_start_date, :date, comment: "The start date for the time a member is given to resolve a negative determination on their CE certification"
+    add_column :certification_cases, :verification_window_end_date, :date, comment: "The end date for the time a member is given to resolve a negative determination on their CE certification"
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_22_182945) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_01_163009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -119,6 +119,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_22_182945) do
     t.jsonb "facts"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "verification_window_start_date", comment: "The start date for the time a member is given to resolve a negative determination on their CE certification"
+    t.date "verification_window_end_date", comment: "The end date for the time a member is given to resolve a negative determination on their CE certification"
     t.index ["certification_id"], name: "index_certification_cases_on_certification_id"
   end
 


### PR DESCRIPTION
## Ticket

Enables #606

## Context for reviewers

This is the database migration that enables changes coming in a follow-on PR for #606 

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->