### PR TITLE
OSCER-638: Allow multiple activity reports

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -46,11 +46,12 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   transition(EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedCommunityEngagementActionRequired", REPORT_ACTIVITIES_STEP)
 
   # --- Transitions: Activity report workflow ---
-  # Reviewer determines compliance: approved = compliant, denied = not compliant
-  # Both outcomes close the case
+  # Reviewer determines compliance: approved = compliant, denied = not compliant.
+  # A denial while the verification window is open returns the member to report_activities so they
+  # can submit again; approval and final denial (window ended) close the case.
   transition(REPORT_ACTIVITIES_STEP, "ActivityReportApplicationFormSubmitted", REVIEW_ACTIVITY_REPORT_STEP)
   transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportApproved", END_STEP)
-  transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportDenied", END_STEP)
+  transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportDenied", REPORT_ACTIVITIES_STEP)
   transition(REVIEW_ACTIVITY_REPORT_STEP, "ActivityReportDeniedFinal", END_STEP)
 
   # --- Transitions: Exemption claim workflow ---

--- a/reporting-app/app/controllers/activity_report_application_forms_controller.rb
+++ b/reporting-app/app/controllers/activity_report_application_forms_controller.rb
@@ -12,6 +12,7 @@ class ActivityReportApplicationFormsController < ApplicationController
     accept_doc_ai
   ]
   before_action :authenticate_user!
+  before_action :create_activity_report_application_form, only: %i[create]
   before_action :set_certification_case, only: %i[show edit review update]
   before_action :set_certification, only: %i[show review]
   before_action :set_monthly_statistics, only: %i[show review]
@@ -29,15 +30,20 @@ class ActivityReportApplicationFormsController < ApplicationController
       return
     end
     @certification_case = certification_service.find(params[:certification_case_id], hydrate: false)
+
+    if @certification_case.closed?
+      redirect_to dashboard_path, notice: t(".errors.case_closed")
+    elsif @certification_case.verification_window_ended?
+      redirect_to dashboard_path, notice: t(".errors.verification_window_ended")
+    elsif ActivityReportApplicationForm.has_pending_form(@certification_case.id)
+      redirect_to dashboard_path, notice: t(".errors.form_in_progress")
+    end
   end
 
   # POST /activity_report_application_forms
   def create
-    @activity_report_application_form = authorize ActivityReportApplicationForm.new(activity_report_application_form_create_params)
-    @activity_report_application_form.user_id = current_user.id
-
     respond_to do |format|
-      if @activity_report_application_form.save
+      if @activity_report_application_form.valid?
         format.html do
           skip_ai = params.dig(:activity_report_application_form, :skip_ai) == "1"
           session[:doc_ai_skip] = skip_ai
@@ -45,7 +51,6 @@ class ActivityReportApplicationFormsController < ApplicationController
         end
         format.json { render :show, status: :created, location: @activity_report_application_form }
       else
-        flash[:errors] = @activity_report_application_form.errors.full_messages
         format.html { redirect_to dashboard_path }
         format.json { render json: @activity_report_application_form.errors, status: :unprocessable_content }
       end
@@ -160,6 +165,23 @@ class ActivityReportApplicationFormsController < ApplicationController
 
   def activity_report_application_form_create_params
     params.require(:activity_report_application_form).permit(:certification_case_id)
+  end
+
+  def create_activity_report_application_form
+    @activity_report_application_form = ActivityReportApplicationForm.new(activity_report_application_form_create_params)
+    @activity_report_application_form.user_id = current_user.id
+    authorize @activity_report_application_form
+    @activity_report_application_form.save!
+  rescue ActiveRecord::RecordInvalid => e
+    if e.record.errors[:certification_case_id].include?("has already been taken")
+      redirect_to dashboard_path, notice: t("activity_report_application_forms.errors.other_report_exists")
+    elsif e.record.errors[:certification_case_id].include?("has closed")
+      redirect_to dashboard_path, notice: t("activity_report_application_forms.errors.case_closed")
+    elsif e.record.errors[:certification_case_id].include?("verification window has ended")
+      redirect_to dashboard_path, notice: t("activity_report_application_forms.errors.verification_window_ended")
+    else
+      raise
+    end
   end
 
   def set_certification_case

--- a/reporting-app/app/controllers/activity_report_application_forms_controller.rb
+++ b/reporting-app/app/controllers/activity_report_application_forms_controller.rb
@@ -43,17 +43,12 @@ class ActivityReportApplicationFormsController < ApplicationController
   # POST /activity_report_application_forms
   def create
     respond_to do |format|
