### PR TITLE
OSCER-641: Member dashboard exemption draft in progress

### DIFF
--- a/reporting-app/app/assets/stylesheets/_member_dashboard.scss
+++ b/reporting-app/app/assets/stylesheets/_member_dashboard.scss
@@ -107,6 +107,17 @@
     margin-top: units(1);
   }
 
+  &__about-reporting {
+    width: 100%;
+
+    p,
+    ul {
+      // Belt-and-suspenders with class rules below — USWDS sets `p { max-width: 68ex }`
+      // in the compiled bundle before member-dashboard rules.
+      max-width: none;
+    }
+  }
+
   &__about-reporting-heading {
     font-family: font-family("sans");
     font-size: font-size("sans", "md");
@@ -121,6 +132,9 @@
     font-size: 1rem;
     line-height: 1.8;
     margin: 0 0 units(2);
+    // Override USWDS global `p { max-width: 68ex }` so onboarding copy spans the
+    // same width as the alert above (Figma 7203:5214 / get-started frame).
+    max-width: none;
   }
 
   &__about-reporting-list {
@@ -128,10 +142,12 @@
     font-size: 1rem;
     line-height: 1.8;
     margin: 0 0 units(2);
+    max-width: none;
     padding-left: units(3);
 
     li {
       margin-bottom: units(1);
+      max-width: none;
     }
   }
 

--- a/reporting-app/app/controllers/exemption_screener_controller.rb
+++ b/reporting-app/app/controllers/exemption_screener_controller.rb
@@ -6,7 +6,9 @@ class ExemptionScreenerController < ApplicationController
   before_action :ensure_certification_case
   before_action :ensure_certification_case_open
   before_action :authorize_access
-  before_action :check_existing_application
+  before_action :redirect_in_progress_exemption_from_intro, only: [ :index ]
+  before_action :block_when_exemption_already_pending, except: [ :may_qualify ]
+  before_action :block_when_exemption_already_pending_for_may_qualify, only: [ :may_qualify ]
   before_action :set_current_exemption_type, only: %i[show answer may_qualify create_application]
   before_action :setup_navigator, only: %i[show answer]
   before_action :validate_exemption_type, only: %i[show answer]
@@ -100,24 +102,33 @@ class ExemptionScreenerController < ApplicationController
     authorize ExemptionApplicationForm.new(certification_case_id: @certification_case.id), :new?
   end
 
-  def check_existing_application
-    in_progress_form = in_progress_exemption_form
+  def redirect_in_progress_exemption_from_intro
+    form = in_progress_exemption_form
+    return unless form&.exemption_type.present?
 
-    if in_progress_form&.exemption_type.present?
-      return if may_qualify_resume_for?(in_progress_form)
+    redirect_to exemption_screener_may_qualify_path(
+      exemption_type: form.exemption_type,
+      **screener_path_params
+    )
+  end
 
-      if request.get? && action_name == "index"
-        redirect_to exemption_screener_may_qualify_path(
-          exemption_type: in_progress_form.exemption_type,
-          **screener_path_params
-        ) and return
-      end
-    end
+  def block_when_exemption_already_pending_for_may_qualify
+    return if resuming_in_progress_exemption?
 
+    block_when_exemption_already_pending
+  end
+
+  def block_when_exemption_already_pending
     return unless ExemptionApplicationForm.has_pending_form(@certification_case.id)
 
     redirect_to dashboard_path,
       notice: t("exemption_screener.errors.application_exists")
+  end
+
+  def resuming_in_progress_exemption?
+    form = in_progress_exemption_form
+    form&.exemption_type.present? &&
+      params[:exemption_type].to_s == form.exemption_type.to_s
   end
 
   def in_progress_exemption_form
@@ -133,11 +144,6 @@ class ExemptionScreenerController < ApplicationController
       status: :in_progress,
       exemption_type: exemption_type
     )
-  end
-
-  def may_qualify_resume_for?(in_progress_form)
-    action_name == "may_qualify" &&
-      params[:exemption_type].to_s == in_progress_form.exemption_type.to_s
   end
 
   def set_current_exemption_type

--- a/reporting-app/app/controllers/exemption_screener_controller.rb
+++ b/reporting-app/app/controllers/exemption_screener_controller.rb
@@ -56,6 +56,7 @@ class ExemptionScreenerController < ApplicationController
     @exemption_description = Exemption.description_for(@current_exemption_type)
     @required_documents = Exemption.supporting_documents_for(@current_exemption_type)
     @current_step = :result
+    @in_progress_exemption_form = in_progress_exemption_form_for(@current_exemption_type)
   end
 
   # POST /exemption-screener/may-qualify/:exemption_type
@@ -100,10 +101,43 @@ class ExemptionScreenerController < ApplicationController
   end
 
   def check_existing_application
