### PR TITLE
OSCER-652: Make activity-report denial verification-window-aware

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -51,6 +51,7 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   transition(REPORT_ACTIVITIES_STEP, "ActivityReportApplicationFormSubmitted", REVIEW_ACTIVITY_REPORT_STEP)
   transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportApproved", END_STEP)
   transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportDenied", END_STEP)
+  transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportDeniedFinal", END_STEP)
 
   # --- Transitions: Exemption claim workflow ---
   transition(REPORT_ACTIVITIES_STEP, "ExemptionApplicationFormSubmitted", REVIEW_EXEMPTION_CLAIM_STEP)

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -67,7 +67,7 @@ module DashboardHelper
     return false unless certification_case.present?
 
     certification_case.open? &&
-      (certification_case.verification_window_end_date.blank? ||  certification_case.verification_window_end_date > Time.now) &&
+      !certification_case.verification_window_ended? &&
       !ExemptionApplicationForm.has_pending_form(certification_case.id)
   end
 

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -93,7 +93,10 @@ class CertificationCase < Strata::Case
       )
     end
 
-    Strata::EventManager.publish("ActivityReportDenied", { case_id: id, certification_id: certification_id, application_form_id: application_form.id })
+    # Split the denial event by verification-window state so the member's notification reflects
+    # whether they can still report.
+    event_name = verification_window_ended? ? "ActivityReportDeniedFinal" : "ActivityReportDenied"
+    Strata::EventManager.publish(event_name, { case_id: id, certification_id: certification_id, application_form_id: application_form.id })
   end
 
   def accept_exemption_request(user)
@@ -236,6 +239,10 @@ class CertificationCase < Strata::Case
       verification_window_start_date: start_date,
       verification_window_end_date: start_date + VERIFICATION_WINDOW_DURATION_DAYS
     )
+  end
+
+  def verification_window_ended?
+    verification_window_end_date.present? && verification_window_end_date < Time.current
   end
 
   private

--- a/reporting-app/app/models/exemption_application_form.rb
+++ b/reporting-app/app/models/exemption_application_form.rb
@@ -57,7 +57,7 @@ class ExemptionApplicationForm < Strata::ApplicationForm
       errors.add(:certification_case_id, "is invalid")
     elsif certification_case.closed?
       errors.add(:certification_case_id, "has closed")
-    elsif certification_case.verification_window_end_date && certification_case.verification_window_end_date < Time.now
+    elsif certification_case.verification_window_ended?
       errors.add(:certification_case_id, "verification window has ended")
     end
   end

--- a/reporting-app/app/services/notifications_event_listener.rb
+++ b/reporting-app/app/services/notifications_event_listener.rb
@@ -10,7 +10,8 @@
 # - DeterminedHoursInsufficient → insufficient_hours_email
 # - DeterminedCommunityEngagementInsufficient → insufficient_community_engagement_email (hours and/or income sections).
 # - ActivityReportApproved → compliant_email (reviewer determined compliance)
-# - ActivityReportDenied → insufficient_hours_email (reviewer determined non-compliance)
+# - ActivityReportDenied → insufficient_hours_email (non-compliance, verification window open)
+# - ActivityReportDeniedFinal → insufficient_hours_email (non-compliance, verification window ended)
 #
 # Payload may carry:
 # - case_id
@@ -38,6 +39,7 @@ class NotificationsEventListener
       Strata::EventManager.subscribe("DeterminedCommunityEngagementInsufficient", method(:handle_insufficient_community_engagement))
       Strata::EventManager.subscribe("ActivityReportApproved", method(:handle_activity_report_approved))
       Strata::EventManager.subscribe("ActivityReportDenied", method(:handle_activity_report_denied))
+      Strata::EventManager.subscribe("ActivityReportDeniedFinal", method(:handle_activity_report_denied_final))
     end
 
     private
@@ -147,11 +149,17 @@ class NotificationsEventListener
     end
 
     def handle_activity_report_denied(event)
-      # Reviewer denied = member is not compliant
+      # Denied while the verification window is open: the member can still report again.
       event_with_source = event.merge(
         payload: event[:payload].merge(source: :activity_report_denied)
       )
       handle_insufficient_hours(event_with_source)
+    end
+
+    def handle_activity_report_denied_final(event)
+      # Denied after the window has ended — final. No source set (unlike the sibling), so the
+      # email reflects the closed window.
+      handle_insufficient_hours(event)
     end
 
     def fetch_certification(event)

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       expect(certification_case).to be_closed
     end
 