-      if @activity_report_application_form.valid?
-        format.html do
-          skip_ai = params.dig(:activity_report_application_form, :skip_ai) == "1"
-          session[:doc_ai_skip] = skip_ai
-          redirect_to edit_activity_report_application_form_path(@activity_report_application_form)
-        end
-        format.json { render :show, status: :created, location: @activity_report_application_form }
-      else
-        format.html { redirect_to dashboard_path }
-        format.json { render json: @activity_report_application_form.errors, status: :unprocessable_content }
+      format.html do
+        skip_ai = params.dig(:activity_report_application_form, :skip_ai) == "1"
+        session[:doc_ai_skip] = skip_ai
+        redirect_to edit_activity_report_application_form_path(@activity_report_application_form)
       end
+      format.json { render :show, status: :created, location: @activity_report_application_form }
     end
   end
 

--- a/reporting-app/app/helpers/activity_report_application_forms_helper.rb
+++ b/reporting-app/app/helpers/activity_report_application_forms_helper.rb
@@ -2,7 +2,11 @@
 
 module ActivityReportApplicationFormsHelper
   def activity_report_status_class(status)
-    status == "approved" ? "text-green" : "text-red"
+    case status
+    when "approved" then "text-green"
+    when "denied" then "text-red"
+    else ""
+    end
   end
 
   def activity_report_current_step(form, flash_notice_present:)

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -40,7 +40,7 @@ module DashboardHelper
   end
 
   def is_activity_report_submitted?
-    @activity_report_application_form&.submitted? && @certification_case&.activity_report_approval_status.nil?
+    @activity_report_application_form&.flow_status == "submitted"
   end
 
   def is_exemption_request_submitted?
@@ -48,7 +48,7 @@ module DashboardHelper
   end
 
   def is_activity_report_approved?
-    @activity_report_application_form&.submitted? && @certification_case&.activity_report_approval_status == "approved"
+    @activity_report_application_form&.flow_status == "approved"
   end
 
   def is_exemption_request_approved?
@@ -56,7 +56,7 @@ module DashboardHelper
   end
 
   def is_activity_report_denied?
-    @activity_report_application_form&.submitted? && @certification_case&.activity_report_approval_status == "denied"
+    @activity_report_application_form&.flow_status == "denied"
   end
 
   def is_exemption_request_denied?
@@ -69,6 +69,14 @@ module DashboardHelper
     certification_case.open? &&
       !certification_case.verification_window_ended? &&
       !ExemptionApplicationForm.has_pending_form(certification_case.id)
+  end
+
+  def should_show_submit_new_activity_report_form?(certification_case)
+    return false unless certification_case.present?
+
+    certification_case.open? &&
+      !certification_case.verification_window_ended? &&
+      !ActivityReportApplicationForm.has_pending_form(certification_case.id)
   end
 
   # Figma "Get started" — exemption screener CTA before any application forms exist (7203:6175).

--- a/reporting-app/app/models/activity_report_application_form.rb
+++ b/reporting-app/app/models/activity_report_application_form.rb
@@ -12,8 +12,9 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
   strata_attribute :number_of_months_to_certify, :integer
   strata_attribute :months_that_can_be_certified, :year_month, array: true
 
