### PR TITLE
Jdettmann/oscer 655 approval status migration

### DIFF
--- a/reporting-app/db/migrate/20260612120000_add_approval_status_to_strata_tasks.rb
+++ b/reporting-app/db/migrate/20260612120000_add_approval_status_to_strata_tasks.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddApprovalStatusToStrataTasks < ActiveRecord::Migration[8.0]
+  def up
+    add_column :strata_tasks, :approval_status, :string
+    # application_form_id was added (OSCER-585) without an index; the per-form outcome
+    # delegation now looks tasks up by it, so index it here.
+    add_index :strata_tasks, :application_form_id unless index_exists?(:strata_tasks, :application_form_id)
+
+    backfill_approval_status(ReviewActivityReportTask, :activity_report_approval_status)
+    backfill_approval_status(ReviewExemptionClaimTask, :exemption_request_approval_status)
+  end
+
+  def down
+    remove_index :strata_tasks, :application_form_id, if_exists: true
+    remove_column :strata_tasks, :approval_status
+  end
+
+  private
+
+  # A case can hold multiple forms (and review tasks) after a denial + re-submission.
+  # The case fact retains only the most recent decision, so attribute it to the most
+  # recent task and treat every superseded task as denied (a later form only exists
+  # because the earlier one was denied). Idempotent on re-run.
+  def backfill_approval_status(task_class, form_class_approval_status)
+    task_class.where.not(case_id: nil).group_by(&:case_id).each do |case_id, tasks|
+      kase = CertificationCase.find_by(id: case_id)
+      next if kase.nil?
+
+      ordered = tasks.sort_by(&:created_at).reverse
+      say "Backfilling #{tasks.size} #{task_class.name}(s) on case #{case_id}" if tasks.size > 1
+
+      ordered.each_with_index do |task, index|
+        status = index.zero? ? kase.public_send(form_class_approval_status) : "denied"
+        task.update_column(:approval_status, status) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_01_172517) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -347,6 +347,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_01_172517) do
     t.datetime "updated_at", null: false
     t.string "case_type"
     t.uuid "application_form_id"
+    t.string "approval_status"
+    t.index ["application_form_id"], name: "index_strata_tasks_on_application_form_id"
     t.index ["assignee_id"], name: "index_strata_tasks_on_assignee_id"
     t.index ["case_id", "case_type"], name: "index_strata_tasks_on_case_id_and_case_type"
     t.index ["status"], name: "index_strata_tasks_on_status"


### PR DESCRIPTION
## Ticket

Part of #655 (schema prerequisite — does not resolve the ticket on its own)

## Changes

- Add a nullable `approval_status` column to `strata_tasks` so review tasks can record their staff decision (`approved` / `denied`; `nil` = undecided).
- Add an index on `strata_tasks.application_form_id` (the column was added in OSCER-585 without one).
- Backfill `approval_status` for existing review tasks from the case-level approval facts.

## Context for reviewers

This is a schema-only PR, split out from the feature work. Tasks were chosen to hold the value, as application forms are immutable after submission.

**Backfill rule.** A case can now hold multiple forms (and review tasks) after a denial + re-submission, but the case-level fact (`activity_report_approval_status` / `exemption_request_approval_status`) only retains the most recent decision. So per case, the most-recent review task inherits the case fact and every superseded task is set to `denied` (a later form only exists because the earlier one was denied). The backfill is idempotent and logs any case with more than one task.

## Testing

- `make db-migrate` applied cleanly; backfill logged the multi-task cases it touched.
- Spot-checked the backfilled data for both form types: in multi-task cases only the most-recent task carries the `approved` outcome, with the superseded tasks set to `denied` — confirming the attribution rule.
- `make lint` — no offenses.
- `make test` — 2184 examples, 0 failures (96.05% line / 82.04% branch coverage).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->