+    in_progress_form = in_progress_exemption_form
+
+    if in_progress_form&.exemption_type.present?
+      return if may_qualify_resume_for?(in_progress_form)
+
+      if request.get? && action_name == "index"
+        redirect_to exemption_screener_may_qualify_path(
+          exemption_type: in_progress_form.exemption_type,
+          **screener_path_params
+        ) and return
+      end
+    end
+
     return unless ExemptionApplicationForm.has_pending_form(@certification_case.id)
 
     redirect_to dashboard_path,
       notice: t("exemption_screener.errors.application_exists")
+  end
+
+  def in_progress_exemption_form
+    ExemptionApplicationForm.find_by(
+      certification_case_id: @certification_case.id,
+      status: :in_progress
+    )
+  end
+
+  def in_progress_exemption_form_for(exemption_type)
+    ExemptionApplicationForm.find_by(
+      certification_case_id: @certification_case.id,
+      status: :in_progress,
+      exemption_type: exemption_type
+    )
+  end
+
+  def may_qualify_resume_for?(in_progress_form)
+    action_name == "may_qualify" &&
+      params[:exemption_type].to_s == in_progress_form.exemption_type.to_s
   end
 
   def set_current_exemption_type

--- a/reporting-app/app/controllers/exemption_screener_controller.rb
+++ b/reporting-app/app/controllers/exemption_screener_controller.rb
@@ -6,9 +6,9 @@ class ExemptionScreenerController < ApplicationController
   before_action :ensure_certification_case
   before_action :ensure_certification_case_open
   before_action :authorize_access
-  before_action :redirect_in_progress_exemption_from_intro, only: [ :index ]
-  before_action :block_when_exemption_already_pending, except: [ :may_qualify ]
-  before_action :block_when_exemption_already_pending_for_may_qualify, only: [ :may_qualify ]
+  before_action :resume_in_progress_exemption, only: [ :index ]
+  before_action :block_exemption_pending, except: [ :may_qualify ]
+  before_action :block_mismatch_exemption_pending, only: [ :may_qualify ]
   before_action :set_current_exemption_type, only: %i[show answer may_qualify create_application]
   before_action :setup_navigator, only: %i[show answer]
   before_action :validate_exemption_type, only: %i[show answer]
@@ -102,7 +102,7 @@ class ExemptionScreenerController < ApplicationController
     authorize ExemptionApplicationForm.new(certification_case_id: @certification_case.id), :new?
   end
 
-  def redirect_in_progress_exemption_from_intro
+  def resume_in_progress_exemption
     form = in_progress_exemption_form
     return unless form&.exemption_type.present?
 
@@ -112,13 +112,13 @@ class ExemptionScreenerController < ApplicationController
     )
   end
 
-  def block_when_exemption_already_pending_for_may_qualify
+  def block_mismatch_exemption_pending
     return if resuming_in_progress_exemption?
 
-    block_when_exemption_already_pending
+    block_exemption_pending
   end
 
-  def block_when_exemption_already_pending
+  def block_exemption_pending
     return unless ExemptionApplicationForm.has_pending_form(@certification_case.id)
 
     redirect_to dashboard_path,

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -18,8 +18,8 @@ module DashboardHelper
       "exemption_approved"
     elsif @certification.nil?
       "no_certification"
-    elsif (exemption_draft_partial = exemption_draft_dashboard_partial)
-      exemption_draft_partial
+    elsif @member_dashboard_compliance&.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_DRAFT
+      "exemption_draft"
     elsif are_activity_report_or_exemption_incomplete?
       "new_certification"
     elsif is_activity_report_submitted?
@@ -45,8 +45,16 @@ module DashboardHelper
     @activity_report_application_form.present? || @exemption_application_form.present?
   end
 
+  def activity_report_incomplete?
+    !@activity_report_application_form&.submitted?
+  end
+
+  def exemption_incomplete?
+    !@exemption_application_form&.submitted?
+  end
+
   def are_activity_report_or_exemption_incomplete?
-    !(@activity_report_application_form&.submitted? || @exemption_application_form&.submitted?)
+    activity_report_incomplete? && exemption_incomplete?
   end
 
   def is_activity_report_submitted?
@@ -59,16 +67,6 @@ module DashboardHelper
 
   def is_activity_report_denied?
     @activity_report_application_form&.flow_status == "denied"
-  end
-
-  # Draft exemption frame (#641) — in-progress form, not yet submitted.
-  # Takes precedence over +new_certification+ when an activity report is also in progress
-  # (Figma 7203:5214 is draft-only; reporting CTAs land in #642).
-  def exemption_draft_dashboard_partial
-    return nil unless @member_dashboard_compliance.present?
-    return unless @member_dashboard_compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_DRAFT
-
-    "exemption_draft"
   end
 
   # Maps +compliance.exemption_flow_state+ to the legacy dashboard partial names (OSCER-640).

--- a/reporting-app/app/helpers/dashboard_helper.rb
+++ b/reporting-app/app/helpers/dashboard_helper.rb
@@ -3,14 +3,13 @@
 module DashboardHelper
   # Returns the dashboard partial to render for the member's current state.
   #
