### PR TITLE
OSCER-608 allow case to have multiple application forms of each type

### DIFF
--- a/reporting-app/app/controllers/dashboard_controller.rb
+++ b/reporting-app/app/controllers/dashboard_controller.rb
@@ -28,11 +28,11 @@ class DashboardController < ApplicationController
   end
 
   def set_exemption_application_form
-    @exemption_application_form = ExemptionApplicationForm.where(certification_case_id: @certification_case&.id).order(:status).first
+    @exemption_application_form = ExemptionApplicationForm.where(certification_case_id: @certification_case&.id).order(:status, created_at: :desc).first
   end
 
   def set_activity_report_application_form
-    @activity_report_application_form = ActivityReportApplicationForm.where(certification_case_id: @certification_case&.id).order(:status).first
+    @activity_report_application_form = ActivityReportApplicationForm.where(certification_case_id: @certification_case&.id).order(:status, created_at: :desc).first
   end
 
   def set_information_requests

--- a/reporting-app/app/controllers/dashboard_controller.rb
+++ b/reporting-app/app/controllers/dashboard_controller.rb
@@ -28,11 +28,11 @@ class DashboardController < ApplicationController
   end
 
   def set_exemption_application_form
-    @exemption_application_form = ExemptionApplicationForm.find_by_certification_case_id(@certification_case&.id)
+    @exemption_application_form = ExemptionApplicationForm.where(certification_case_id: @certification_case&.id).order(:status).first
   end
 
   def set_activity_report_application_form
-    @activity_report_application_form = ActivityReportApplicationForm.find_by_certification_case_id(@certification_case&.id)
+    @activity_report_application_form = ActivityReportApplicationForm.where(certification_case_id: @certification_case&.id).order(:status).first
   end
 
   def set_information_requests

--- a/reporting-app/app/models/activity_report_application_form.rb
+++ b/reporting-app/app/models/activity_report_application_form.rb
@@ -12,7 +12,8 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
   strata_attribute :number_of_months_to_certify, :integer
   strata_attribute :months_that_can_be_certified, :year_month, array: true
 