-    context 'when activity report is denied' do
+    context 'when activity report is denied while the verification window is open' do
       before do
         # Submit activity report
         activity_report = create(:activity_report_application_form,
@@ -154,6 +154,28 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
 
       it 'sets member status to not_compliant' do
         expect(certification_case.member_status).to eq(MemberStatus::NOT_COMPLIANT)
+      end
+
+      it 'closes the case' do
+        expect(certification_case).to be_closed
+      end
+    end
+
+    context 'when activity report is denied after the verification window has ended' do
+      before do
+        activity_report = create(:activity_report_application_form,
+          certification_case_id: certification_case.id
+        )
+        activity_report.submit_application
+        certification_case.reload
+
+        certification_case.update_attribute(:verification_window_end_date, 1.day.ago)
+        certification_case.deny_activity_report(user, activity_report)
+        certification_case.reload
+      end
+
+      it 'transitions to end step via the final-denial event' do
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
       end
 
       it 'closes the case' do

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -118,13 +118,34 @@ RSpec.describe CertificationCase, type: :model do
         .with(anything, application_form: application_form)
     end
 
-    it 'publishes ActivityReportDenied event' do
+    it 'publishes ActivityReportDenied event while the verification window is open' do
       certification_case.deny_activity_report(user, application_form)
 
       expect(Strata::EventManager).to have_received(:publish).with(
         "ActivityReportDenied",
         { case_id: certification_case.id, certification_id: certification_case.certification_id, application_form_id: application_form.id }
       )
+    end
+
+    context 'when the verification window has ended' do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.ago) }
+
+      it 'still closes the case' do
+        certification_case.deny_activity_report(user, application_form)
+        certification_case.reload
+
+        expect(certification_case.activity_report_approval_status).to eq("denied")
+        expect(certification_case).to be_closed
+      end
+
+      it 'publishes ActivityReportDeniedFinal event' do
+        certification_case.deny_activity_report(user, application_form)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "ActivityReportDeniedFinal",
+          { case_id: certification_case.id, certification_id: certification_case.certification_id, application_form_id: application_form.id }
+        )
+      end
     end
 
     it 'logs decision to audit log' do

--- a/reporting-app/spec/services/notifications_event_listener_spec.rb
+++ b/reporting-app/spec/services/notifications_event_listener_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe NotificationsEventListener, type: :service do
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementInsufficient", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("ActivityReportApproved", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("ActivityReportDenied", anything)
+      expect(Strata::EventManager).to have_received(:subscribe).with("ActivityReportDeniedFinal", anything)
     end
   end
 
@@ -335,6 +336,33 @@ RSpec.describe NotificationsEventListener, type: :service do
             hours_data: { total_hours: 30, hours_by_source: { external: 30, activity: 0 } },
             target_hours: HoursComplianceDeterminationService::TARGET_HOURS,
             open_verification_window: true,
+            case_id: certification_case.id
+          },
+          :insufficient_hours_email,
+          [ certification.member_email ]
+        )
+      end
+    end
+
+    describe "#handle_activity_report_denied_final" do
+      let(:application_form) { create(:activity_report_application_form) }
+
+      it "sends insufficient_hours_email with the verification window closed" do
+        allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification)
+          .with(certification, application_form: application_form)
+          .and_return({ total_hours: 30, hours_by_source: { external: 30, activity: 0 } })
+
+        event = { payload: { case_id: certification_case.id, certification_id: certification.id, application_form_id: application_form.id } }
+
+        described_class.send(:handle_activity_report_denied_final, event)
+
+        expect(NotificationService).to have_received(:send_email_notification).with(
+          MemberMailer,
+          {
+            certification: certification,
+            hours_data: { total_hours: 30, hours_by_source: { external: 30, activity: 0 } },
+            target_hours: HoursComplianceDeterminationService::TARGET_HOURS,
+            open_verification_window: false,
             case_id: certification_case.id
           },
           :insufficient_hours_email,


### PR DESCRIPTION
## Ticket

Resolves #652 

## Changes

- Certification Case publishes different events on denial based on whether verification window closed
- New `ActivityReportDeniedFinal` event added to business-process flow
- Utility method for verification closure added to CertificationCase; used elsewhere in code

## Context for reviewers

We will need to refer the case back to the member on denial while the verification window is open, but close the case when the verification closes. This ticket puts in the plumbing for the divergent flows in order to keep the multiple-submission PR reasonable.

## Testing

Manually tested denying an activity report with verification window both open and closed. Both closed the case. The logs showed the correct notifications fired.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->