-  # At most one in-progress form per case; any number of submitted forms may accumulate over resubmissions.
-  validates :certification_case_id, presence: true, uniqueness: { conditions: -> { in_progress } }
+  validates :certification_case_id, presence: true
+  validate :case_not_closed, on: :create
+  validate :no_pending_forms, on: :create
   validates :reporting_periods,
     length: {
       is: :number_of_months_to_certify,
@@ -60,7 +61,43 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
       .map { |ym| Date.new(ym.year, ym.month, 1) }
   end
 
+  def flow_status
+    unless @flow_status.present?
+      task_complete = ReviewActivityReportTask.where(case_id: certification_case_id,
+                                                     application_form: self,
+                                                     status: :completed).exists?
+      @flow_status = if task_complete
+                       CertificationCase.find(certification_case_id).activity_report_approval_status
+      else
+                       status
+      end
+    end
+
+    @flow_status
+  end
+
+  def self.has_pending_form(certification_case_id)
+    ActivityReportApplicationForm.where(certification_case_id:, status: :in_progress).exists? ||
+    ReviewActivityReportTask.where(application_form: ActivityReportApplicationForm.where(certification_case_id:).all,
+                                   status: [ :on_hold, :pending ]).exists?
+  end
+
   private
+
+  def case_not_closed
+    certification_case = CertificationCase.find_by(id: certification_case_id)
+    if certification_case.blank?
+      errors.add(:certification_case_id, "is invalid")
+    elsif certification_case.closed?
+      errors.add(:certification_case_id, "has closed")
+    elsif certification_case.verification_window_ended?
+      errors.add(:certification_case_id, "verification window has ended")
+    end
+  end
+
+  def no_pending_forms
+    errors.add(:certification_case_id, "has already been taken") if ActivityReportApplicationForm.has_pending_form(certification_case_id)
+  end
 
   def validate_reporting_periods_in_range
     invalid = reporting_periods - months_that_can_be_certified

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -81,7 +81,7 @@ class CertificationCase < Strata::Case
     transaction do
       self.activity_report_approval_status = "denied"
       self.activity_report_approval_status_updated_at = Time.current
-      close!
+      verification_window_ended? ? close! : save!
 
       certification.record_determination!(
         decision_method: :manual,

--- a/reporting-app/app/views/activity_report_application_forms/show.html.erb
+++ b/reporting-app/app/views/activity_report_application_forms/show.html.erb
@@ -34,12 +34,11 @@
     </div>
   </div>
 
-<% elsif @certification_case&.activity_report_approval_status %>
-  <p class="usa-intro <%= activity_report_status_class(@certification_case.activity_report_approval_status) %>">
-    <%= t("activity_report_application_forms.shared.status_messages.#{@certification_case.activity_report_approval_status}") %>
-  </p>
 <% else %>
-  <p class="usa-intro"><%= t("activity_report_application_forms.shared.status_messages.submitted") %></p>
+  <% flow_status = @activity_report_application_form.flow_status %>
+  <p class="usa-intro <%= activity_report_status_class(flow_status) %>">
+    <%= t("activity_report_application_forms.shared.status_messages.#{flow_status}") %>
+  </p>
 <% end %>
 <div class="margin-y-6">
   <%= render "activity_report_application_forms/activity_report_application_form",

--- a/reporting-app/app/views/dashboard/_activity_report_denied.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_denied.html.erb
@@ -2,5 +2,8 @@
   <%= render AlertComponent.new(type: AlertComponent::TYPES::ERROR, heading: t(".heading"), message: t(".intro"), heading_level: 3) %>
   <div class="margin-top-3">
     <%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
+    <%= link_to(t(".submit_new_activity_report_button"),
+          new_activity_report_application_form_path(certification_case_id: certification_case&.id),
+          class: "usa-button usa-button--outline") if should_show_submit_new_activity_report_form?(certification_case) %>
   </div>
 </div>

--- a/reporting-app/config/locales/views/activity_report_application_forms/en.yml
+++ b/reporting-app/config/locales/views/activity_report_application_forms/en.yml
@@ -41,6 +41,14 @@ en:
         callout_heading: "✨ Save time with AI"
         callout_body: "We can help you skip the manual data entry. Our uploader automatically scans your uploaded documents to identify and fill in key details for you."
         skip_ai_label: "Skip AI, and enter my details manually"
+      errors:
+        case_closed: "Unable to create an activity report as this certification has closed."
+        verification_window_ended: "Unable to create an activity report as the verification window has ended."
+        form_in_progress: "You already have an activity report for this certification period."
+    errors:
+      other_report_exists: "An activity report already exists for this certification case"
+      case_closed: "Certification case has been closed"
+      verification_window_ended: "Verification window has ended"
     accept_doc_ai:
       no_activities_created: "No income activities were created from your documents."
       payslip_not_in_reporting_period: "One or more uploaded documents have dates that don't match your selected reporting period. Please review your documents and try again."

--- a/reporting-app/config/locales/views/dashboard/activity_report_denied.yml
+++ b/reporting-app/config/locales/views/dashboard/activity_report_denied.yml
@@ -4,3 +4,4 @@ en:
       heading: "Activity report does not meet requirements"
       intro: "Your activity report does not meet the requirements. You are still required to report activities. If you disagree with this decision, you may appeal this decision."
       view_activity_report_button: "View activity report"
+      submit_new_activity_report_button: "Submit new activity report"

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -148,16 +148,16 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
         certification_case.reload
       end
 
-      it 'transitions to end step' do
-        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
+      it 'returns to report_activities step so the member can report again' do
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::REPORT_ACTIVITIES_STEP)
       end
 
       it 'sets member status to not_compliant' do
         expect(certification_case.member_status).to eq(MemberStatus::NOT_COMPLIANT)
       end
 
-      it 'closes the case' do
-        expect(certification_case).to be_closed
+      it 'keeps the case open' do
+        expect(certification_case).to be_open
       end
     end
 

--- a/reporting-app/spec/helpers/dashboard_helper_spec.rb
+++ b/reporting-app/spec/helpers/dashboard_helper_spec.rb
@@ -47,4 +47,58 @@ RSpec.describe DashboardHelper, type: :helper do
       expect(helper.member_dashboard_get_started_screen?(compliance_with_exemption)).to be(false)
     end
   end
+
+  describe "#should_show_submit_new_activity_report_form?" do
+    it "returns false when certification_case is blank" do
+      expect(helper.should_show_submit_new_activity_report_form?(nil)).to be(false)
+    end
+
+    it "is true when the case is open, the window has not ended, and no form is pending" do
+      expect(helper.should_show_submit_new_activity_report_form?(certification_case)).to be(true)
+    end
+
+    it "is false when the case is closed" do
+      certification_case.close!
+      expect(helper.should_show_submit_new_activity_report_form?(certification_case)).to be(false)
+    end
+
+    it "is false when the verification window has ended" do
+      certification_case.update_attribute(:verification_window_end_date, 1.day.ago)
+      expect(helper.should_show_submit_new_activity_report_form?(certification_case)).to be(false)
+    end
+
+    it "is false when a form is already pending" do
+      create(:activity_report_application_form, certification_case_id: certification_case.id)
+      expect(helper.should_show_submit_new_activity_report_form?(certification_case)).to be(false)
+    end
+  end
+
+  describe "activity report status helpers" do
+    let(:activity_report) { create(:activity_report_application_form, certification_case_id: certification_case.id) }
+
+    before do
+      assign(:activity_report_application_form, activity_report)
+      assign(:certification_case, certification_case)
+    end
+
+    it "#is_activity_report_submitted? is true when flow_status is 'submitted'" do
+      allow(activity_report).to receive(:flow_status).and_return("submitted")
+      expect(helper.is_activity_report_submitted?).to be(true)
+    end
+
+    it "#is_activity_report_approved? is true when flow_status is 'approved'" do
+      allow(activity_report).to receive(:flow_status).and_return("approved")
+      expect(helper.is_activity_report_approved?).to be(true)
+    end
+
+    it "#is_activity_report_denied? is true when flow_status is 'denied'" do
+      allow(activity_report).to receive(:flow_status).and_return("denied")
+      expect(helper.is_activity_report_denied?).to be(true)
+    end
+
+    it "#is_activity_report_submitted? is false once the report is approved" do
+      allow(activity_report).to receive(:flow_status).and_return("approved")
+      expect(helper.is_activity_report_submitted?).to be(false)
+    end
+  end
 end

--- a/reporting-app/spec/models/activity_report_application_form_spec.rb
+++ b/reporting-app/spec/models/activity_report_application_form_spec.rb
@@ -4,47 +4,182 @@ require 'rails_helper'
 
 RSpec.describe ActivityReportApplicationForm, type: :model do
   describe "validations" do
-    describe "certification_case_id" do
-      let(:certification) { create(:certification) }
-      let(:certification_case) { create(:certification_case, certification: certification) }
+    let(:certification) { create(:certification) }
+    let(:certification_case) { create(:certification_case, certification: certification) }
 
-      before { allow(Strata::EventManager).to receive(:publish) }
+    it "requires a certification_case_id" do
+      form = build(:activity_report_application_form, certification_case_id: nil)
 
-      it "requires a certification_case_id" do
-        form = build(:activity_report_application_form, certification_case_id: nil)
+      expect(form.save).to be(false)
+      expect(form.errors[:certification_case_id]).to include("can't be blank")
+    end
 
-        expect(form.save).to be(false)
-        expect(form.errors[:certification_case_id]).to include("can't be blank")
-      end
+    it "allows only one in-progress form per case" do
+      create(:activity_report_application_form, certification_case_id: certification_case.id)
+      second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
 
-      it "allows only one in-progress form per case" do
-        create(:activity_report_application_form, certification_case_id: certification_case.id)
+      expect(second_form.save).to be(false)
+      expect(second_form.errors[:certification_case_id]).to include("has already been taken")
+    end
+
+    it "allows different certification_case_ids" do
+      certification_case_2 = create(:certification_case)
+      create(:activity_report_application_form, certification_case_id: certification_case.id)
+      second_form = build(:activity_report_application_form, certification_case_id: certification_case_2.id)
+
+      expect(second_form.save).to be(true)
+    end
+
+    context "with existing submitted form" do
+      let!(:first_form) { create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
+
+      it "does not allow a new form while the review task is still pending" do
         second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
 
         expect(second_form.save).to be(false)
         expect(second_form.errors[:certification_case_id]).to include("has already been taken")
       end
 
-      it "allows a new in-progress form once the prior form is submitted" do
-        create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
-        second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+      context "with task on hold" do
+        before { ReviewActivityReportTask.find_by(application_form: first_form).on_hold! }
 
-        expect(second_form.save).to be(true)
+        it "does not allow a new form" do
+          second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+
+          expect(second_form.save).to be(false)
+        end
       end
 
-      it "allows multiple submitted forms for the same case" do
-        create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
-        second_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+      context "with task completed" do
+        before { ReviewActivityReportTask.find_by(application_form: first_form).completed! }
 
-        expect(second_form.submit_application).to be(true)
+        it "allows a new form" do
+          second_form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+
+          expect(second_form.save).to be(true)
+        end
+
+        it "allows multiple submitted forms for the same case" do
+          second_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+
+          expect(second_form.submit_application).to be(true)
+        end
+      end
+    end
+
+    context "when certification closed" do
+      before { certification_case.close! }
+
+      it "does not allow creation" do
+        form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+        expect(form.save).to be(false)
+      end
+    end
+
+    context "when verification window closed" do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.ago) }
+
+      it "does not allow creation" do
+        form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+        expect(form.save).to be(false)
+      end
+    end
+
+    context "when verification window open" do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.from_now) }
+
+      it "allows creation" do
+        form = build(:activity_report_application_form, certification_case_id: certification_case.id)
+        expect(form.save).to be(true)
+      end
+    end
+  end
+
+  describe "flow status" do
+    let(:certification) { create(:certification) }
+    let(:certification_case) { create(:certification_case, certification: certification) }
+
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
+        total_hours: 40,
+        hours_by_category: { "education" => 40 },
+        hours_by_source: { external: 30, activity: 10 },
+        external_hourly_activity_ids: [ "ex-1" ],
+        activity_ids: [ "act-1" ]
+      })
+    end
+
+    context "without previous activity report" do
+      it "returns 'in progress' when not submitted" do
+        form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+        expect(form.flow_status).to eq "in_progress"
       end
 
