### PR TITLE
OSCER-635: unify error behavior of external activity services

### DIFF
--- a/reporting-app/app/services/certifications/creation_service.rb
+++ b/reporting-app/app/services/certifications/creation_service.rb
@@ -84,12 +84,6 @@ class Certifications::CreationService
         employer: activity_data.employer,
         recalculate_income_compliance: false
       )
-
-      if result.is_a?(Hash) && result[:error]
-        row = ExternalIncomeActivity.new
-        row.errors.add(:base, result[:error])
-        raise ActiveRecord::RecordInvalid.new(row)
-      end
     end
   end
 end

--- a/reporting-app/app/services/certifications/creation_service.rb
+++ b/reporting-app/app/services/certifications/creation_service.rb
@@ -55,14 +55,6 @@ class Certifications::CreationService
         source_type: ExternalHourlyActivity::SOURCE_TYPES[:api],
         source_id: nil
       )
-
-      # Handle service error response
-      if result.is_a?(Hash) && result[:error]
-        # Create a dummy record to use RecordInvalid pattern
-        activity = ExternalHourlyActivity.new
-        activity.errors.add(:base, result[:error])
-        raise ActiveRecord::RecordInvalid.new(activity)
-      end
     end
   end
 

--- a/reporting-app/app/services/external_hourly_activity_service.rb
+++ b/reporting-app/app/services/external_hourly_activity_service.rb
@@ -12,11 +12,13 @@ class ExternalHourlyActivityService
     # @return [Hash] with :error, :status keys on failure
     def create_entry(member_id:, category:, hours:, period_start:, period_end:,
                      source_type:, source_id: nil)
+      entry = ExternalHourlyActivity.new
       if duplicate_entry?(member_id:, category:, hours:, period_start:, period_end:)
-        return { error: "Duplicate entry", status: :conflict }
+        entry.errors.add(:base, "Duplicate entry")
+        raise ActiveRecord::RecordInvalid.new(entry)
       end
 
