### PR TITLE
Fix flaky activity-name assertions in tasks request spec

### DIFF
--- a/reporting-app/spec/requests/tasks_spec.rb
+++ b/reporting-app/spec/requests/tasks_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe "/staff/tasks", type: :request do
 
             expect(response.body).to include('data-document-preview-target="prefillForm"')
             expect(response.body).to include("data-activity-id=\"#{activity.id}\"")
-            expect(response.body).to include(activity.name)
+            # Escape: Faker names can contain HTML-special chars (e.g. "O'Kon" -> &#39;).
+            expect(response.body).to include(CGI.escapeHTML(activity.name))
             expect(response.body).to include('data-action="document-preview#close"')
           end
         end
@@ -211,7 +212,8 @@ RSpec.describe "/staff/tasks", type: :request do
           with_doc_ai_enabled do
             get "/staff/tasks/#{activity_report_task.id}"
 
-            expect(response.body).to include(activity.name)
+            # Escape: Faker names can contain HTML-special chars (e.g. "O'Kon" -> &#39;).
+            expect(response.body).to include(CGI.escapeHTML(activity.name))
             expect(response.body).not_to include('data-document-preview-target="previewArea"')
           end
         end


### PR DESCRIPTION
Resolves #586

The :activity factory sets name { Faker::Company.name }, ~3% of which
contain an apostrophe (e.g. "O'Kon"). The staff activity report renders
the name with plain ERB (<%= activity.name %>), which escapes ' to &#39;,
so `expect(response.body).to include(activity.name)` failed intermittently
when Faker rolled a name with HTML-special characters.

The flake was invisible to --seed reproduction because Faker is not
seeded to RSpec's seed: the same seed produced different outcomes.

Wrap the expected value in CGI.escapeHTML so the assertion matches what
Rails actually renders, keeping the realistic Faker-generated data and
additionally verifying the name is HTML-escaped.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->