-      it "allows different certification_case_ids" do
-        certification_case_2 = create(:certification_case)
-        create(:activity_report_application_form, certification_case_id: certification_case.id)
-        second_form = build(:activity_report_application_form, certification_case_id: certification_case_2.id)
+      it "returns 'submitted' when no task" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        expect(form.flow_status).to eq "submitted"
+      end
 
-        expect(second_form.save).to be(true)
+      it "returns 'submitted' when task pending" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        create(:review_activity_report_task, application_form: form, case: certification_case)
+        expect(form.flow_status).to eq "submitted"
+      end
+
+      it "returns 'approved' when approved" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        task = create(:review_activity_report_task, application_form: form, case: certification_case)
+        task.completed!
+        certification_case.accept_activity_report(nil, form)
+        expect(form.flow_status).to eq "approved"
+      end
+
+      it "returns 'denied' when denied" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        task = create(:review_activity_report_task, application_form: form, case: certification_case)
+        task.completed!
+        certification_case.deny_activity_report(nil, form)
+        expect(form.flow_status).to eq "denied"
+      end
+    end
+
+    context "with previous denied activity report" do
+      before do
+        previous_form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        certification_case.deny_activity_report(nil, previous_form)
+      end
+
+      it "returns 'in progress' when not submitted" do
+        form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+        expect(form.flow_status).to eq "in_progress"
+      end
+
+      it "returns 'submitted' when no task" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        expect(form.flow_status).to eq "submitted"
+      end
+
+      it "returns 'submitted' when task pending" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        create(:review_activity_report_task, application_form: form, case: certification_case)
+        expect(form.flow_status).to eq "submitted"
+      end
+
+      it "returns 'approved' when approved" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        task = create(:review_activity_report_task, application_form: form, case: certification_case)
+        task.completed!
+        certification_case.accept_activity_report(nil, form)
+        expect(form.flow_status).to eq "approved"
+      end
+
+      it "returns 'denied' when denied" do
+        form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        task = create(:review_activity_report_task, application_form: form, case: certification_case)
+        task.completed!
+        certification_case.deny_activity_report(nil, form)
+        expect(form.flow_status).to eq "denied"
       end
     end
   end