-      entry = ExternalHourlyActivity.new(
+      entry.update!(
         member_id: member_id,
         category: category,
         hours: hours,
@@ -26,11 +28,7 @@ class ExternalHourlyActivityService
         source_id: source_id
       )
 
-      if entry.save
-        entry
-      else
-        { error: entry.errors.full_messages.join(", "), status: :unprocessable_entity }
-      end
+      entry
     end
 
     # Check for exact duplicate entry

--- a/reporting-app/app/services/external_hourly_activity_service.rb
+++ b/reporting-app/app/services/external_hourly_activity_service.rb
@@ -9,7 +9,7 @@ class ExternalHourlyActivityService
   class << self
     # Create hours data entry for a member
     # @return [ExternalHourlyActivity] on success
-    # @return [Hash] with :error, :status keys on failure
+    # @raise [ActiveRecord::RecordInvalid] on duplicate entry or validation failure
     def create_entry(member_id:, category:, hours:, period_start:, period_end:,
                      source_type:, source_id: nil)
       entry = ExternalHourlyActivity.new

--- a/reporting-app/app/services/external_income_activity_service.rb
+++ b/reporting-app/app/services/external_income_activity_service.rb
@@ -19,6 +19,8 @@ class ExternalIncomeActivityService
     def create_entry(member_id:, category:, gross_income:, period_start:, period_end:,
                      source_type:, source_id: nil, reported_at: Time.current, metadata: {}, employer: nil,
                      recalculate_income_compliance: true)
+      entry = ExternalIncomeActivity.new()
+
       if duplicate_entry?(
         member_id: member_id,
         category: category,
@@ -26,23 +28,23 @@ class ExternalIncomeActivityService
         period_start: period_start,
         period_end: period_end
       )
-        return { error: "Duplicate entry" }
+        entry.errors.add(:base, "Duplicate entry")
+        raise ActiveRecord::RecordInvalid.new(entry)
       end
 
-      entry = ExternalIncomeActivity.new(
-        member_id: member_id,
-        category: category,
-        gross_income: gross_income,
-        period_start: period_start,
-        period_end: period_end,
-        source_type: source_type,
-        source_id: source_id,
-        reported_at: reported_at,
-        metadata: (metadata || {}).merge(employer.present? ? { "employer" => employer } : {})
-      )
-
       Strata::AuditLog.record do |log|
-        entry.save!
+        entry.update!(
+          member_id: member_id,
+          category: category,
+          gross_income: gross_income,
+          period_start: period_start,
+          period_end: period_end,
+          source_type: source_type,
+          source_id: source_id,
+          reported_at: reported_at,
+          metadata: (metadata || {}).merge(employer.present? ? { "employer" => employer } : {})
+        )
+
         log.add_line(
           actor: self,
           action: "external_income_activity.create",

--- a/reporting-app/app/services/external_income_activity_service.rb
+++ b/reporting-app/app/services/external_income_activity_service.rb
@@ -15,7 +15,7 @@ class ExternalIncomeActivityService
     #   compliance for the open case (may +close!+ when compliant); +Certifications::CreationService+ passes +false+.
     # @return [ExternalIncomeActivity] on success
     # @return [Hash] with +:error+ key when a duplicate entry is detected (before save)
-    # @raise [ActiveRecord::RecordInvalid] when validations fail
+# @raise [ActiveRecord::RecordInvalid] on duplicate entry or validation failure
     def create_entry(member_id:, category:, gross_income:, period_start:, period_end:,
                      source_type:, source_id: nil, reported_at: Time.current, metadata: {}, employer: nil,
                      recalculate_income_compliance: true)

--- a/reporting-app/app/services/external_income_activity_service.rb
+++ b/reporting-app/app/services/external_income_activity_service.rb
@@ -15,7 +15,7 @@ class ExternalIncomeActivityService
     #   compliance for the open case (may +close!+ when compliant); +Certifications::CreationService+ passes +false+.
     # @return [ExternalIncomeActivity] on success
     # @return [Hash] with +:error+ key when a duplicate entry is detected (before save)
-# @raise [ActiveRecord::RecordInvalid] on duplicate entry or validation failure
+    # @raise [ActiveRecord::RecordInvalid] on duplicate entry or validation failure
     def create_entry(member_id:, category:, gross_income:, period_start:, period_end:,
                      source_type:, source_id: nil, reported_at: Time.current, metadata: {}, employer: nil,
                      recalculate_income_compliance: true)

--- a/reporting-app/spec/services/external_hourly_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_hourly_activity_service_spec.rb
@@ -50,59 +50,38 @@ RSpec.describe ExternalHourlyActivityService do
       end
 
       it "returns conflict error" do
-        result = described_class.create_entry(**valid_params)
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to eq("Duplicate entry")
-        expect(result[:status]).to eq(:conflict)
+        expect { described_class.create_entry(**valid_params) }.to raise_error(/Duplicate entry/)
       end
 
       it "does not create a new entry" do
         expect {
-          described_class.create_entry(**valid_params)
+          begin
+            described_class.create_entry(**valid_params)
+          rescue
+          end
         }.not_to change(ExternalHourlyActivity, :count)
       end
     end
 
     context "with validation errors" do
       it "returns error for missing member_id" do
-        result = described_class.create_entry(**valid_params.merge(member_id: nil))
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to include("Member")
-        expect(result[:status]).to eq(:unprocessable_entity)
+        expect { described_class.create_entry(**valid_params.merge(member_id: nil)) }.to raise_error(/Member/)
       end
 
       it "returns error for invalid category" do
-        result = described_class.create_entry(**valid_params.merge(category: "invalid"))
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to include("Category")
-        expect(result[:status]).to eq(:unprocessable_entity)
+        expect { described_class.create_entry(**valid_params.merge(category: "invalid")) }.to raise_error(/Category/)
       end
 
       it "returns error for zero hours" do
-        result = described_class.create_entry(**valid_params.merge(hours: 0))
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to include("Hours")
-        expect(result[:status]).to eq(:unprocessable_entity)
+        expect { described_class.create_entry(**valid_params.merge(hours: 0)) }.to raise_error(/Hours/)
       end
 
       it "returns error for negative hours" do
-        result = described_class.create_entry(**valid_params.merge(hours: -10))
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to include("Hours")
-        expect(result[:status]).to eq(:unprocessable_entity)
+        expect { described_class.create_entry(**valid_params.merge(hours: -10)) }.to raise_error(/Hours/)
       end
 
       it "returns error for invalid source_type" do
-        result = described_class.create_entry(**valid_params.merge(source_type: "invalid"))
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to include("Source type")
-        expect(result[:status]).to eq(:unprocessable_entity)
+        expect { described_class.create_entry(**valid_params.merge(source_type: "invalid")) }.to raise_error(/Source type/)
       end
     end
 

--- a/reporting-app/spec/services/external_income_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_income_activity_service_spec.rb
@@ -135,15 +135,15 @@ RSpec.describe ExternalIncomeActivityService do
       end
 
       it "returns conflict error" do
-        result = described_class.create_entry(**valid_params)
-
-        expect(result).to be_a(Hash)
-        expect(result[:error]).to eq("Duplicate entry")
+        expect { described_class.create_entry(**valid_params) }.to raise_error(/Duplicate/)
       end
 
       it "does not create a new entry" do
         expect {
-          described_class.create_entry(**valid_params)
+          begin
+            described_class.create_entry(**valid_params)
+          rescue
+          end
         }.not_to change(ExternalIncomeActivity, :count)
       end
     end


### PR DESCRIPTION
## Ticket

Resolves #635

## Changes

- ExternalIncomeActivityService and ExternalHourlyActivityService updated to raise validation errors instead of passing error hashes
- Certifications::CreationService updated so no longer looks for hashes to raise validation errors from.

## Context for reviewers

Simple refactor.

When logging creation of ExternalIncomeActivity, we realized we were avoiding raising validation errors only to raise them later. It was easier to raise them in ExternalIncomeActivity, so we did. This consolidates the behavior across both external activity services to improve consistency and simplify the code.

## Testing

- CI passes
- Generation of external activities via the demo consistent with main
- Forcing duplicate in external activity services consistent with main
- Forcing validation error in external activity services consistent with main

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->