### PR TITLE
Fix date-dependent flaky test in ExemptionDeterminationService spec

### DIFF
--- a/reporting-app/spec/services/exemption_determination_service_spec.rb
+++ b/reporting-app/spec/services/exemption_determination_service_spec.rb
@@ -14,7 +14,16 @@ RSpec.describe ExemptionDeterminationService do
   end
 
   describe '#determine' do
-    let(:certification) { create(:certification, member_data: member_data) }
+    let(:certification) do
+      create(
+        :certification,
+        member_data: member_data,
+        # Pin the evaluation date to the same anchor as the DOBs (cert_date). The
+        # factory default is a random future date, which flips age-boundary cases
+        # (under-19, 64) by calendar day — a non-deterministic flake.
+        certification_requirements: build(:certification_certification_requirements, certification_date: cert_date)
+      )
+    end
     let(:kase) { create(:certification_case, certification_id: certification.id) }
 
     before do


### PR DESCRIPTION
The #determine specs derive member DOBs from a fixed anchor
(cert_date = 2025-07-01; e.g. "under 19" = cert_date - 18.years), but the
certification's evaluation date came from the factory default
Faker::Date.forward(days: 30) — a random date anchored to the system
clock. With the DOB anchor ~a year before the random eval date, a
birthday could fall in the gap, computing ages ~1 year high and flipping
age-boundary cases.

This armed on 2026-06-01 — the first date Faker's window (today+1..+30)
could reach the under-19 case's 19th birthday (2026-07-01). Failure
probability rises ~1/30 per day, reaching 100% on 2026-06-30. The
"64 years old" case shares the same 2026-07-01 boundary (its 65th
birthday), so both contexts are affected.

Pin the evaluation date to cert_date in the shared let(:certification),
so age is computed against the same anchor as the DOBs. Deterministic,
intent-preserving (age-at-certification), and spec-local — the factory
default is left unchanged to avoid blast radius on specs that rely on a
future certification_date.

Verified: with eval pinned to the boundary the spec fails 8/41; with the
fix it passes deterministically across seeds 1/12345/99999.

Resolves #614

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->