### PR TITLE
OSCER-621: force certification lookback to include income for spec

### DIFF
--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -313,10 +313,12 @@ RSpec.describe MemberDashboardComplianceService do
     end
 
     context "when income aggregation runs against the open case" do
+      let(:certification_date) { Date.today }
+      let(:certification) { create(:certification, certification_requirements: build(:certification_certification_requirements, certification_date:)) }
       let(:activity_report_application_form) { create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
 
       before do
-        create(:income_activity, activity_report_application_form_id: activity_report_application_form.id, income: 30_00)
+        create(:income_activity, activity_report_application_form_id: activity_report_application_form.id, income: 30_00, month: certification_date)
         activity_report_application_form.reload
       end
 


### PR DESCRIPTION
## Ticket

Resolves #621

## Changes

- Date explicitly set for certification date and income for spec

## Context for reviewers

Spec was intermittently failing, as the income was set for a month ago, and the certification lookback period was set randomly, so did not always include it.

Fix was to make sure the two were always in sync.

## Testing

- CI passes
- Ran the loop in the bug report for several minutes without failure

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->