-  # The three exemption-outcome partials delegate into +_member_compliance_dashboard+
-  # (requires +@member_dashboard_compliance+) and line up with +compliance.exemption_flow_state+ (OSCER-640):
+  # Exemption dashboard partials delegate into +_member_compliance_dashboard+
+  # (requires +@member_dashboard_compliance+) and line up with +compliance.exemption_flow_state+:
   #
-  #   "exemption_approved"  -> EXEMPTION_APPROVED       (approved request *and* the
-  #                                                      automated exempt path via
-  #                                                      +member_status_exempt?+)
-  #   "exemption_submitted" -> EXEMPTION_PENDING_REVIEW
-  #   "exemption_denied"    -> EXEMPTION_DENIED
+  #   "exemption_draft"     -> EXEMPTION_DRAFT           (#641)
+  #   "exemption_approved"  -> EXEMPTION_APPROVED        (#640; also +member_status_exempt?+)
+  #   "exemption_submitted" -> EXEMPTION_PENDING_REVIEW  (#640)
+  #   "exemption_denied"    -> EXEMPTION_DENIED          (#640)
   #
   # All other partials (no_certification, new_certification, activity_report_*) are not
   # exemption-outcome frames and keep their existing behavior.
@@ -19,6 +18,8 @@ module DashboardHelper
       "exemption_approved"
     elsif @certification.nil?
       "no_certification"
+    elsif (exemption_draft_partial = exemption_draft_dashboard_partial)
+      exemption_draft_partial
     elsif are_activity_report_or_exemption_incomplete?
       "new_certification"
     elsif is_activity_report_submitted?
@@ -58,6 +59,16 @@ module DashboardHelper
 
   def is_activity_report_denied?
     @activity_report_application_form&.flow_status == "denied"
+  end
+
+  # Draft exemption frame (#641) — in-progress form, not yet submitted.
+  # Takes precedence over +new_certification+ when an activity report is also in progress
+  # (Figma 7203:5214 is draft-only; reporting CTAs land in #642).
+  def exemption_draft_dashboard_partial
+    return nil unless @member_dashboard_compliance.present?
+    return unless @member_dashboard_compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_DRAFT
+
+    "exemption_draft"
   end
 
   # Maps +compliance.exemption_flow_state+ to the legacy dashboard partial names (OSCER-640).

--- a/reporting-app/app/helpers/member_compliance_helper.rb
+++ b/reporting-app/app/helpers/member_compliance_helper.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 # View helpers for the member dashboard compliance UI (OSCER-337 / OSCER-480).
-# This slice (#640) covers the exemption outcome states: exempt, under review,
-# and does not qualify. Progress cards / activity tables arrive in later slices (#642, #643).
+# Exemption dashboard UI (#640 outcome states, #641 draft). Progress cards /
+# activity tables arrive in later slices (#642, #643).
 module MemberComplianceHelper
-  # Valid +exemption_flow_state+ values for +_member_compliance_exemption+ (outcome frames only).
+  # Outcome states guarded by +guard_member_compliance_exemption_outcome_state!+.
+  # +_member_compliance_exemption+ also renders +EXEMPTION_DRAFT+ (#641), which is not listed here.
   EXEMPTION_OUTCOME_FLOW_STATES = [
     MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW,
     MemberDashboardCompliance::EXEMPTION_APPROVED,
@@ -42,6 +43,26 @@ module MemberComplianceHelper
       MemberDashboardCompliance::EXEMPTION_DRAFT,
       MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW
     ].exclude?(compliance.exemption_flow_state)
+  end
+
+  def member_compliance_exemption_draft_screen?(compliance)
+    compliance.exemption_flow_state == MemberDashboardCompliance::EXEMPTION_DRAFT
+  end
+
+  # Draft continue returns to the exemption screener (may-qualify step when the draft
+  # has an exemption type; otherwise the screener intro).
+  def member_compliance_exemption_draft_continue_path(compliance)
+    certification_case = compliance.certification_case
+    form = compliance.exemption_application_form
+
+    if form&.exemption_type.present?
+      exemption_screener_may_qualify_path(
+        exemption_type: form.exemption_type,
+        certification_case_id: certification_case.id
+      )
+    else
+      exemption_screener_path(certification_case_id: certification_case.id)
+    end
   end
 
   def member_compliance_exemption_pending_review_screen?(compliance)

--- a/reporting-app/app/views/dashboard/_exemption_draft.html.erb
+++ b/reporting-app/app/views/dashboard/_exemption_draft.html.erb
@@ -1,0 +1,2 @@
+<%# Exemption draft in progress — delegates to the compliance dashboard (OSCER-337 / #641). %>
+<%= render "dashboard/member_compliance_dashboard", compliance: compliance %>

