### PR TITLE
OSCER-639: Member dashboard landing (hero, get started, previous certs)

### DIFF
--- a/e2e/reporting-app/pages/members/DashboardPage.ts
+++ b/e2e/reporting-app/pages/members/DashboardPage.ts
@@ -9,19 +9,34 @@ export class DashboardPage extends BasePage {
   }
 
   readonly reportActivitiesButton: Locator;
+  readonly startReportingActivitiesLink: Locator;
   readonly requestExemptionButton: Locator;
   readonly getStartedLink: Locator;
 
   constructor(page: Page) {
     super(page);
-    // Match both old and new button text variants
     this.reportActivitiesButton = page.getByRole('link', { name: /^report activities/i });
+    this.startReportingActivitiesLink = page.getByRole('link', {
+      name: /^start reporting activities/i,
+    });
     this.requestExemptionButton = page.getByRole('link', { name: /request exemption/i });
     // "Get started" links to the exemption screener with certification_case_id
     this.getStartedLink = page.getByRole('link', { name: /^get started$/i });
   }
 
   async clickReportActivities() {
+    if (await this.getStartedLink.isVisible()) {
+      const screenerIndexPage = await this.clickGetStarted();
+      const firstQuestionPage = await screenerIndexPage.clickStart();
+      const completePage = await firstQuestionPage.answerNoUntilComplete();
+      return completePage.clickReportActivities();
+    }
+
+    if (await this.startReportingActivitiesLink.isVisible()) {
+      await this.startReportingActivitiesLink.click();
+      return new BeforeYouStartPage(this.page).waitForURLtoMatchPagePath();
+    }
+
     await this.reportActivitiesButton.click();
     return new BeforeYouStartPage(this.page).waitForURLtoMatchPagePath();
   }

--- a/e2e/reporting-app/pages/members/exemptions/ExemptionScreenerCompletePage.ts
+++ b/e2e/reporting-app/pages/members/exemptions/ExemptionScreenerCompletePage.ts
@@ -1,0 +1,21 @@
+import { Locator, Page } from '@playwright/test';
+import { BasePage } from '../../BasePage';
+import { BeforeYouStartPage } from '../activity-reports';
+
+export class ExemptionScreenerCompletePage extends BasePage {
+  get pagePath() {
+    return '**/exemption-screener/complete*';
+  }
+
+  readonly reportActivitiesLink: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.reportActivitiesLink = page.getByRole('link', { name: /^report activities/i });
+  }
+
+  async clickReportActivities() {
+    await this.reportActivitiesLink.click();
+    return new BeforeYouStartPage(this.page).waitForURLtoMatchPagePath();
+  }
+}

--- a/e2e/reporting-app/pages/members/exemptions/ExemptionScreenerQuestionPage.ts
+++ b/e2e/reporting-app/pages/members/exemptions/ExemptionScreenerQuestionPage.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 import { BasePage } from '../../BasePage';
 import { ExemptionMayQualifyPage } from './ExemptionMayQualifyPage';
