### PR TITLE
OSCER-608: Migration to allow multiple forms

### DIFF
--- a/reporting-app/db/migrate/20260601172517_allow_multiple_forms_per_case.rb
+++ b/reporting-app/db/migrate/20260601172517_allow_multiple_forms_per_case.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AllowMultipleFormsPerCase < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :activity_report_application_forms, :certification_case_id, unique: true
+    add_index :activity_report_application_forms, :certification_case_id
+    remove_index :exemption_application_forms, :certification_case_id, unique: true
+    add_index :exemption_application_forms, :certification_case_id
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_01_163009) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_01_172517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -65,7 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_01_163009) do
     t.datetime "submitted_at"
     t.uuid "certification_case_id"
     t.jsonb "reporting_periods"
-    t.index ["certification_case_id"], name: "idx_on_certification_case_id_df9964575c", unique: true
+    t.index ["certification_case_id"], name: "idx_on_certification_case_id_df9964575c"
   end
 
   create_table "certification_batch_upload_audit_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -153,7 +153,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_01_163009) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "certification_case_id"
-    t.index ["certification_case_id"], name: "index_exemption_application_forms_on_certification_case_id", unique: true
+    t.index ["certification_case_id"], name: "index_exemption_application_forms_on_certification_case_id"
   end
 
   create_table "external_hourly_activities", id: :uuid, default: -> { "gen_random_uuid()" }, comment: "Hours data from external sources (API/batch) for compliance calculation", force: :cascade do |t|


### PR DESCRIPTION
## Ticket

Enables #608

## Changes

MIgration added that changes unique index to simple index

## Context for reviewers

Will allow removal of uniqueness constraints in models

## Testing

- Rollback returns schema to previous state
- CI Passes

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->