--- a/reporting-app/spec/models/activity_report_application_form_spec.rb
+++ b/reporting-app/spec/models/activity_report_application_form_spec.rb
@@ -101,13 +101,6 @@ RSpec.describe ActivityReportApplicationForm, type: :model do
 
     before do
       allow(Strata::EventManager).to receive(:publish)
-      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
-        total_hours: 40,
-        hours_by_category: { "education" => 40 },
-        hours_by_source: { external: 30, activity: 10 },
-        external_hourly_activity_ids: [ "ex-1" ],
-        activity_ids: [ "act-1" ]
-      })
     end
 
     context "without previous activity report" do

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -90,13 +90,33 @@ RSpec.describe CertificationCase, type: :model do
       })
     end
 
-    it 'sets denial status and closes case' do
+    it 'sets denial status' do
       certification_case.deny_activity_report(user, application_form)
       certification_case.reload
 
       expect(certification_case.activity_report_approval_status).to eq("denied")
       expect(certification_case.activity_report_approval_status_updated_at).to be_present
-      expect(certification_case).to be_closed
+    end
+
+    context 'when the verification window has not been opened (end date nil)' do
+      before { certification_case.update_attribute(:verification_window_end_date, nil) }
+
+      it 'keeps the case open so the member can report again' do
+        certification_case.deny_activity_report(user, application_form)
+        certification_case.reload
+
+        expect(certification_case.activity_report_approval_status).to eq("denied")
+        expect(certification_case).to be_open
+      end
+
+      it 'publishes ActivityReportDenied event' do
+        certification_case.deny_activity_report(user, application_form)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "ActivityReportDenied",
+          { case_id: certification_case.id, certification_id: certification_case.certification_id, application_form_id: application_form.id }
+        )
+      end
     end
 
     it 'records not_compliant determination' do