+import { ExemptionScreenerCompletePage } from './ExemptionScreenerCompletePage';
 
 export class ExemptionScreenerQuestionPage extends BasePage {
   get pagePath() {
@@ -31,5 +32,16 @@ export class ExemptionScreenerQuestionPage extends BasePage {
     await this.noRadio.dispatchEvent('click');
     await this.continueButton.click();
     return new ExemptionScreenerQuestionPage(this.page).waitForURLtoMatchPagePath();
+  }
+
+  // Answer "No" to every screener question until the "No exemptions apply" result page.
+  async answerNoUntilComplete() {
+    while (!this.page.url().includes('/exemption-screener/complete')) {
+      await this.noRadio.dispatchEvent('click');
+      await this.continueButton.click();
+      await this.page.waitForURL(/exemption-screener\/(question|complete)/);
+    }
+
+    return new ExemptionScreenerCompletePage(this.page);
   }
 }

--- a/e2e/reporting-app/pages/members/exemptions/index.ts
+++ b/e2e/reporting-app/pages/members/exemptions/index.ts
@@ -1,5 +1,6 @@
 export { ExemptionScreenerPage } from './ExemptionScreenerPage';
 export { ExemptionScreenerQuestionPage } from './ExemptionScreenerQuestionPage';
+export { ExemptionScreenerCompletePage } from './ExemptionScreenerCompletePage';
 export { ExemptionMayQualifyPage } from './ExemptionMayQualifyPage';
 export { ExemptionDocumentsPage } from './ExemptionDocumentsPage';
 export { ExemptionReviewPage } from './ExemptionReviewPage';

--- a/reporting-app/app/assets/stylesheets/_member_dashboard.scss
+++ b/reporting-app/app/assets/stylesheets/_member_dashboard.scss
@@ -1,0 +1,118 @@
+@use "uswds-core" as *;
+
+// Member dashboard: welcome hero (OSCER-337 / Figma 7203:6175)
+.member-dashboard-hero {
+  background-color: color("primary-darker");
+  color: color("white");
+  margin-bottom: units(4);
+  margin-top: 0;
+  padding: units(5) 0;
+  text-align: center;
+
+  &__heading {
+    font-family: font-family("serif");
+    font-size: 1.96rem;
+    font-weight: 900;
+    line-height: 1.24;
+    margin: 0 0 units(2);
+  }
+
+  &__intro {
+    font-size: 1.0625rem;
+    line-height: 1.5;
+    margin: 0 auto;
+    max-width: 48rem;
+  }
+}
+
+.member-dashboard-greeting {
+  font-family: font-family("serif");
+  font-size: 2.5rem;
+  font-weight: 900;
+  line-height: 1.25;
+  margin: 0 0 units(2);
+}
+
+.member-dashboard-previous-certifications {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: units(2);
+  margin-top: units(3);
+  padding-bottom: units(4);
+
+  &__intro {
+    max-width: measure(4);
+  }
+
+  .usa-button {
+    width: auto;
+  }
+}
+
+// Get started frame (OSCER-639)
+.member-dashboard-compliance {
+  &__alert {
+    border-radius: 4px;
+    border-style: solid;
+    border-width: 1px;
+    margin-bottom: 0;
+    padding: units(3);
+  }
+
+  &__alert-heading {
+    font-size: 1.375rem;
+    font-weight: font-weight("bold");
+    line-height: 1.18;
+    margin: 0 0 units(1);
+  }
+
+  &__alert-text {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  &__alert--info {
+    background-color: #E7F6F8;
+    border-color: #5DC0D1;
+  }
+
+  &__onboarding {
+    display: flex;
+    flex-direction: column;
+    gap: units(3);
+  }
+
+  &__onboarding-cta {
+    margin-top: units(1);
+  }
+
+  &__about-reporting-heading {
+    font-family: font-family("sans");
+    font-size: font-size("sans", "md");
+    font-weight: font-weight("bold");
+    line-height: 1.3;
+    margin: 0 0 units(1);
+  }
+
+  &__about-reporting-intro,
+  &__about-reporting-footer {
+    font-family: font-family("serif");
+    font-size: 1rem;
+    line-height: 1.8;
+    margin: 0 0 units(2);
+  }
+
+  &__about-reporting-list {
+    font-family: font-family("serif");
+    font-size: 1rem;
+    line-height: 1.8;
+    margin: 0 0 units(2);
+    padding-left: units(3);
+
+    li {
+      margin-bottom: units(1);
+    }
+  }
+}

--- a/reporting-app/app/assets/stylesheets/_member_dashboard.scss
+++ b/reporting-app/app/assets/stylesheets/_member_dashboard.scss
@@ -1,5 +1,10 @@
 @use "uswds-core" as *;
 
+// Member dashboard layout: hero flush under site header
+.member-dashboard-page {
+  padding-top: 0;
+}
+
 // Member dashboard: welcome hero (OSCER-337 / Figma 7203:6175)
 .member-dashboard-hero {
   background-color: color("primary-darker");

--- a/reporting-app/app/assets/stylesheets/application.scss
+++ b/reporting-app/app/assets/stylesheets/application.scss
@@ -2,8 +2,8 @@
 @forward "uswds";
 @forward "sso";
 @forward "uswds-overrides";
-@forward "overrides";
 @forward "member_dashboard";
+@forward "overrides";
 
 @use "uswds-core" as *;
 

--- a/reporting-app/app/assets/stylesheets/application.scss
+++ b/reporting-app/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @forward "sso";
 @forward "uswds-overrides";
 @forward "overrides";
+@forward "member_dashboard";
 
 @use "uswds-core" as *;
 

--- a/reporting-app/app/controllers/dashboard_controller.rb
+++ b/reporting-app/app/controllers/dashboard_controller.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class DashboardController < ApplicationController
+  layout "dashboard"
+
   before_action :authenticate_user!
   before_action :set_certifications
+  before_action :set_previous_completed_certifications
   before_action :set_certification_case, if: -> { @certification.present? }
   before_action :set_exemption_application_form, if: -> { @certification_case.present? }
   before_action :set_activity_report_application_form, if: -> { @certification_case.present? }
@@ -21,6 +24,13 @@ class DashboardController < ApplicationController
   def set_certifications
     @all_certifications = Certification.find_by_member_email(current_user.email).order(created_at: :desc).all
     @certification = @all_certifications.first
+  end
+
+  def set_previous_completed_certifications
+    @previous_completed_certifications = MemberStatusService.previous_completed_certifications(
+      @all_certifications,
+      current_certification: @certification
+    )
   end
 
   def set_certification_case

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -62,4 +62,11 @@ module DashboardHelper
   def is_exemption_request_denied?
     @exemption_application_form&.submitted? && @certification_case&.exemption_request_approval_status == "denied"
   end
+
+  # Figma "Get started" — exemption screener CTA before any application forms exist (7203:6175).
+  def member_dashboard_get_started_screen?(compliance)
+    compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_NOT_STARTED &&
+      compliance.activity_report_application_form.blank? &&
+      compliance.exemption_application_form.blank?
+  end
 end

--- a/reporting-app/app/helpers/member_compliance_helper.rb
+++ b/reporting-app/app/helpers/member_compliance_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module MemberComplianceHelper
-  # Figma "Get started" — exemption screener CTA before any activity report exists (7203:6175).
-  def member_compliance_get_started_screen?(compliance, activity_report:)
-    compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_NOT_STARTED &&
-      activity_report.blank?
-  end
-end

--- a/reporting-app/app/helpers/member_compliance_helper.rb
+++ b/reporting-app/app/helpers/member_compliance_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module MemberComplianceHelper
+  # Figma "Get started" — exemption screener CTA before any activity report exists (7203:6175).
+  def member_compliance_get_started_screen?(compliance, activity_report:)
+    compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_NOT_STARTED &&
+      activity_report.blank?
+  end
+end

--- a/reporting-app/app/models/member_dashboard_compliance.rb
+++ b/reporting-app/app/models/member_dashboard_compliance.rb
@@ -56,6 +56,8 @@ class MemberDashboardCompliance
   attr_reader :report_status_token,
               :latest_determination,
               :show_income_summary,
+              :activity_report_application_form,
+              :exemption_application_form,
               :total_hours_reported,
               :target_hours,
               :hours_needed,

--- a/reporting-app/app/models/member_status.rb
+++ b/reporting-app/app/models/member_status.rb
@@ -45,6 +45,9 @@ class MemberStatus < Strata::ValueObject
   NOT_COMPLIANT = "not_compliant"
   PENDING_REVIEW = "pending_review"
 
+  # Outcomes that mean a certification period is finished (used for "previous completed" dashboard UI).
+  TERMINAL_CERTIFICATION_STATUSES = [ COMPLIANT, EXEMPT, NOT_COMPLIANT ].freeze
+
   include Strata::Attributes
 
   strata_attribute :status, :string
@@ -72,5 +75,10 @@ class MemberStatus < Strata::ValueObject
     when EXEMPT then DASHBOARD_REPORT_EXEMPT
     else DASHBOARD_REPORT_IN_PROGRESS
     end
+  end
+
+  # @return [Boolean] true when the member's certification period has a final outcome
+  def certification_period_completed?
+    status.in?(TERMINAL_CERTIFICATION_STATUSES)
   end
 end

--- a/reporting-app/app/services/member_status_service.rb
+++ b/reporting-app/app/services/member_status_service.rb
@@ -75,6 +75,29 @@ class MemberStatusService
       results
     end
 
+    # Prior certifications with a terminal outcome (or closed case), excluding the current period.
+    #
+    # @param all_certifications [Array<Certification>]
+    # @param current_certification [Certification, nil]
+    # @return [Array<Certification>]
+    def previous_completed_certifications(all_certifications, current_certification:)
+      return [] if current_certification.blank?
+
+      previous = Array(all_certifications).reject { |cert| cert.id == current_certification.id }
+      return [] if previous.empty?
+
+      statuses_by_key = determine_many(previous)
+      closed_certification_ids = CertificationCase.closed
+        .where(certification_id: previous.map(&:id))
+        .pluck(:certification_id)
+        .to_set
+
+      previous.select do |cert|
+        member_status = statuses_by_key[[ cert.class.name, cert.id ]]
+        member_status.certification_period_completed? || closed_certification_ids.include?(cert.id)
+      end
+    end
+
     private
 
     # Bulk loads all related data needed for status determination in a single operation

--- a/reporting-app/app/views/dashboard/_member_compliance_about_reporting.html.erb
+++ b/reporting-app/app/views/dashboard/_member_compliance_about_reporting.html.erb
@@ -1,0 +1,19 @@
+<%# Shared "About the reporting requirement" block (OSCER-337 onboarding frames) %>
+<% compliance = local_assigns.fetch(:compliance) %>
+<% target_income_display = number_to_currency(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY, precision: 0) %>
+
+<div class="member-dashboard-compliance__about-reporting">
+  <h2 class="member-dashboard-compliance__about-reporting-heading">
+    <%= t("dashboard.member_compliance.about_reporting.heading") %>
+  </h2>
+  <p class="member-dashboard-compliance__about-reporting-intro">
+    <%= t("dashboard.member_compliance.about_reporting.intro") %>
+  </p>
+  <ul class="member-dashboard-compliance__about-reporting-list">
+    <li><%= t("dashboard.member_compliance.about_reporting.hours_bullet", target_hours: compliance.target_hours) %></li>
+    <li><%= t("dashboard.member_compliance.about_reporting.income_bullet", target_income: target_income_display) %></li>
+  </ul>
+  <p class="member-dashboard-compliance__about-reporting-footer">
+    <%= t("dashboard.member_compliance.about_reporting.footer") %>
+  </p>
+</div>

--- a/reporting-app/app/views/dashboard/_member_compliance_get_started.html.erb
+++ b/reporting-app/app/views/dashboard/_member_compliance_get_started.html.erb
@@ -1,0 +1,24 @@
+<%# OSCER-337 frame: Get started (exemption not started, no activity report — Figma 7203:6175) %>
+<% compliance = local_assigns.fetch(:compliance) %>
+<% certification_case = local_assigns[:certification_case] %>
+
+<div class="member-dashboard-compliance__onboarding">
+  <div class="member-dashboard-compliance__alert member-dashboard-compliance__alert--info"
+       role="alert"
+       aria-labelledby="member-compliance-get-started-alert-heading">
+    <h3 id="member-compliance-get-started-alert-heading" class="member-dashboard-compliance__alert-heading">
+      <%= t("dashboard.member_compliance.exemption_alerts.not_started.title") %>
+    </h3>
+    <p class="member-dashboard-compliance__alert-text">
+      <%= t("dashboard.member_compliance.exemption_alerts.not_started.body") %>
+    </p>
+  </div>
+
+  <div class="member-dashboard-compliance__onboarding-cta">
+    <%= link_to t("dashboard.member_compliance.exemption_alerts.not_started.button"),
+          exemption_screener_path(certification_case_id: certification_case&.id),
+          class: "usa-button" %>
+  </div>
+
+  <%= render "dashboard/member_compliance_about_reporting", compliance: compliance %>
+</div>

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -1,4 +1,4 @@
-<% if local_assigns[:compliance].present? && member_compliance_get_started_screen?(compliance, activity_report: activity_report) %>
+<% if local_assigns[:compliance].present? && member_dashboard_get_started_screen?(compliance) %>
   <div class="grid-container member-dashboard-compliance">
     <%= render "dashboard/member_compliance_get_started",
                compliance: compliance,

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -1,63 +1,40 @@
-<% if !application_exists? %>
-<section class="usa-section usa-section--light padding-y-3 margin-bottom-4" aria-label="Get started">
+<% if local_assigns[:compliance].present? && member_compliance_get_started_screen?(compliance, activity_report: activity_report) %>
+  <div class="grid-container member-dashboard-compliance">
+    <%= render "dashboard/member_compliance_get_started",
+               compliance: compliance,
+               certification_case: certification_case %>
+  </div>
+<% else %>
   <div class="grid-container">
-    <div class="grid-row flex-column tablet:flex-row gap-4">
-      <div class="usa-hero__callout grid-col">
-        <h2 class="usa-hero__heading font-heading-xl">
-          <%# TODO: handle this formatting stuff in the content so can pass the date %>
-          <%# TODO: also '%b %d, %Y' doesn't correspond to a defined date format for locales, most similar to :short, but that doesn't have the year %>
-          <span class="usa-hero__heading--alt"><%= t(".get_started.header") %></span> <%= certification.certification_requirements.due_date&.strftime('%b %d, %Y') %>
-        </h2>
-        <p class="text-base-lightest">
-         <%= t(".get_started.prompt") %>
-        </p>
-        <%= link_to t(".get_started.button"), exemption_screener_path(certification_case_id: certification_case&.id), class: "usa-button" %>
-      </div>
+    <%= render "dashboard/compliance_status",
+               current_period: current_period,
+               target_hours: target_hours,
+               period_end_date: period_end_date,
+               total_hours_reported: total_hours_reported,
+               hours_needed: hours_needed %>
 
-      <div class="grid-col display-flex flex-align-center">
-        <p class="font-serif-md">
-          <%= t(".get_started.info") %>
-        </p>
-      </div>
+    <%# Action Buttons %>
+    <div class="margin-bottom-4">
+      <% if hours_needed == 0 %>
+        <%# Requirements met - show view activity report button %>
+        <%= link_to t(".current_period.view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" if activity_report.present? %>
+      <% else %>
+        <%# Requirements not met - show report activities and request exemption buttons %>
+        <% if activity_report&.in_progress? %>
+          <% continue_path = feature_enabled?(:doc_ai) && !session[:doc_ai_skip] ?
+                doc_ai_upload_activity_report_application_form_path(activity_report) :
+                activity_report_application_form_path(activity_report) %>
+          <%= link_to t(".activity_report.continue_report_button"), continue_path,
+                class: "usa-button margin-right-2 margin-bottom-1" %>
+        <% else %>
+          <%= link_to t(".current_period.report_activities_button"), new_activity_report_application_form_path(certification_case_id: certification_case&.id), class: "usa-button margin-right-2 margin-bottom-1" %>
+        <% end %>
+        <% if exemption_application&.in_progress? %>
+          <%= link_to t(".exemption_request.continue_request_button"), exemption_application_form_path(exemption_application), class: "usa-button usa-button--outline margin-bottom-1" %>
+        <% else %>
+          <%= link_to t(".current_period.request_exemption_button"), new_exemption_application_form_path(certification_case_id: certification_case&.id), class: "usa-button usa-button--outline margin-bottom-1" %>
+        <% end %>
+      <% end %>
     </div>
   </div>
-</section>
 <% end %>
-
-<div class="grid-container">
-  <%= render "dashboard/compliance_status",
-             current_period: current_period,
-             target_hours: target_hours,
-             period_end_date: period_end_date,
-             total_hours_reported: total_hours_reported,
-             hours_needed: hours_needed %>
-
-  <%# Action Buttons %>
-  <div class="margin-bottom-4">
-    <% if hours_needed == 0 %>
-      <%# Requirements met - show view activity report button %>
-      <%= link_to t(".current_period.view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" if activity_report.present? %>
-    <% else %>
-      <%# Requirements not met - show report activities and request exemption buttons %>
-      <% if activity_report&.in_progress? %>
-        <% continue_path = feature_enabled?(:doc_ai) && !session[:doc_ai_skip] ?
-              doc_ai_upload_activity_report_application_form_path(activity_report) :
-              activity_report_application_form_path(activity_report) %>
-        <%= link_to t(".activity_report.continue_report_button"), continue_path,
-              class: "usa-button margin-right-2 margin-bottom-1" %>
-      <% else %>
-        <%= link_to t(".current_period.report_activities_button"), new_activity_report_application_form_path(certification_case_id: certification_case&.id), class: "usa-button margin-right-2 margin-bottom-1" %>
-      <% end %>
-      <% if exemption_application&.in_progress? %>
-        <%= link_to t(".exemption_request.continue_request_button"), exemption_application_form_path(exemption_application), class: "usa-button usa-button--outline margin-bottom-1" %>
-      <% else %>
-        <%= link_to t(".current_period.request_exemption_button"), new_exemption_application_form_path(certification_case_id: certification_case&.id), class: "usa-button usa-button--outline margin-bottom-1" %>
-      <% end %>
-    <% end %>
-  </div>
-
-  <%# Previously Completed Requirements Section %>
-  <h2 class="font-heading-lg margin-top-6 margin-bottom-2"><%= t(".previous_requirements.header") %></h2>
-  <p class="margin-bottom-2"><%= t(".previous_requirements.intro") %></p>
-  <%= link_to t(".previous_requirements.button"), certifications_path, class: "usa-button usa-button--outline" %>
-</div>

--- a/reporting-app/app/views/dashboard/_previous_certifications.html.erb
+++ b/reporting-app/app/views/dashboard/_previous_certifications.html.erb
@@ -1,0 +1,10 @@
+<%# Rendered once from dashboard/index when the member has prior completed certification periods. %>
+<section class="grid-container member-dashboard-previous-certifications" aria-labelledby="previous-certifications-heading">
+  <h2 id="previous-certifications-heading" class="font-heading-lg margin-0"><%= t("dashboard.index.previous_certifications.title") %></h2>
+  <p class="member-dashboard-previous-certifications__intro font-serif-md margin-0">
+    <%= t("dashboard.index.previous_certifications.intro") %>
+  </p>
+  <%= link_to t("dashboard.index.previous_certifications.review_previous_certifications_button"),
+        certifications_path,
+        class: "usa-button usa-button--outline" %>
+</section>

--- a/reporting-app/app/views/dashboard/index.html.erb
+++ b/reporting-app/app/views/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="grid-container">
-  <h1 class="margin-bottom-2"><%= t(".greeting", first_name: (@certification&.member_name&.first || current_user.full_name&.split&.first)&.capitalize) %></h1>
+  <h2 class="member-dashboard-greeting"><%= t(".greeting", first_name: (@certification&.member_name&.first || current_user.full_name&.split&.first)&.capitalize) %></h2>
 </div>
 <% if @information_request %>
   <div class="grid-container">
@@ -7,6 +7,7 @@
   </div>
 <% end %>
 <%= render determine_dashboard_view,
+           compliance: @member_dashboard_compliance,
            activity_report: @activity_report_application_form,
            exemption_application: @exemption_application_form,
            certification_case: @certification_case,
@@ -16,13 +17,6 @@
            period_end_date: @period_end_date,
            total_hours_reported: @total_hours_reported,
            hours_needed: @hours_needed %>
-<!-- Previous Certifications -->
-<% if @all_certifications.length > 1 %>
-  <section class="grid-container usa-section">
-    <h2><%= t(".previous_certifications.title") %></h2>
-    <p class="font-serif-md">
-      <%= t(".previous_certifications.intro") %>
-    </p>
-    <%= link_to t(".previous_certifications.review_previous_certifications_button"), certifications_path, class: "usa-button usa-button--outline" %>
-  </section>
+<% if @previous_completed_certifications.present? %>
+  <%= render "dashboard/previous_certifications" %>
 <% end %>

--- a/reporting-app/app/views/layouts/application_base.html.erb
+++ b/reporting-app/app/views/layouts/application_base.html.erb
@@ -24,20 +24,18 @@
 
       <main id="main-content" class="grid-col-fill display-flex flex-column">
         <div class="grid-col-fill <%= yield :main_col_class %>">
-          <% flash_visible = flash[:notice].present? || flash[:errors].present? || alert.present? || notice.present? %>
-          <% unless @suppress_base_flash_section %>
-            <% if flash_visible %>
-              <section class="usa-section padding-y-4">
-                <div class="grid-container">
-                  <div id="flash-messages">
-                    <%= render partial: "application/flash" %>
-                  </div>
-                </div>
-              </section>
-            <% end %>
-          <% end %>
-
           <%= yield :banner if content_for?(:banner) %>
+
+          <% flash_visible = flash[:notice].present? || flash[:errors].present? || alert.present? || notice.present? %>
+          <% if flash_visible %>
+            <section class="usa-section padding-y-4">
+              <div class="grid-container">
+                <div id="flash-messages">
+                  <%= render partial: "application/flash" %>
+                </div>
+              </div>
+            </section>
+          <% end %>
 
           <%= content_for?(:main_content) ? yield(:main_content) : yield %>
         </div>

--- a/reporting-app/app/views/layouts/application_base.html.erb
+++ b/reporting-app/app/views/layouts/application_base.html.erb
@@ -24,13 +24,17 @@
 
       <main id="main-content" class="grid-col-fill display-flex flex-column">
         <div class="grid-col-fill <%= yield :main_col_class %>">
-          <section class="usa-section padding-y-4">
-            <div class="grid-container">
-              <div id="flash-messages">
-                <%= render partial: 'application/flash' %>
+          <% unless @suppress_base_flash_section %>
+            <section class="usa-section padding-y-4">
+              <div class="grid-container">
+                <div id="flash-messages">
+                  <%= render partial: "application/flash" %>
+                </div>
               </div>
-            </div>
-          </section>
+            </section>
+          <% end %>
+
+          <%= yield :banner if content_for?(:banner) %>
 
           <%= content_for?(:main_content) ? yield(:main_content) : yield %>
         </div>

--- a/reporting-app/app/views/layouts/application_base.html.erb
+++ b/reporting-app/app/views/layouts/application_base.html.erb
@@ -24,14 +24,17 @@
 
       <main id="main-content" class="grid-col-fill display-flex flex-column">
         <div class="grid-col-fill <%= yield :main_col_class %>">
+          <% flash_visible = flash[:notice].present? || flash[:errors].present? || alert.present? || notice.present? %>
           <% unless @suppress_base_flash_section %>
-            <section class="usa-section padding-y-4">
-              <div class="grid-container">
-                <div id="flash-messages">
-                  <%= render partial: "application/flash" %>
+            <% if flash_visible %>
+              <section class="usa-section padding-y-4">
+                <div class="grid-container">
+                  <div id="flash-messages">
+                    <%= render partial: "application/flash" %>
+                  </div>
                 </div>
-              </div>
-            </section>
+              </section>
+            <% end %>
           <% end %>
 
           <%= yield :banner if content_for?(:banner) %>

--- a/reporting-app/app/views/layouts/dashboard.html.erb
+++ b/reporting-app/app/views/layouts/dashboard.html.erb
@@ -1,4 +1,6 @@
 <%# Member dashboard: welcome hero via :banner (OSCER-639) %>
+<%= content_for :main_col_class, "member-dashboard-page" %>
+
 <%= content_for :banner do %>
   <section class="member-dashboard-hero" aria-labelledby="member-dashboard-welcome-heading">
     <div class="grid-container">

--- a/reporting-app/app/views/layouts/dashboard.html.erb
+++ b/reporting-app/app/views/layouts/dashboard.html.erb
@@ -1,1 +1,25 @@
-<%= render template: 'layouts/application_base' %>
+<%# Member dashboard: welcome hero via :banner (OSCER-639) %>
+<%= content_for :banner do %>
+  <section class="member-dashboard-hero" aria-labelledby="member-dashboard-welcome-heading">
+    <div class="grid-container">
+      <h1 id="member-dashboard-welcome-heading" class="member-dashboard-hero__heading">
+        <%= t("dashboard.welcome_hero.heading") %>
+      </h1>
+      <p class="member-dashboard-hero__intro">
+        <%= t("dashboard.welcome_hero.intro") %>
+      </p>
+    </div>
+  </section>
+<% end %>
+
+<%= content_for :main_content do %>
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="grid-col-12 <%= yield :content_col_class %>" id="content">
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= render template: "layouts/application_base" %>

--- a/reporting-app/config/locales/views/dashboard/en.yml
+++ b/reporting-app/config/locales/views/dashboard/en.yml
@@ -6,7 +6,7 @@ en:
     no_certification:
       message: "No pending certifications."
     index:
-      greeting: "Hi %{first_name}"
+      greeting: "Hi %{first_name},"
       activity_report:
         title: "Report your community engagement (OSCER)"
         intro: "Certify your community engagement requirements through OSCER."

--- a/reporting-app/config/locales/views/dashboard/en.yml
+++ b/reporting-app/config/locales/views/dashboard/en.yml
@@ -1,5 +1,8 @@
 en:
   dashboard:
+    welcome_hero:
+      heading: "Welcome to the Medicaid Work Reporting Portal"
+      intro: "Welcome to the H.R. 1 Community Engagement Portal. This portal is designed to help report your work, volunteer, or education activities to keep your Medicaid coverage active."
     no_certification:
       message: "No pending certifications."
     index:

--- a/reporting-app/config/locales/views/dashboard/member_compliance.en.yml
+++ b/reporting-app/config/locales/views/dashboard/member_compliance.en.yml
@@ -1,0 +1,14 @@
+en:
+  dashboard:
+    member_compliance:
+      exemption_alerts:
+        not_started:
+          title: "Before you can report activities, let's see if you qualify for an exemption."
+          body: "Answer a few quick questions to find out if you're excused from the work reporting requirement. If you don't qualify, you'll be taken directly to report your activities."
+          button: "Get started"
+      about_reporting:
+        heading: "About the reporting requirement"
+        intro: "To maintain your Medicaid eligibility, adults must either:"
+        hours_bullet: "Complete at least %{target_hours} hours per month of qualifying \"community engagement\" activities"
+        income_bullet: "Show %{target_income} or more of income."
+        footer: "If you have certain conditions, you may be considered exempt and not need to report activities."

--- a/reporting-app/config/locales/views/dashboard/member_compliance.es-US.yml
+++ b/reporting-app/config/locales/views/dashboard/member_compliance.es-US.yml
@@ -1,0 +1,14 @@
+es-US:
+  dashboard:
+    member_compliance:
+      exemption_alerts:
+        not_started:
+          title: "Antes de reportar actividades, veamos si califica para una exención."
+          body: "Responda unas preguntas rápidas para saber si está exento del requisito de reporte de trabajo. Si no califica, podrá reportar sus actividades directamente."
+          button: "Comenzar"
+      about_reporting:
+        heading: "Acerca del requisito de reporte"
+        intro: "Para mantener su elegibilidad de Medicaid, los adultos deben:"
+        hours_bullet: "Completar al menos %{target_hours} horas al mes de actividades calificadas de \"compromiso comunitario\""
+        income_bullet: "Mostrar %{target_income} o más de ingresos."
+        footer: "Si tiene ciertas condiciones, puede considerarse exento y no necesitar reportar actividades."

--- a/reporting-app/spec/helpers/dashboard_helper_spec.rb
+++ b/reporting-app/spec/helpers/dashboard_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe MemberComplianceHelper, type: :helper do
+RSpec.describe DashboardHelper, type: :helper do
   let(:certification) { create(:certification) }
   let(:certification_case) { create(:certification_case, certification_id: certification.id) }
   let(:member_status) { MemberStatusService.determine(certification) }
@@ -16,15 +16,22 @@ RSpec.describe MemberComplianceHelper, type: :helper do
     )
   end
 
-  describe "#member_compliance_get_started_screen?" do
-    it "is true when exemption has not started and no activity report exists" do
-      expect(helper.member_compliance_get_started_screen?(compliance, activity_report: nil)).to be(true)
+  describe "#member_dashboard_get_started_screen?" do
+    it "is true when exemption has not started and no application forms exist" do
+      expect(helper.member_dashboard_get_started_screen?(compliance)).to be(true)
     end
 
     it "is false when an activity report exists" do
       activity_report = create(:activity_report_application_form, certification_case_id: certification_case.id)
+      compliance_with_activity_report = MemberDashboardComplianceService.build(
+        certification: certification,
+        activity_report_application_form: activity_report,
+        certification_case: certification_case,
+        exemption_application_form: nil,
+        member_status: member_status
+      )
 
-      expect(helper.member_compliance_get_started_screen?(compliance, activity_report: activity_report)).to be(false)
+      expect(helper.member_dashboard_get_started_screen?(compliance_with_activity_report)).to be(false)
     end
 
     it "is false when an exemption application exists" do
@@ -37,7 +44,7 @@ RSpec.describe MemberComplianceHelper, type: :helper do
         member_status: member_status
       )
 
-      expect(helper.member_compliance_get_started_screen?(compliance_with_exemption, activity_report: nil)).to be(false)
+      expect(helper.member_dashboard_get_started_screen?(compliance_with_exemption)).to be(false)
     end
   end
 end

--- a/reporting-app/spec/helpers/member_compliance_helper_spec.rb
+++ b/reporting-app/spec/helpers/member_compliance_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MemberComplianceHelper, type: :helper do
+  let(:certification) { create(:certification) }
+  let(:certification_case) { create(:certification_case, certification_id: certification.id) }
+  let(:member_status) { MemberStatusService.determine(certification) }
+  let(:compliance) do
+    MemberDashboardComplianceService.build(
+      certification: certification,
+      activity_report_application_form: nil,
+      certification_case: certification_case,
+      exemption_application_form: nil,
+      member_status: member_status
+    )
+  end
+
+  describe "#member_compliance_get_started_screen?" do
+    it "is true when exemption has not started and no activity report exists" do
+      expect(helper.member_compliance_get_started_screen?(compliance, activity_report: nil)).to be(true)
+    end
+
+    it "is false when an activity report exists" do
+      activity_report = create(:activity_report_application_form, certification_case_id: certification_case.id)
+
+      expect(helper.member_compliance_get_started_screen?(compliance, activity_report: activity_report)).to be(false)
+    end
+
+    it "is false when an exemption application exists" do
+      exemption = create(:exemption_application_form, certification_case_id: certification_case.id)
+      compliance_with_exemption = MemberDashboardComplianceService.build(
+        certification: certification,
+        activity_report_application_form: nil,
+        certification_case: certification_case,
+        exemption_application_form: exemption,
+        member_status: member_status
+      )
+
+      expect(helper.member_compliance_get_started_screen?(compliance_with_exemption, activity_report: nil)).to be(false)
+    end
+  end
+end

--- a/reporting-app/spec/services/member_status_service_spec.rb
+++ b/reporting-app/spec/services/member_status_service_spec.rb
@@ -452,4 +452,35 @@ RSpec.describe MemberStatusService do
       end
     end
   end
+
+  describe ".previous_completed_certifications" do
+    let(:current_certification) { create(:certification) }
+    let(:completed_certification) { create(:certification) }
+    let(:in_progress_certification) { create(:certification) }
+
+    before do
+      create(:certification_case, certification: completed_certification)
+      create(:certification_case, certification: in_progress_certification)
+      create(:determination,
+             subject: completed_certification,
+             outcome: "exempt",
+             decision_method: "automated",
+             reasons: [ "age_under_19_exempt" ])
+    end
+
+    it "returns only prior certifications with terminal outcomes" do
+      all_certifications = [ current_certification, completed_certification, in_progress_certification ]
+
+      result = described_class.previous_completed_certifications(
+        all_certifications,
+        current_certification: current_certification
+      )
+
+      expect(result).to eq([ completed_certification ])
+    end
+
+    it "returns an empty array when the current certification is blank" do
+      expect(described_class.previous_completed_certifications([], current_certification: nil)).to eq([])
+    end
+  end
 end

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe "dashboard/index", type: :view do
   let(:member_data) { build(:certification_member_data, :with_full_name) }
   let(:certification) { create(:certification, member_data: member_data) }
   let(:certification_case) { create(:certification_case, certification_id: certification.id) }
+  let(:exemption_application_form) { nil }
+  let(:activity_report_application_form) { nil }
+  let(:member_status) { MemberStatusService.determine(certification) }
+  let(:member_dashboard_compliance) do
+    MemberDashboardComplianceService.build(
+      certification: certification,
+      activity_report_application_form: activity_report_application_form,
+      certification_case: certification_case,
+      exemption_application_form: exemption_application_form,
+      member_status: member_status
+    )
+  end
 
   before do
     # Prevent auto-triggering business process during test setup
@@ -17,7 +29,12 @@ RSpec.describe "dashboard/index", type: :view do
       certification
     ])
     assign(:certification, certification)
+    assign(:previous_completed_certifications, [])
     assign(:certification_case, certification_case)
+    assign(:exemption_application_form, exemption_application_form)
+    assign(:activity_report_application_form, activity_report_application_form)
+    assign(:member_status, member_status)
+    assign(:member_dashboard_compliance, member_dashboard_compliance)
 
     # Hours compliance data required by the dashboard partials
     assign(:current_period, certification.certification_requirements.certification_date)
@@ -28,26 +45,76 @@ RSpec.describe "dashboard/index", type: :view do
   end
 
   context 'with no current exemption or activity report' do
-    it 'renders the current period header' do
-      render
-      expect(rendered).to have_selector('h2', text: /Current period:/)
+    it 'renders the Figma welcome hero copy via the dashboard layout banner' do
+      render inline: <<~ERB.squish, type: :erb
+        <%= content_for :banner do %>
+          <section class="member-dashboard-hero" aria-labelledby="member-dashboard-welcome-heading">
+            <div class="grid-container">
+              <h1 id="member-dashboard-welcome-heading" class="member-dashboard-hero__heading">
+                <%= t("dashboard.welcome_hero.heading") %>
+              </h1>
+              <p class="member-dashboard-hero__intro">
+                <%= t("dashboard.welcome_hero.intro") %>
+              </p>
+            </div>
+          </section>
+        <% end %>
+        <%= yield :banner %>
+      ERB
+
+      expect(rendered).to have_css(".member-dashboard-hero")
+      expect(rendered).to have_selector(
+        "#member-dashboard-welcome-heading",
+        text: I18n.t("dashboard.welcome_hero.heading")
+      )
+      expect(rendered).to have_text(I18n.t("dashboard.welcome_hero.intro"))
     end
 
-    it 'renders buttons to report activities or request exemption' do
+    it 'renders the member greeting' do
       render
-      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.current_period.report_activities_button'))
-      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.current_period.request_exemption_button'))
+      expect(rendered).to have_css(".member-dashboard-greeting")
     end
 
-    it 'renders "get started" callout' do
+    it 'renders the exemption get-started alert' do
       render
-      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).to have_selector('h3', text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.title'))
+    end
+
+    it 'renders the Figma get-started layout (blue alert, CTA, about reporting)' do
+      render
+
+      expect(rendered).to have_css('.member-dashboard-compliance__onboarding')
+      expect(rendered).to have_css('.member-dashboard-compliance__alert--info[role="alert"]')
+      expect(rendered).to have_css('.member-dashboard-compliance__about-reporting')
+    end
+
+    it 'renders the get started button for the exemption screener' do
+      render
+      expect(rendered).to have_selector('.member-dashboard-compliance__onboarding-cta a.usa-button',
+                                         text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button'))
+    end
+
+    it 'does not render the legacy report activities buttons' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.current_period.report_activities_button'))
+    end
+
+    it 'does not render previous certifications when the member has only one certification' do
+      render
+      expect(rendered).not_to have_selector(
+        'h2',
+        text: I18n.t('dashboard.index.previous_certifications.title')
+      )
     end
   end
 
   context "with an in-progress activity report" do
+    let(:activity_report_application_form) do
+      create(:activity_report_application_form, certification_case_id: certification_case.id)
+    end
+
     before do
-      assign(:activity_report_application_form, create(:activity_report_application_form, certification_case_id: certification_case.id))
+      assign(:activity_report_application_form, activity_report_application_form)
     end
 
     it 'renders a button to continue the activity report' do
@@ -55,15 +122,22 @@ RSpec.describe "dashboard/index", type: :view do
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.activity_report.continue_report_button'))
     end
 
-    it 'does not render the "get started" callout' do
+    it 'does not render the Figma get started callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
   end
 
   context "with an in-progress exemption request" do
+    let(:exemption_application_form) do
+      create(:exemption_application_form, certification_case_id: certification_case.id)
+    end
+
     before do
-      assign(:exemption_application_form, create(:exemption_application_form, certification_case_id: certification_case.id))
+      assign(:exemption_application_form, exemption_application_form)
     end
 
     it 'renders a button to continue the exemption request' do
@@ -71,9 +145,12 @@ RSpec.describe "dashboard/index", type: :view do
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.exemption_request.continue_request_button'))
     end
 
-    it 'does not render the "get started" callout' do
+    it 'does not render the Figma get started callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
   end
 
@@ -97,7 +174,10 @@ RSpec.describe "dashboard/index", type: :view do
 
     it 'does not render the "get started" callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
   end
 
@@ -121,7 +201,10 @@ RSpec.describe "dashboard/index", type: :view do
 
     it 'does not render the "get started" callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
   end
 
@@ -148,10 +231,9 @@ RSpec.describe "dashboard/index", type: :view do
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_approved.view_activity_report_button'))
     end
 
-    it 'renders the blue banner section' do
-      # The approved activity report view intentionally shows the blue banner
+    it 'does not render the Figma get started callout' do
       render
-      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_css('.member-dashboard-compliance__onboarding')
     end
   end
 
@@ -177,7 +259,10 @@ RSpec.describe "dashboard/index", type: :view do
 
     it 'does not render the "get started" callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
   end
 
@@ -232,7 +317,10 @@ RSpec.describe "dashboard/index", type: :view do
 
     it 'does not render the "get started" callout' do
       render
-      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.get_started.button'))
+      expect(rendered).not_to have_selector(
+        'a',
+        text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
+      )
     end
 
     context "with an in-progress activity report" do
@@ -247,19 +335,35 @@ RSpec.describe "dashboard/index", type: :view do
     end
   end
 
-  context "with previous certifications" do
-    let(:older_certification) { create(:certification) }
+  context "with a completed prior certification period" do
+    let(:older_certification) { create(:certification, member_data: member_data) }
 
     before do
-      assign(:all_certifications, [
-        certification,
-        older_certification
-      ])
+      create(:certification_case, certification: older_certification)
+      create(:determination,
+             subject: older_certification,
+             outcome: "compliant",
+             decision_method: "manual",
+             reasons: [ "hours_reported_compliant" ])
+      older_certification.update!(created_at: 2.months.ago)
+      certification.update!(created_at: 1.day.ago)
+      assign(:all_certifications, [ certification, older_certification ])
+      assign(:previous_completed_certifications,
+             MemberStatusService.previous_completed_certifications(
+               [ certification, older_certification ],
+               current_certification: certification
+             ))
     end
 
     it 'renders a section for previous certifications' do
       render
       expect(rendered).to have_selector('h2', text: I18n.t('dashboard.index.previous_certifications.title'))
+    end
+
+    it 'renders previous certifications only once' do
+      render
+      title = I18n.t('dashboard.index.previous_certifications.title')
+      expect(rendered.scan(title).length).to eq(1)
     end
 
     it 'renders a button to review previous certifications' do
@@ -268,11 +372,33 @@ RSpec.describe "dashboard/index", type: :view do
     end
   end
 
+  context "with an older certification still in progress" do
+    let(:older_certification) { create(:certification, member_data: member_data) }
+
+    before do
+      create(:certification_case, certification: older_certification)
+      older_certification.update!(created_at: 2.months.ago)
+      certification.update!(created_at: 1.day.ago)
+      assign(:all_certifications, [ certification, older_certification ])
+      assign(:previous_completed_certifications,
+             MemberStatusService.previous_completed_certifications(
+               [ certification, older_certification ],
+               current_certification: certification
+             ))
+    end
+
+    it "does not render previous certifications" do
+      render
+      expect(rendered).not_to have_selector(
+        'h2',
+        text: I18n.t('dashboard.index.previous_certifications.title')
+      )
+    end
+  end
+
   context "without previous certifications" do
     it 'does not render the previous certifications section from index' do
       render
-      # The index.html.erb only shows previous certifications section when there are >1 certifications
-      # But the new_certification partial has its own "Previously completed requirements" section
       expect(rendered).not_to have_selector('h2', text: I18n.t('dashboard.index.previous_certifications.title'))
     end
   end


### PR DESCRIPTION
## Ticket

Resolves [OSCER-639](https://github.com/navapbc/oscer/issues/639)

## Changes

- Add member dashboard layout with welcome hero (`:banner` in `layouts/dashboard.html.erb` + `application_base` banner slot).
- Replace legacy blue “get started” callout with Figma onboarding frame (`_member_compliance_get_started`, `_member_compliance_about_reporting`) when exemption has not started and no activity report exists; keep legacy compliance status + action buttons for all other `new_certification` states.
- Update `dashboard/index` greeting styling and move “previous completed requirements” to `_previous_certifications`, gated by `MemberStatusService.previous_completed_certifications` (terminal outcomes / closed cases only).
- Add landing SCSS (`_member_dashboard.scss`), minimal `MemberComplianceHelper`, and locale keys for hero + get-started copy.
- Add `MemberStatus#certification_period_completed?` and service specs for prior-period detection.
- Fix hero spacing: skip empty flash wrapper padding so the welcome banner sits flush under the site header.

## Context for reviewers

- This is **slice 1** of the OSCER-480 stack; closes [#626](https://github.com/navapbc/oscer/pull/626) in favor of smaller PRs ([#640](https://github.com/navapbc/oscer/issues/640)–[#643](https://github.com/navapbc/oscer/issues/643) follow).
- Exemption/reporting outcome partials, progress cards, and staff-style activity tables are **intentionally out of scope** here—legacy partials remain for those dashboard states.
- `activity_report_approved` still uses the old blue banner with a “Get started” link (same label as Figma CTA); that partial is deferred to a later slice.

## Testing

From `reporting-app/`:

```bash
make lint
make test args='spec/helpers/member_compliance_helper_spec.rb spec/services/member_status_service_spec.rb spec/views/dashboard/index.html.erb_spec.rb'
```

- 84 examples, 0 failures (targeted run).
- Manual: sign in as a member with a fresh certification (no exemption or activity report) → hero, greeting, Figma get-started alert + screener CTA, about-reporting block. Member with a prior completed period → “Previous completed requirements” section once at bottom.
- 
<img width="745" height="589" alt="Screenshot 2026-06-05 at 11 43 51 AM" src="https://github.com/user-attachments/assets/47d4d465-0895-4f0b-a510-80a7da85a20c" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->