-  validates :certification_case_id, presence: true, uniqueness: true
+  # At most one in-progress form per case; any number of submitted forms may accumulate over resubmissions.
+  validates :certification_case_id, presence: true, uniqueness: { conditions: -> { in_progress } }
   validates :reporting_periods,
     length: {
       is: :number_of_months_to_certify,

--- a/reporting-app/app/models/exemption_application_form.rb
+++ b/reporting-app/app/models/exemption_application_form.rb
@@ -6,7 +6,8 @@ class ExemptionApplicationForm < Strata::ApplicationForm
 
   enum :exemption_type, Exemption.enum_hash
   validates :exemption_type, inclusion: { in: Exemption.types + LEGACY_EXEMPTION_TYPES }, allow_nil: true
-  validates :certification_case_id, uniqueness: true
+  # At most one in-progress form per case; any number of submitted forms may accumulate over resubmissions.
+  validates :certification_case_id, uniqueness: { conditions: -> { in_progress } }
 
   has_many_attached :supporting_documents
 

--- a/reporting-app/spec/models/activity_report_application_form_spec.rb
+++ b/reporting-app/spec/models/activity_report_application_form_spec.rb
@@ -4,16 +4,39 @@ require 'rails_helper'
 
 RSpec.describe ActivityReportApplicationForm, type: :model do
   describe "validations" do
-    describe "certification_case_id uniqueness" do
+    describe "certification_case_id" do
       let(:certification) { create(:certification) }
       let(:certification_case) { create(:certification_case, certification: certification) }
 
-      it "requires unique certification_case_id" do
+      before { allow(Strata::EventManager).to receive(:publish) }
+
+      it "requires a certification_case_id" do
+        form = build(:activity_report_application_form, certification_case_id: nil)
+
+        expect(form.save).to be(false)
+        expect(form.errors[:certification_case_id]).to include("can't be blank")
+      end
+
+      it "allows only one in-progress form per case" do
         create(:activity_report_application_form, certification_case_id: certification_case.id)
         second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
 
         expect(second_form.save).to be(false)
         expect(second_form.errors[:certification_case_id]).to include("has already been taken")
+      end
+
+      it "allows a new in-progress form once the prior form is submitted" do
+        create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+
+        expect(second_form.save).to be(true)
+      end
+
+      it "allows multiple submitted forms for the same case" do
+        create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        second_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+
+        expect(second_form.submit_application).to be(true)
       end
 
       it "allows different certification_case_ids" do

--- a/reporting-app/spec/models/exemption_application_form_spec.rb
+++ b/reporting-app/spec/models/exemption_application_form_spec.rb
@@ -22,16 +22,32 @@ RSpec.describe ExemptionApplicationForm, type: :model do
   end
 
   describe "validations" do
-    describe "certification_case_id uniqueness" do
+    describe "certification_case_id" do
       let(:certification) { create(:certification) }
       let(:certification_case) { create(:certification_case, certification: certification) }
 
-      it "requires unique certification_case_id" do
+      before { allow(Strata::EventManager).to receive(:publish) }
+
+      it "allows only one in-progress form per case" do
         create(:exemption_application_form, certification_case_id: certification_case.id)
         second_form = build(:exemption_application_form, certification_case_id: certification_case.id)
 
         expect(second_form.save).to be(false)
         expect(second_form.errors[:certification_case_id]).to include("has already been taken")
+      end
+
+      it "allows a new in-progress form once the prior form is submitted" do
+        create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        second_form = build(:exemption_application_form, certification_case_id: certification_case.id)
+
+        expect(second_form.save).to be(true)
+      end
+
+      it "allows multiple submitted forms for the same case" do
+        create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        second_form = create(:exemption_application_form, certification_case_id: certification_case.id)
+
+        expect(second_form.submit_application).to be(true)
       end
 
       it "allows different certification_case_ids" do

--- a/reporting-app/spec/requests/dashboard_spec.rb
+++ b/reporting-app/spec/requests/dashboard_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "/dashboard", type: :request do
+  include Warden::Test::Helpers
+
+  let(:member_data) { build(:certification_member_data, :with_account_email) }
+  let!(:certification) { create(:certification, member_data: member_data) }
+  let(:user) { create(:user, email: member_data.account_email) }
+  let(:certification_case) { create(:certification_case, certification: certification) }
+
+  before do
+    allow(Strata::EventManager).to receive(:publish)
+    login_as user
+  end
+
+  after do
+    Warden.test_reset!
+  end
+
+  describe "GET /" do
+    it "does not fail if no application form" do
+      get "/dashboard"
+      expect(response).to be_ok
+    end
+
+    it "sets the activity report application form" do
+      form = create(:activity_report_application_form, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).to include(activity_report_application_form_path(form))
+    end
+
+    it "sets the in-progress activity report application form if more than one form" do
+      submitted_form = create(:activity_report_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id)
+      form = create(:activity_report_application_form, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).not_to include(activity_report_application_form_path(submitted_form))
+      expect(response.body).to include(activity_report_application_form_path(form))
+    end
+
+    it "sets the exemption application form" do
+      form = create(:exemption_application_form, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).to include(exemption_application_form_path(form))
+    end
+
+    it "sets the in-progress exemption application form if more than one form" do
+      submitted_form = create(:exemption_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id)
+      form = create(:exemption_application_form, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).not_to include(exemption_application_form_path(submitted_form))
+      expect(response.body).to include(exemption_application_form_path(form))
+    end
+  end
+end

--- a/reporting-app/spec/requests/dashboard_spec.rb
+++ b/reporting-app/spec/requests/dashboard_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "/dashboard", type: :request do
       expect(response.body).to include(activity_report_application_form_path(form))
     end
 
+    it "sets the most recent activity report application form if only submitted exist" do
+      older_submitted_form = create(:activity_report_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id, created_at: 1.day.ago)
+      younger_submitted_form = create(:activity_report_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).not_to include(activity_report_application_form_path(older_submitted_form))
+      expect(response.body).to include(activity_report_application_form_path(younger_submitted_form))
+    end
+
     it "sets the exemption application form" do
       form = create(:exemption_application_form, user_id: user.id, certification_case_id: certification_case.id)
       get "/dashboard"
@@ -51,6 +59,14 @@ RSpec.describe "/dashboard", type: :request do
       get "/dashboard"
       expect(response.body).not_to include(exemption_application_form_path(submitted_form))
       expect(response.body).to include(exemption_application_form_path(form))
+    end
+
+    it "sets the most recent exemption application form if only submitted exist" do
+      older_submitted_form = create(:exemption_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id, created_at: 1.day.ago)
+      younger_submitted_form = create(:exemption_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id)
+      get "/dashboard"
+      expect(response.body).not_to include(exemption_application_form_path(older_submitted_form))
+      expect(response.body).to include(exemption_application_form_path(younger_submitted_form))
     end
   end
 end


### PR DESCRIPTION
## Ticket

Resolves #608 

## Changes

- Change uniqueness on application forms to uniqueness on in_progress forms
- Update member dashboard to return in_progress form(s) if exists, else arbitrary form(s)

## Context for reviewers

Final step in the journey in the backend to allow multiple form submissions in the verification window.

Does *not* enable users to submit multiple forms.

FWIW, the dashboard test failed without the "order by status" set when testing locally.

Manually tested only for regressions, as the frontend does not even support submitting an activity report application form when an exemption form has been denied.

## Testing

- CI passes
- Manual test of member dashboard to assure no regressions
  - Works when go back to dashboard with in-progress activity report form
  - Works when go to dashboard with submitted activity report form
  - Works when go back to dashboard with in-progress exemption form
  - Works when go to dashboard with submitted exemption form


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->