@@ -118,19 +138,31 @@ RSpec.describe CertificationCase, type: :model do
         .with(anything, application_form: application_form)
     end
 
-    it 'publishes ActivityReportDenied event while the verification window is open' do
-      certification_case.deny_activity_report(user, application_form)
+    context 'when the verification window is open' do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.from_now) }
 
-      expect(Strata::EventManager).to have_received(:publish).with(
-        "ActivityReportDenied",
-        { case_id: certification_case.id, certification_id: certification_case.certification_id, application_form_id: application_form.id }
-      )
+      it 'keeps the case open so the member can report again' do
+        certification_case.deny_activity_report(user, application_form)
+        certification_case.reload
+
+        expect(certification_case.activity_report_approval_status).to eq("denied")
+        expect(certification_case).to be_open
+      end
+
+      it 'publishes ActivityReportDenied event' do
+        certification_case.deny_activity_report(user, application_form)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "ActivityReportDenied",
+          { case_id: certification_case.id, certification_id: certification_case.certification_id, application_form_id: application_form.id }
+        )
+      end
     end
 
     context 'when the verification window has ended' do
       before { certification_case.update_attribute(:verification_window_end_date, 1.day.ago) }
 
-      it 'still closes the case' do
+      it 'closes the case' do
         certification_case.deny_activity_report(user, application_form)
         certification_case.reload
 

--- a/reporting-app/spec/requests/activity_report_application_forms_spec.rb
+++ b/reporting-app/spec/requests/activity_report_application_forms_spec.rb
@@ -146,6 +146,41 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
         expect(response).to be_successful
       end
     end
+
+    context "when the certification case is closed" do
+      before { certification_case.close! }
+
+      it "redirects to the dashboard with a notice" do
+        get new_activity_report_application_form_url(certification_case_id: certification_case.id)
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("activity_report_application_forms.new.errors.case_closed"))
+      end
+    end
+
+    context "when the verification window has ended" do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.ago) }
+
+      it "redirects to the dashboard with a notice" do
+        get new_activity_report_application_form_url(certification_case_id: certification_case.id)
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("activity_report_application_forms.new.errors.verification_window_ended"))
+      end
+    end
+
+    context "when a form is already in progress" do
+      before do
+        create(:activity_report_application_form, certification_case_id: certification_case.id, user_id: user.id)
+      end
+
+      it "redirects to the dashboard with a notice" do
+        get new_activity_report_application_form_url(certification_case_id: certification_case.id)
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("activity_report_application_forms.new.errors.form_in_progress"))
+      end
+    end
   end
 
   describe "POST /create" do
@@ -172,7 +207,45 @@ RSpec.describe "/dashboard/activity_report_application_forms", type: :request do
         post activity_report_application_forms_url(params: invalid_params)
         expect(response).to redirect_to(dashboard_path)
         follow_redirect!