--- a/reporting-app/app/views/dashboard/_member_compliance_exemption.html.erb
+++ b/reporting-app/app/views/dashboard/_member_compliance_exemption.html.erb
@@ -1,10 +1,12 @@
-<%# Exemption outcome states — alerts, history, badges (OSCER-337 / #640).
-    Valid only for pending_review, approved, and denied. Draft and get-started
-    states are owned by other slices (#641, #639). %>
+<%# Exemption states — alerts, history, badges (OSCER-337 / #640, #641).
+    Outcome frames: pending_review, approved, denied (#640). Draft (#641).
+    Get-started (#639) stays on +_new_certification+. %>
 <% compliance = local_assigns.fetch(:compliance) %>
 
 <% exemption_section_labelledby = if show_member_compliance_exemption_details_heading?(compliance)
                                     "exemption-details-heading"
+                                  elsif member_compliance_exemption_draft_screen?(compliance)
+                                    "member-compliance-exemption-draft-alert-heading"
                                   elsif member_compliance_exemption_pending_review_screen?(compliance)
                                     "member-compliance-exemption-pending-review-alert-heading"
                                   end %>
@@ -26,6 +28,9 @@
   <% end %>
 
   <% case compliance.exemption_flow_state %>
+  <% when MemberDashboardCompliance::EXEMPTION_DRAFT %>
+    <%= render "dashboard/member_compliance_exemption_draft", compliance: compliance %>
+
   <% when MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW %>
     <%= render "dashboard/member_compliance_exemption_pending_review", compliance: compliance %>
 

--- a/reporting-app/app/views/dashboard/_member_compliance_exemption_draft.html.erb
+++ b/reporting-app/app/views/dashboard/_member_compliance_exemption_draft.html.erb
@@ -1,0 +1,23 @@
+<%# OSCER-337 frame: Exemption draft in progress (Figma 7203:5214) %>
+<% compliance = local_assigns.fetch(:compliance) %>
+
+<div class="member-dashboard-compliance__onboarding">
+  <div class="member-dashboard-compliance__alert member-dashboard-compliance__alert--info"
+       role="region"
+       aria-labelledby="member-compliance-exemption-draft-alert-heading">
+    <h3 id="member-compliance-exemption-draft-alert-heading" class="member-dashboard-compliance__alert-heading">
+      <%= t("dashboard.member_compliance.exemption_alerts.draft.title") %>
+    </h3>
+    <p class="member-dashboard-compliance__alert-text">
+      <%= t("dashboard.member_compliance.exemption_alerts.draft.body") %>
+    </p>
+  </div>
+
+  <div class="member-dashboard-compliance__onboarding-cta">
+    <%= link_to t("dashboard.member_compliance.exemption_alerts.draft.button"),
+          member_compliance_exemption_draft_continue_path(compliance),
+          class: "usa-button" %>
+  </div>
+
+  <%= render "dashboard/member_compliance_about_reporting", compliance: compliance %>
+</div>

--- a/reporting-app/app/views/exemption_screener/may_qualify.html.erb
+++ b/reporting-app/app/views/exemption_screener/may_qualify.html.erb
@@ -43,8 +43,14 @@
         exemption_screener_path(certification_case_id: @certification_case.id),
         class: "usa-button usa-button--outline" %>
 
-      <%= f.submit t(".buttons.request_exemption"),
-        class: "usa-button" %>
+      <% if @in_progress_exemption_form %>
+        <%= link_to t("dashboard.member_compliance.exemption_alerts.draft.button"),
+              documents_exemption_application_form_path(@in_progress_exemption_form),
+              class: "usa-button" %>
+      <% else %>
+        <%= f.submit t(".buttons.request_exemption"),
+              class: "usa-button" %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/reporting-app/config/locales/views/dashboard/member_compliance.en.yml
+++ b/reporting-app/config/locales/views/dashboard/member_compliance.en.yml
@@ -13,6 +13,10 @@ en:
           title: "Before you can report activities, let's see if you qualify for an exemption."
           body: "Answer a few quick questions to find out if you're excused from the work reporting requirement. If you don't qualify, you'll be taken directly to report your activities."
           button: "Get started"
+        draft:
+          title: "You currently have an exemption request in progress."
+          body: "Finish your request to see if you are excused from reporting activities."
+          button: "Continue exemption request"
         pending_review:
           title: "Exemption under review"
           body: "Your request has been submitted and is currently under review. In the meantime, you don't need to take any action."

--- a/reporting-app/config/locales/views/dashboard/member_compliance.es-US.yml
+++ b/reporting-app/config/locales/views/dashboard/member_compliance.es-US.yml
@@ -13,6 +13,10 @@ es-US:
           title: "Antes de reportar actividades, veamos si califica para una exención."
           body: "Responda unas preguntas rápidas para saber si está exento del requisito de reporte de trabajo. Si no califica, podrá reportar sus actividades directamente."
           button: "Comenzar"
+        draft:
+          title: "Actualmente tiene una solicitud de exención en curso."
+          body: "Complete su solicitud para saber si está exento de reportar actividades."
+          button: "Continuar solicitud de exención"
         pending_review:
           title: "Exención en revisión"
           body: "Su solicitud ha sido enviada y está en revisión. Por ahora no necesita realizar ninguna acción."

--- a/reporting-app/lib/dev/member_dashboard_frame_setup.rb
+++ b/reporting-app/lib/dev/member_dashboard_frame_setup.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 module Dev
-  # Local-only helper to put a member account into one of the OSCER-337 / #640
-  # exemption-outcome dashboard frames for manual QA at /dashboard.
+  # Local-only helper to put a member account into OSCER-337 exemption dashboard frames
+  # (#640 outcomes, #641 draft) for manual QA at /dashboard.
   #
-  # Scoped to this slice's exemption outcome states. Other frames (get started,
-  # exemption draft, and the reporting/progress frames) are added by their own slices.
+  # Scoped to exemption dashboard frames (#640 outcomes, #641 draft). Reporting/progress
+  # frames are added by their own slices (#642, #643).
   class MemberDashboardFrameSetup
     FRAMES = {
+      "exemption_draft" => "Frame 2 — Exemption draft in progress",
       "exemption_pending_review" => "Frame 3 — Exemption under review",
       "exemption_approved" => "Frame 4 — Exempt",
       "exemption_denied" => "Frame 5 — Not exempt"
@@ -38,6 +39,9 @@ module Dev
       reset_determinations!(certification)
 
       case frame
+      when "exemption_draft"
+        ensure_income_determination!(certification)
+        create_draft_exemption!(certification_case)
       when "exemption_pending_review"
         ensure_income_determination!(certification)
         create_submitted_exemption!(certification_case)
@@ -121,6 +125,14 @@ module Dev
       OscerTask.where(application_form_id: form.id).delete_all
       form.strict_loading!(false)
       form.destroy!
+    end
+
+    def create_draft_exemption!(certification_case)
+      ExemptionApplicationForm.create!(
+        certification_case_id: certification_case.id,
+        exemption_type: "caregiver_child",
+        user_id: @member_user.id
+      )
     end
 
     def create_submitted_exemption!(certification_case)

--- a/reporting-app/spec/helpers/dashboard_helper_spec.rb
+++ b/reporting-app/spec/helpers/dashboard_helper_spec.rb
@@ -12,6 +12,78 @@ RSpec.describe DashboardHelper, type: :helper do
     allow(NotificationService).to receive(:send_email_notification)
   end
 
+  def assign_dashboard_ivars(
+    member_dashboard_compliance: nil,
+    certification: self.certification,
+    exemption_application_form: nil,
+    activity_report_application_form: nil,
+    member_status: MemberStatusService.determine(certification)
+  )
+    helper.instance_variable_set(:@member_dashboard_compliance, member_dashboard_compliance)
+    helper.instance_variable_set(:@certification, certification)
+    helper.instance_variable_set(:@certification_case, certification_case)
+    helper.instance_variable_set(:@exemption_application_form, exemption_application_form)
+    helper.instance_variable_set(:@activity_report_application_form, activity_report_application_form)
+    helper.instance_variable_set(:@member_status, member_status)
+  end
+
+  describe "#exemption_draft_dashboard_partial" do
+    it "returns exemption_draft when the read model is draft" do
+      compliance = instance_double(MemberDashboardCompliance, exemption_flow_state: MemberDashboardCompliance::EXEMPTION_DRAFT)
+      assign_dashboard_ivars(member_dashboard_compliance: compliance)
+
+      expect(helper.exemption_draft_dashboard_partial).to eq("exemption_draft")
+    end
+
+    it "returns nil when the read model is absent" do
+      assign_dashboard_ivars(member_dashboard_compliance: nil)
+
+      expect(helper.exemption_draft_dashboard_partial).to be_nil
+    end
+
+    it "returns nil for non-draft exemption flow states" do
+      compliance = instance_double(MemberDashboardCompliance, exemption_flow_state: MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW)
+      assign_dashboard_ivars(member_dashboard_compliance: compliance)
+
+      expect(helper.exemption_draft_dashboard_partial).to be_nil
+    end
+  end
+
+  describe "#determine_dashboard_view" do
+    it "returns exemption_draft before the new_certification incomplete path" do
+      exemption_application_form = create(:exemption_application_form, certification_case_id: certification_case.id)
+      activity_report_application_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+      member_status = MemberStatusService.determine(certification)
+      compliance = MemberDashboardComplianceService.build(
+        certification: certification,
+        certification_case: certification_case,
+        exemption_application_form: exemption_application_form,
+        activity_report_application_form: activity_report_application_form,
+        member_status: member_status
+      )
+
+      assign_dashboard_ivars(
+        member_dashboard_compliance: compliance,
+        exemption_application_form: exemption_application_form,
+        activity_report_application_form: activity_report_application_form,
+        member_status: member_status
+      )
+
+      expect(helper.determine_dashboard_view).to eq("exemption_draft")
+    end
+
+    it "returns new_certification when no read model is present and applications are incomplete" do
+      exemption_application_form = create(:exemption_application_form, certification_case_id: certification_case.id)
+
+      assign_dashboard_ivars(
+        member_dashboard_compliance: nil,
+        exemption_application_form: exemption_application_form
+      )
+
+      expect(helper.determine_dashboard_view).to eq("new_certification")
+    end
+  end
+
   describe "#should_show_submit_new_exemption_form?" do
     let(:exemption_application_form) do
       form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)

--- a/reporting-app/spec/helpers/dashboard_helper_spec.rb
+++ b/reporting-app/spec/helpers/dashboard_helper_spec.rb
@@ -27,28 +27,6 @@ RSpec.describe DashboardHelper, type: :helper do
     helper.instance_variable_set(:@member_status, member_status)
   end
 
-  describe "#exemption_draft_dashboard_partial" do
-    it "returns exemption_draft when the read model is draft" do
-      compliance = instance_double(MemberDashboardCompliance, exemption_flow_state: MemberDashboardCompliance::EXEMPTION_DRAFT)
-      assign_dashboard_ivars(member_dashboard_compliance: compliance)
-
-      expect(helper.exemption_draft_dashboard_partial).to eq("exemption_draft")
-    end
-
-    it "returns nil when the read model is absent" do
-      assign_dashboard_ivars(member_dashboard_compliance: nil)
-
-      expect(helper.exemption_draft_dashboard_partial).to be_nil
-    end
-
-    it "returns nil for non-draft exemption flow states" do
-      compliance = instance_double(MemberDashboardCompliance, exemption_flow_state: MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW)
-      assign_dashboard_ivars(member_dashboard_compliance: compliance)
-
-      expect(helper.exemption_draft_dashboard_partial).to be_nil
-    end
-  end
-
   describe "#determine_dashboard_view" do
     it "returns exemption_draft before the new_certification incomplete path" do
       exemption_application_form = create(:exemption_application_form, certification_case_id: certification_case.id)
@@ -81,6 +59,51 @@ RSpec.describe DashboardHelper, type: :helper do
       )
 
       expect(helper.determine_dashboard_view).to eq("new_certification")
+    end
+
+    it "returns new_certification for a non-draft exemption flow state with incomplete forms" do
+      exemption_application_form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+      compliance = instance_double(
+        MemberDashboardCompliance,
+        exemption_flow_state: MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW
+      )
+
+      assign_dashboard_ivars(
+        member_dashboard_compliance: compliance,
+        exemption_application_form: exemption_application_form
+      )
+
+      expect(helper.determine_dashboard_view).not_to eq("exemption_draft")
+    end
+  end
+
+  describe "#are_activity_report_or_exemption_incomplete?" do
+    it "is true when neither application form is submitted" do
+      assign_dashboard_ivars(
+        activity_report_application_form: create(:activity_report_application_form, certification_case_id: certification_case.id)
+      )
+
+      expect(helper.are_activity_report_or_exemption_incomplete?).to be(true)
+    end
+
+    it "is false when only the exemption form is submitted" do
+      exemption_application_form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+
+      assign_dashboard_ivars(exemption_application_form: exemption_application_form)
+
+      expect(helper.are_activity_report_or_exemption_incomplete?).to be(false)
+    end
+
+    it "is false when both forms are submitted" do
+      exemption_application_form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+      activity_report_application_form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+
+      assign_dashboard_ivars(
+        exemption_application_form: exemption_application_form,
+        activity_report_application_form: activity_report_application_form
+      )
+
+      expect(helper.are_activity_report_or_exemption_incomplete?).to be(false)
     end
   end
 

--- a/reporting-app/spec/helpers/member_compliance_helper_spec.rb
+++ b/reporting-app/spec/helpers/member_compliance_helper_spec.rb
@@ -80,6 +80,44 @@ RSpec.describe MemberComplianceHelper, type: :helper do
     end
   end
 
+  describe "#member_compliance_exemption_draft_screen?" do
+    it "is true only for the draft state" do
+      expect(helper.member_compliance_exemption_draft_screen?(compliance_double(exemption_flow_state: MemberDashboardCompliance::EXEMPTION_DRAFT))).to be(true)
+      expect(helper.member_compliance_exemption_draft_screen?(compliance_double(exemption_flow_state: MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW))).to be(false)
+    end
+  end
+
+  describe "#member_compliance_exemption_draft_continue_path" do
+    it "returns the may-qualify screener path when the draft has an exemption type" do
+      form = instance_double(ExemptionApplicationForm, exemption_type: "caregiver_child")
+      compliance = instance_double(
+        MemberDashboardCompliance,
+        certification_case: certification_case,
+        exemption_application_form: form
+      )
+
+      expect(helper.member_compliance_exemption_draft_continue_path(compliance)).to eq(
+        exemption_screener_may_qualify_path(
+          exemption_type: "caregiver_child",
+          certification_case_id: certification_case.id
+        )
+      )
+    end
+
+    it "returns the screener intro when the draft has no exemption type" do
+      form = instance_double(ExemptionApplicationForm, exemption_type: nil)
+      compliance = instance_double(
+        MemberDashboardCompliance,
+        certification_case: certification_case,
+        exemption_application_form: form
+      )
+
+      expect(helper.member_compliance_exemption_draft_continue_path(compliance)).to eq(
+        exemption_screener_path(certification_case_id: certification_case.id)
+      )
+    end
+  end
+
   describe "#member_compliance_exemption_pending_review_screen?" do
     it "is true only for the pending review state" do
       expect(helper.member_compliance_exemption_pending_review_screen?(compliance_double(exemption_flow_state: MemberDashboardCompliance::EXEMPTION_PENDING_REVIEW))).to be(true)

--- a/reporting-app/spec/requests/dashboard_spec.rb
+++ b/reporting-app/spec/requests/dashboard_spec.rb
@@ -47,18 +47,28 @@ RSpec.describe "/dashboard", type: :request do
       expect(response.body).to include(activity_report_application_form_path(younger_submitted_form))
     end
 
-    it "sets the exemption application form" do
+    it "renders the screener continue link for an in-progress exemption request" do
       form = create(:exemption_application_form, user_id: user.id, certification_case_id: certification_case.id)
       get "/dashboard"
-      expect(response.body).to include(exemption_application_form_path(form))
+      expect(response.body).to include(
+        exemption_screener_may_qualify_path(
+          exemption_type: form.exemption_type,
+          certification_case_id: certification_case.id
+        )
+      )
     end
 
-    it "sets the in-progress exemption application form if more than one form" do
+    it "renders the in-progress exemption screener link when multiple forms exist" do
       submitted_form = create(:exemption_application_form, :with_submitted_status, user_id: user.id, certification_case_id: certification_case.id)
       form = create(:exemption_application_form, user_id: user.id, certification_case_id: certification_case.id)
       get "/dashboard"
       expect(response.body).not_to include(exemption_application_form_path(submitted_form))
-      expect(response.body).to include(exemption_application_form_path(form))
+      expect(response.body).to include(
+        exemption_screener_may_qualify_path(
+          exemption_type: form.exemption_type,
+          certification_case_id: certification_case.id
+        )
+      )
     end
 
     it "sets the most recent exemption application form if only submitted exist" do

--- a/reporting-app/spec/requests/exemption_screener_spec.rb
+++ b/reporting-app/spec/requests/exemption_screener_spec.rb
@@ -56,19 +56,32 @@ RSpec.describe "ExemptionScreeners", type: :request do
     end
 
     context "when exemption application already started" do
-      before do
+      let!(:draft_form) do
         create(:exemption_application_form,
           certification_case_id: certification_case.id,
-          user_id: user.id
+          user_id: user.id,
+          exemption_type: first_exemption_type)
+      end
+
+      it "redirects the screener intro to may-qualify so the member can continue" do
+        get exemption_screener_path(certification_case_id: certification_case.id)
+
+        expect(response).to redirect_to(
+          exemption_screener_may_qualify_path(
+            exemption_type: draft_form.exemption_type,
+            certification_case_id: certification_case.id
+          )
         )
       end
 
-      it "redirects to dashboard with notice" do
-        get exemption_screener_path(certification_case_id: certification_case.id)
+      it "allows may-qualify for the in-progress exemption type" do
+        get exemption_screener_may_qualify_path(
+          exemption_type: draft_form.exemption_type,
+          certification_case_id: certification_case.id
+        )
 
-        expect(response).to redirect_to(dashboard_path)
-        follow_redirect!
-        expect(response.body).to include("already have an exemption application")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(I18n.t("dashboard.member_compliance.exemption_alerts.draft.button"))
       end
     end
 

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -154,11 +154,54 @@ RSpec.describe "dashboard/index", type: :view do
 
     before do
       assign(:exemption_application_form, exemption_application_form)
+      reassign_compliance_read_model
+    end
+
+    it 'renders the blue "draft in progress" alert' do
+      render
+      expect(rendered).to have_css('.member-dashboard-compliance__alert--info[role="region"]')
+      expect(rendered).to have_selector('h3', text: I18n.t('dashboard.member_compliance.exemption_alerts.draft.title'))
+      expect(rendered).to have_text(I18n.t('dashboard.member_compliance.exemption_alerts.draft.body'))
+    end
+
+    it 'renders the Figma draft layout (onboarding alert, CTA, about reporting)' do
+      render
+
+      expect(rendered).to have_css('.member-dashboard-compliance__onboarding')
+      expect(rendered).to have_css('.member-dashboard-compliance__about-reporting')
     end
 
     it 'renders a button to continue the exemption request' do
       render
-      expect(rendered).to have_selector('a', text: I18n.t('dashboard.new_certification.exemption_request.continue_request_button'))
+      expect(rendered).to have_link(
+        I18n.t('dashboard.member_compliance.exemption_alerts.draft.button'),
+        href: exemption_screener_may_qualify_path(
+          exemption_type: exemption_application_form.exemption_type,
+          certification_case_id: certification_case.id
+        )
+      )
+      expect(rendered).to have_selector('.member-dashboard-compliance__onboarding-cta a.usa-button')
+    end
+
+    it 'does not render the "Exemption details" heading' do
+      render
+      expect(rendered).not_to have_selector('h2', text: I18n.t('dashboard.member_compliance.exemption_details_heading'))
+    end
+
+    it 'does not render exemption history' do
+      render
+      expect(rendered).not_to have_selector('h3', text: I18n.t('dashboard.member_compliance.exemption_request_history_heading'))
+    end
+
+    it 'does not render a reporting section' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.current_period.report_activities_button'))
+      expect(rendered).not_to have_selector('h2', text: I18n.t('dashboard.member_compliance.reporting.heading'))
+    end
+
+    it 'does not render the legacy compliance status block' do
+      render
+      expect(rendered).not_to have_selector('a', text: I18n.t('dashboard.new_certification.exemption_request.continue_request_button'))
     end
 
     it 'does not render the Figma get started callout' do
@@ -167,6 +210,36 @@ RSpec.describe "dashboard/index", type: :view do
         'a',
         text: I18n.t('dashboard.member_compliance.exemption_alerts.not_started.button')
       )
+    end
+
+    context "with an in-progress activity report also present" do
+      let(:activity_report_application_form) do
+        create(:activity_report_application_form, certification_case_id: certification_case.id)
+      end
+
+      before do
+        assign(:activity_report_application_form, activity_report_application_form)
+        reassign_compliance_read_model
+      end
+
+      it 'renders the exemption draft frame only (no activity-report continue CTA)' do
+        render
+        expect(rendered).to have_link(
+          I18n.t('dashboard.member_compliance.exemption_alerts.draft.button'),
+          href: exemption_screener_may_qualify_path(
+            exemption_type: exemption_application_form.exemption_type,
+            certification_case_id: certification_case.id
+          )
+        )
+        expect(rendered).not_to have_selector(
+          'a',
+          text: I18n.t('dashboard.member_compliance.reporting.continue_report_button')
+        )
+        expect(rendered).not_to have_selector(
+          'a',
+          text: I18n.t('dashboard.new_certification.activity_report.continue_report_button')
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Ticket

Resolves [OSCER-641](https://github.com/navapbc/oscer/issues/641) (slice 3 of 5 in the [OSCER-480](https://github.com/navapbc/oscer/issues/480) stack).

## Changes

- Route `determine_dashboard_view` to `_exemption_draft` when `MemberDashboardCompliance` reports `EXEMPTION_DRAFT`, before the legacy `_new_certification` incomplete-application path.
- Add `_exemption_draft.html.erb` and `_member_compliance_exemption_draft.html.erb` (Figma 7203:5214): blue info alert, **Continue exemption request** CTA, and about-reporting block via the existing `_member_compliance_dashboard` shell.
- Extend `_member_compliance_exemption` with the draft case; add `member_compliance_exemption_draft_screen?` helper.
- Locales: `exemption_alerts.draft` in `member_compliance.en.yml` / `member_compliance.es-US.yml`.
- Dev rake: `dev:member_dashboard:apply[EMAIL,exemption_draft]` frame.
- SCSS: override USWDS `p { max-width: 68ex }` on onboarding about-reporting copy so intro/list/footer span full frame width (draft + get-started).
- Specs: draft view expectations (including dual in-progress + CTA `href`) in `index.html.erb_spec.rb`; `member_compliance_helper_spec` and `dashboard_helper_spec` for routing predicates.

## Context for reviewers

- **Stacked on** [#640 / PR #649](https://github.com/navapbc/oscer/pull/649) (`jgavin/OSCER-640-exemption-outcome-states`). Rebase onto `main` after #640 merges.
- Draft members no longer see the legacy `_new_certification` compliance-status block or the old continue-button copy — they get the Figma onboarding layout (same pattern as get-started, different alert/CTA).
- **Draft vs. dual in-progress:** When both an exemption draft and an in-progress activity report exist, `EXEMPTION_DRAFT` routing wins (Figma 7203:5214 is draft-only). The activity-report continue CTA from legacy `_new_certification` is intentionally dropped until #642; view spec covers the dual case.
- **Out of scope** (other slices): exemption outcome states (#640), activity tables / full reporting section (#642), progress cards (#643), get-started landing (#639).
- "About the reporting requirement" is intentional on this frame (matches Figma / get-started); the reporting **section** (CTAs, tables, cards) still lands in #642.

## Testing

- `cd reporting-app && make lint`
- `cd reporting-app && make test args='spec/views/dashboard/index.html.erb_spec.rb spec/helpers/member_compliance_helper_spec.rb spec/helpers/dashboard_helper_spec.rb'`
- Manual (development): `docker compose exec reporting-app bin/rake 'dev:member_dashboard:apply[your@email.com,exemption_draft]'` then open `http://localhost:3000/dashboard` — expect blue draft alert, continue CTA, about-reporting block; no exemption details heading, history, or reporting CTAs.

<img width="722" height="542" alt="Screenshot 2026-06-15 at 3 10 01 PM" src="https://github.com/user-attachments/assets/378e8b2a-3fe3-4dc8-806f-61f3e274e7f3" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->