### PR TITLE
OSCER-629: Can submit activity report after exemption denial

### DIFF
--- a/reporting-app/app/views/dashboard/_exemption_denied.html.erb
+++ b/reporting-app/app/views/dashboard/_exemption_denied.html.erb
@@ -1,6 +1,16 @@
 <div class="grid-container">
   <%= render AlertComponent.new(type: AlertComponent::TYPES::ERROR, heading: t(".heading"), message: t(".intro"), heading_level: 3) %>
   <div class="margin-top-3">
-    <%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button" %>
+    <% if activity_report&.in_progress? %>
+      <% continue_path = feature_enabled?(:doc_ai) && !session[:doc_ai_skip] ?
+            doc_ai_upload_activity_report_application_form_path(activity_report) :
+            activity_report_application_form_path(activity_report) %>
+      <%= link_to t("dashboard.new_certification.activity_report.continue_report_button"), continue_path,
+            class: "usa-button margin-right-2 margin-bottom-1" %>
+    <% else %>
+      <%= link_to t("dashboard.new_certification.current_period.report_activities_button"), new_activity_report_application_form_path(certification_case_id: certification_case&.id),
+            class: "usa-button margin-right-2 margin-bottom-1" %>
+    <% end %>
+    <%= link_to t(".view_exemption_button"), exemption_application_form_path(exemption_application), class: "usa-button usa-button--outline margin-bottom-1" %>
   </div>
 </div>

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -234,6 +234,7 @@ RSpec.describe "dashboard/index", type: :view do
       render
       expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
     end
+
     context "with an in-progress activity report" do
       before do
         assign(:activity_report_application_form, create(:activity_report_application_form, certification_case_id: certification_case.id))

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -181,6 +181,71 @@ RSpec.describe "dashboard/index", type: :view do
     end
   end
 
+  context "with a denied activity report" do
+    let(:activity_report_application_form) { create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
+
+    before do
+      assign(:activity_report_application_form, activity_report_application_form)
+      assign(:certification_case, certification_case)
+      # Set hours_needed to 0 to show requirements met state
+      assign(:hours_needed, 0)
+      assign(:total_hours_reported, HoursComplianceDeterminationService::TARGET_HOURS)
+
+      certification_case.activity_report_approval_status = "denied"
+    end
+
+    it 'renders a message that the activity report is denied' do
+      render
+      expect(rendered).to have_selector('p', text: I18n.t('dashboard.activity_report_denied.intro'))
+    end
+
+    it 'has a button to view the activity report' do
+      render
+      expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_denied.view_activity_report_button'))
+    end
+  end
+
+  context "with a denied exemption request" do
+    let (:exemption_application_form) { create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
+
+    before do
+      assign(:exemption_application_form, exemption_application_form)
+      assign(:certification_case, certification_case)
+
+      certification_case.exemption_request_approval_status = "denied"
+    end
+
+    it 'renders a message that the exemption request is denied' do
+      render
+      expect(rendered).to have_selector('p', text: I18n.t('dashboard.exemption_denied.intro'))
+    end
+
+    it 'has a button to view the exemption' do
+      render
+      expect(rendered).to have_selector('a', text: I18n.t('dashboard.exemption_denied.view_exemption_button'))
+    end
+
+    it 'renders button to report activities' do
+      render
+      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.current_period.report_activities_button'))
+    end
+
+    it 'does not render the "get started" callout' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+    end
+    context "with an in-progress activity report" do
+      before do
+        assign(:activity_report_application_form, create(:activity_report_application_form, certification_case_id: certification_case.id))
+      end
+
+      it 'renders a button to continue the activity report' do
+        render
+        expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.activity_report.continue_report_button'))
+      end
+    end
+  end
+
   context "with previous certifications" do
     let(:older_certification) { create(:certification) }
 


### PR DESCRIPTION
## Ticket

Resolves #629 

## Changes

- Button added to _exemption_denied partial for add and complete activity report
- Specs added for denial views

## Context for reviewers

When an exemption is denied, the case is referred back to the member so they can add an activity report. The buttons allowing them to do this were missing. This PR adds them back.

Buttons taken directly from _new_certification partial. It did not seem worth it to create a new partial to share the buttons.

Also requires UX review.

## Testing

- CI
- Manual

### Exemption under Review
<img width="1052" height="473" alt="Exemption review" src="https://github.com/user-attachments/assets/5b526ae3-1c05-4664-a78f-5fdc7fa8f4fe" />

### Exemption Denied
<img width="1033" height="515" alt="Exemption Denied" src="https://github.com/user-attachments/assets/c844b1d5-b172-4f32-a327-5dc9ad7ad6a7" />

### Activity Report Incomplete
<img width="1008" height="499" alt="AR WIP" src="https://github.com/user-attachments/assets/aea1c435-48a6-43a5-9c95-6284077cc511" />

### Activity Report under Review
<img width="967" height="395" alt="AR Review" src="https://github.com/user-attachments/assets/f8ced1b9-6f0b-42bb-8897-dee80eb2b527" />

### Activity Report Denied
<img width="1009" height="487" alt="AR Denied" src="https://github.com/user-attachments/assets/0f5415b7-aa84-4ce2-acc4-c003cdf378f2" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->