-        expect(response.body).to include("Certification case has already been taken")
+        expect(response.body).to include(I18n.t("activity_report_application_forms.errors.other_report_exists"))
+      end
+    end
+
+    context "with a closed certification case" do
+      before { certification_case.close! }
+
+      let(:params) { { activity_report_application_form: { certification_case_id: certification_case.id } } }
+
+      it "does not create a new ActivityReportApplicationForm" do
+        expect {
+          post activity_report_application_forms_url, params: params
+        }.not_to change(ActivityReportApplicationForm, :count)
+      end
+
+      it "redirects to dashboard with a notice" do
+        post activity_report_application_forms_url, params: params
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("activity_report_application_forms.errors.case_closed"))
+      end
+    end
+
+    context "when the verification window has ended" do
+      before { certification_case.update_attribute(:verification_window_end_date, 1.day.ago) }
+
+      let(:params) { { activity_report_application_form: { certification_case_id: certification_case.id } } }
+
+      it "does not create a new ActivityReportApplicationForm" do
+        expect {
+          post activity_report_application_forms_url, params: params
+        }.not_to change(ActivityReportApplicationForm, :count)
+      end
+
+      it "redirects to dashboard with a notice" do
+        post activity_report_application_forms_url, params: params
+        expect(response).to redirect_to(dashboard_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("activity_report_application_forms.errors.verification_window_ended"))
       end
     end
 

--- a/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "/review_activity_report_tasks", type: :request do
   before do
     login_as user
     allow(NotificationService).to receive(:send_email_notification)
+
+    # Keep the bootstrap community-engagement check from closing the factory-created case
+    # (the hours stub below would otherwise mark it compliant during certification setup).
+    allow(CommunityEngagementCheckService).to receive(:determine) do |bootstrap_case|
+      Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", {
+        case_id: bootstrap_case.id,
+        certification_id: bootstrap_case.certification_id
+      })
+    end
   end
 
   after do
@@ -85,13 +94,26 @@ RSpec.describe "/review_activity_report_tasks", type: :request do
         expect(task).to be_completed
       end
 
-      it "marks case as denied and transitions to end (not compliant)" do
+      it "marks case as denied and returns to report_activities while the verification window is open" do
         patch review_activity_report_task_url(task), params: deny_params
         kase.reload
 
         expect(kase.activity_report_approval_status).to eq("denied")
-        expect(kase.business_process_instance.current_step).to eq("end")
-        expect(kase).to be_closed
+        expect(kase.business_process_instance.current_step).to eq("report_activities")
+        expect(kase).to be_open
+      end
+
+      context "when the verification window has ended" do
+        before { kase.update_attribute(:verification_window_end_date, 1.day.ago) }
+
+        it "marks case as denied and transitions to end (final denial)" do
+          patch review_activity_report_task_url(task), params: deny_params
+          kase.reload
+
+          expect(kase.activity_report_approval_status).to eq("denied")
+          expect(kase.business_process_instance.current_step).to eq("end")
+          expect(kase).to be_closed
+        end
       end
 
       it "redirects back to the task" do

--- a/reporting-app/spec/views/activity_report_application_forms/show.html.erb_spec.rb
+++ b/reporting-app/spec/views/activity_report_application_forms/show.html.erb_spec.rb
@@ -33,4 +33,41 @@ RSpec.describe "activity_report_application_forms/show", type: :view do
     render
     expect(rendered).not_to have_link("Add activity")
   end
+
+  context "when the form has been submitted (not editable)" do
+    before { stub_pundit_for(activity_report_application_form, edit?: false) }
+
+    it "shows the 'being reviewed' message when this form's flow_status is submitted" do
+      allow(activity_report_application_form).to receive(:flow_status).and_return("submitted")
+
+      render
+      expect(rendered).to have_selector("p", text: I18n.t("activity_report_application_forms.shared.status_messages.submitted"))
+    end
+
+    it "shows 'being reviewed' for a resubmitted form even when the case was previously denied" do
+      certification_case = create(:certification_case)
+      certification_case.activity_report_approval_status = "denied"
+      assign(:certification_case, certification_case)
+      allow(activity_report_application_form).to receive(:flow_status).and_return("submitted")
+
+      render
+      expect(rendered).to have_selector("p", text: I18n.t("activity_report_application_forms.shared.status_messages.submitted"))
+      expect(rendered).not_to have_content(I18n.t("activity_report_application_forms.shared.status_messages.denied"))
+      expect(rendered).not_to have_selector("p.text-red")
+    end
+
+    it "shows the approved message when this form's flow_status is approved" do
+      allow(activity_report_application_form).to receive(:flow_status).and_return("approved")
+
+      render
+      expect(rendered).to have_selector("p.text-green", text: I18n.t("activity_report_application_forms.shared.status_messages.approved"))
+    end
+
+    it "shows the denied message when this form's flow_status is denied" do
+      allow(activity_report_application_form).to receive(:flow_status).and_return("denied")
+
+      render
+      expect(rendered).to have_selector("p.text-red", text: I18n.t("activity_report_application_forms.shared.status_messages.denied"))
+    end
+  end
 end

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -218,7 +218,12 @@ RSpec.describe "dashboard/index", type: :view do
       assign(:hours_needed, 0)
       assign(:total_hours_reported, HoursComplianceDeterminationService::TARGET_HOURS)
 
-      certification_case.activity_report_approval_status = "approved"
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
+        total_hours: 85, hours_by_category: {}, hours_by_source: { external: 85, activity: 0 },
+        external_hourly_activity_ids: [], activity_ids: []
+      })
+      ReviewActivityReportTask.find_by(application_form: activity_report_application_form).completed!
+      certification_case.accept_activity_report(nil, activity_report_application_form)
     end
 
     it 'renders a message that the requirements are met' do
@@ -277,7 +282,12 @@ RSpec.describe "dashboard/index", type: :view do
       assign(:hours_needed, 0)
       assign(:total_hours_reported, HoursComplianceDeterminationService::TARGET_HOURS)
 
-      certification_case.activity_report_approval_status = "denied"
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
+        total_hours: 40, hours_by_category: {}, hours_by_source: { external: 40, activity: 0 },
+        external_hourly_activity_ids: [], activity_ids: []
+      })
+      ReviewActivityReportTask.find_by(application_form: activity_report_application_form).completed!
+      certification_case.deny_activity_report(nil, activity_report_application_form)
     end
 
     it 'renders a message that the activity report is denied' do
@@ -288,6 +298,29 @@ RSpec.describe "dashboard/index", type: :view do
     it 'has a button to view the activity report' do
       render
       expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_denied.view_activity_report_button'))
+    end
+
+    it 'renders button to submit a new activity report' do
+      render
+      expect(rendered).to have_selector('a', text: I18n.t('dashboard.activity_report_denied.submit_new_activity_report_button'))
+    end
+
+    context "when verification window ended" do
+      before { certification_case.update_attribute!(:verification_window_end_date, 1.day.ago) }
+
+      it 'does not render the button to submit a new activity report' do
+        render
+        expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.activity_report_denied.submit_new_activity_report_button'))
+      end
+    end
+
+    context "when case closed" do
+      before { certification_case.close! }
+
+      it 'does not render the button to submit a new activity report' do
+        render
+        expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.activity_report_denied.submit_new_activity_report_button'))
+      end
     end
   end
 


### PR DESCRIPTION
## Ticket

Resolves #638

## Changes

Allows a member to submit another activity report after a prior one is denied, as long as the certification case is still open and the verification window has not ended. This mirrors the multiple-exemption-forms work (#646 / OSCER-637).

- **`CertificationCase#deny_activity_report`** now keeps the case open while the verification window is open (or has not been opened yet); only a final denial after the window has ended closes the case.
- **Business process**: a non-final `ActivityReportDenied` event routes the member back to `report_activities` instead of `end`.
- **`ActivityReportApplicationForm`**: replaced the in-progress uniqueness validation with create-context `case_not_closed` / `no_pending_forms` validations; added `flow_status` and `has_pending_form`.
- **Dashboard helper**: status checks (`is_activity_report_submitted?/approved?/denied?`) now read the form's `flow_status`; added `should_show_submit_new_activity_report_form?`.
- **Controller**: `create` now matches the exemption controller — a `before_action` builds and saves the form, translating creation errors into friendly notices; `new` guards against a closed case, ended verification window, or an already-pending form.
- **Dashboard denied partial**: added a "Submit new activity report" button (shown only when a resubmission is allowed).
- **Activity report show page**: derives its status message from the form's `flow_status`, so a resubmitted form no longer inherits a prior form's "denied" message.

## Context for reviewers

The key behavioral change is that an activity-report denial is no longer always terminal. While the verification window is open, denial refers the case back to the member (case stays open, member status is `not_compliant`, business process returns to `report_activities`); once the window has ended, denial is final and closes the case.

`flow_status` is the mechanism that keeps per-form status correct once multiple forms exist on a case: it reports the case-level approval status only for the specific form whose review task completed, and `submitted` / `in_progress` otherwise. The dashboard and the show page both use it now, since reading the case-level `activity_report_approval_status` directly would mis-label a freshly resubmitted form as denied.

## Testing

- Full RSpec suite green (2184 examples, 0 failures); `make lint` clean.
- Manually tested:
  - Denied a report (window open) → dashboard shows "Submit new activity report"
  - Submitted a second report → both dashboard and show page show "being reviewed"
  - Originally-denied report still shows its denial
  - "Submit new activity report" button hidden when case closed
  - "Submit new activity report" button hidden when verification window ended
  - Cannot start a new form when case closed → redirected to dashboard with notice
  - Cannot start a new form when verification window ended → redirected to dashboard with notice

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->