### PR TITLE
OSCER-656 show all submitted activity forms in case view

### DIFF
--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -19,7 +19,10 @@ class CertificationCasesController < StaffController
 
   def show
     @information_requests = InformationRequest.for_application_forms(application_form_ids)
-    @activity_report = ActivityReportApplicationForm.find_by(certification_case_id: @case.id)
+    @activity_reports = ActivityReportApplicationForm.where(certification_case_id: @case.id).order(created_at: :desc)
+    # Drives the case-level compliance summary and the external-data section; the most recent
+    # form preserves single-form behavior (where there is exactly one, it is that one).
+    @activity_report = @activity_reports.first
     @member_status = MemberStatusService.determine(@case)
     @tasks = @case.tasks.order(created_at: :desc)
 
@@ -52,8 +55,8 @@ class CertificationCasesController < StaffController
     @target_income = IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY
     @hours_has_data = @external_hourly_activities.any? || @member_hour_activities.any?
     @income_has_data = @external_income_activities.any? || @member_income_activities.any?
-    if Features.doc_ai_enabled? && @activity_report
-      activity_ids = @activity_report.activities.pluck(:id)
+    if Features.doc_ai_enabled? && @activity_reports.any?
+      activity_ids = @activity_reports.flat_map { |form| form.activities.pluck(:id) }
       @confidence_by_activity = DocAiConfidenceService.new.confidence_by_activity_id(activity_ids)
     end
   end
@@ -75,9 +78,9 @@ class CertificationCasesController < StaffController
   end
 
   def application_form_ids
-    [ ActivityReportApplicationForm, ExemptionApplicationForm ].map do |form_class|
-      form_class.find_by_certification_case_id(@case.id)&.id
-    end.compact
+    [ ActivityReportApplicationForm, ExemptionApplicationForm ].flat_map do |form_class|
+      form_class.where(certification_case_id: @case.id).pluck(:id)
+    end
   end
 
   def fetch_external_hourly_activities

--- a/reporting-app/app/helpers/activity_report_application_forms_helper.rb
+++ b/reporting-app/app/helpers/activity_report_application_forms_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActivityReportApplicationFormsHelper
-  def activity_report_status_class(status, change="text")
+  def activity_report_status_class(status, change = "text")
     case status
     when "approved" then "#{change}-green"
     when "denied" then "#{change}-red"

--- a/reporting-app/app/helpers/activity_report_application_forms_helper.rb
+++ b/reporting-app/app/helpers/activity_report_application_forms_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module ActivityReportApplicationFormsHelper
-  def activity_report_status_class(status)
+  def activity_report_status_class(status, change="text")
     case status
-    when "approved" then "text-green"
-    when "denied" then "text-red"
+    when "approved" then "#{change}-green"
+    when "denied" then "#{change}-red"
     else ""
     end
   end

--- a/reporting-app/app/helpers/activity_report_application_forms_helper.rb
+++ b/reporting-app/app/helpers/activity_report_application_forms_helper.rb
@@ -9,6 +9,14 @@ module ActivityReportApplicationFormsHelper
     end
   end
 
+  # Per-form status for staff display: the form's own decided outcome (approved/denied) when its
+  # review task has decided, otherwise the form's workflow status (in_progress/submitted). Unlike
+  # +flow_status+, this reads the per-form review-task decision rather than the shared case-level
+  # approval fact, so each form on a multi-form case reports its own outcome.
+  def activity_report_display_status(form)
+    form.approval_status || form.status
+  end
+
   def activity_report_current_step(form, flash_notice_present:)
     if form.submitted_at.present?
       :submitted

--- a/reporting-app/app/views/certification_cases/show.html.erb
+++ b/reporting-app/app/views/certification_cases/show.html.erb
@@ -127,9 +127,10 @@
       <h3 class="margin-top-4"><%= t(".activity_line_items") %></h3>
       <% @activity_reports.each do |form| %>
         <% if @activity_reports.size > 1 %>
+          <% form_status = activity_report_display_status(form) %>
           <h4 class="margin-top-3">
             <%= t(".form_submitted_on", date: (form.submitted_at || form.updated_at).strftime("%m/%d/%Y")) %>
-            <span class="usa-tag <%= activity_report_status_class(form.flow_status) %>"><%= t(".form_status.#{form.flow_status}") %></span>
+            <span class="usa-tag <%= activity_report_status_class(form_status) %>"><%= t(".form_status.#{form_status}") %></span>
           </h4>
         <% end %>
         <%= render partial: "activity_report_application_forms/staff_activity_report", locals: { activity_report: form } %>

--- a/reporting-app/app/views/certification_cases/show.html.erb
+++ b/reporting-app/app/views/certification_cases/show.html.erb
@@ -122,9 +122,18 @@
     <% else %>
       <p><%= t(".no_activity_report") %></p>
     <% end %>
-    <% if @activity_report && Features.doc_ai_enabled? %>
+    <% show_line_items = @activity_reports.size > 1 || Features.doc_ai_enabled? %>
+    <% if show_line_items && @activity_reports.any? %>
       <h3 class="margin-top-4"><%= t(".activity_line_items") %></h3>
-      <%= render partial: "activity_report_application_forms/staff_activity_report", locals: { activity_report: @activity_report } %>
+      <% @activity_reports.each do |form| %>
+        <% if @activity_reports.size > 1 %>
+          <h4 class="margin-top-3">
+            <%= t(".form_submitted_on", date: (form.submitted_at || form.updated_at).strftime("%m/%d/%Y")) %>
+            <span class="usa-tag <%= activity_report_status_class(form.flow_status) %>"><%= t(".form_status.#{form.flow_status}") %></span>
+          </h4>
+        <% end %>
+        <%= render partial: "activity_report_application_forms/staff_activity_report", locals: { activity_report: form } %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/reporting-app/app/views/certification_cases/show.html.erb
+++ b/reporting-app/app/views/certification_cases/show.html.erb
@@ -122,14 +122,14 @@
     <% else %>
       <p><%= t(".no_activity_report") %></p>
     <% end %>
-    <% show_line_items = @activity_reports.size > 1 || Features.doc_ai_enabled? %>
-    <% if show_line_items && @activity_reports.any? %>
+    <% show_line_items = @activity_reports.size > 1 || (@activity_reports.any? && Features.doc_ai_enabled?) %>
+    <% if show_line_items %>
       <h3 class="margin-top-4"><%= t(".activity_line_items") %></h3>
       <% @activity_reports.each do |form| %>
         <% if @activity_reports.size > 1 %>
           <% form_status = activity_report_display_status(form) %>
           <h4 class="margin-top-3">
-            <%= t(".form_submitted_on", date: (form.submitted_at || form.updated_at).strftime("%m/%d/%Y")) %>
+            <%= t(".form_submitted_on", date: l(form.submitted_at || form.updated_at)) %>
             <span class="usa-tag <%= activity_report_status_class(form_status) %>"><%= t(".form_status.#{form_status}") %></span>
           </h4>
         <% end %>

--- a/reporting-app/app/views/certification_cases/show.html.erb
+++ b/reporting-app/app/views/certification_cases/show.html.erb
@@ -130,7 +130,7 @@
           <% form_status = activity_report_display_status(form) %>
           <h4 class="margin-top-3">
             <%= t(".form_submitted_on", date: l(form.submitted_at || form.updated_at)) %>
-            <span class="usa-tag <%= activity_report_status_class(form_status) %>"><%= t(".form_status.#{form_status}") %></span>
+            <span class="usa-tag <%= activity_report_status_class(form_status, "bg") %>"><%= t(".form_status.#{form_status}") %></span>
           </h4>
         <% end %>
         <%= render partial: "activity_report_application_forms/staff_activity_report", locals: { activity_report: form } %>

--- a/reporting-app/config/locales/views/certification_cases/en.yml
+++ b/reporting-app/config/locales/views/certification_cases/en.yml
@@ -32,6 +32,12 @@ en:
       no_hours_or_income_reported: "No hours or income reported"
       no_activity_report: "No activity report submitted"
       external_data: "External Data"
+      form_submitted_on: "Submitted %{date}"
+      form_status:
+        in_progress: "In progress"
+        submitted: "Submitted"
+        approved: "Approved"
+        denied: "Denied"
       information_request_info: "Tasks will be updated once the member provides updated documents."
       information_request_sent: "We sent a Request for Information to this member"
       information_requests: "Requests for Information"

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -266,15 +266,16 @@ RSpec.describe "/staff/certification_cases", type: :request do
 
       # A denied form followed by a re-submission. Events are stubbed to a no-op (the shared
       # before calls original) so submitting a form does not spin up a pending review task that
-      # would block a second form on the same case. A completed review task + denial gives the
-      # older form a "denied" flow_status; the newer form stays "in_progress".
+      # would block a second form on the same case. The older form's review task records a
+      # per-form "denied" decision; the newer form stays "in_progress".
       before do
         allow(Strata::EventManager).to receive(:publish)
 
         older_form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
         older_form.activities.create!(hours: 40, name: "Older Employer Inc", type: "WorkActivity", month: month)
-        create(:review_activity_report_task, application_form: older_form, case: certification_case).completed!
-        certification_case.deny_activity_report(nil, older_form)
+        task = create(:review_activity_report_task, application_form: older_form, case: certification_case)
+        task.update!(approval_status: :denied)
+        task.completed!
 
         newer_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
         newer_form.activities.create!(hours: 30, name: "Newer Employer Inc", type: "WorkActivity", month: month)

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -260,6 +260,84 @@ RSpec.describe "/staff/certification_cases", type: :request do
       end
     end
 
+    context "with multiple activity report forms on the case" do
+      let(:lookback_period) { certification.certification_requirements.continuous_lookback_period }
+      let(:month) { lookback_period.start.to_date }
+
+      # A denied form followed by a re-submission. Events are stubbed to a no-op (the shared
+      # before calls original) so submitting a form does not spin up a pending review task that
+      # would block a second form on the same case. A completed review task + denial gives the
+      # older form a "denied" flow_status; the newer form stays "in_progress".
+      before do
+        allow(Strata::EventManager).to receive(:publish)
+
+        older_form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        older_form.activities.create!(hours: 40, name: "Older Employer Inc", type: "WorkActivity", month: month)
+        create(:review_activity_report_task, application_form: older_form, case: certification_case).completed!
+        certification_case.deny_activity_report(nil, older_form)
+
+        newer_form = create(:activity_report_application_form, certification_case_id: certification_case.id)
+        newer_form.activities.create!(hours: 30, name: "Newer Employer Inc", type: "WorkActivity", month: month)
+      end
+
+      it "renders line items for every activity report form, not just one" do
+        get "/staff/certification_cases/#{certification_case.id}"
+
+        expect(response.body).to include("Older Employer Inc")
+        expect(response.body).to include("Newer Employer Inc")
+      end
+
+      it "labels each form with its status so re-submissions are distinguishable" do
+        get "/staff/certification_cases/#{certification_case.id}"
+
+        expect(response.body).to include(I18n.t("certification_cases.show.form_status.denied"))
+        expect(response.body).to include(I18n.t("certification_cases.show.form_status.in_progress"))
+      end
+
+      it "renders the line items even when Doc AI is disabled" do
+        with_doc_ai_disabled do
+          get "/staff/certification_cases/#{certification_case.id}"
+
+          expect(response.body).to include("Older Employer Inc")
+          expect(response.body).to include("Newer Employer Inc")
+        end
+      end
+
+      it "still renders the case-level compliance summary" do
+        get "/staff/certification_cases/#{certification_case.id}"
+
+        expect(response.body).to include("Hours reported")
+        expect(response.body).to include("Total reported")
+      end
+    end
+
+    context "with information requests tied to more than one form" do
+      # Info requests tied to a non-most-recent activity report form and to an exemption form
+      # must both load. Events stubbed to a no-op so the submitted form does not block the
+      # second form on the case.
+      before do
+        allow(Strata::EventManager).to receive(:publish)
+
+        older_activity_report = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+        create(:activity_report_application_form, certification_case_id: certification_case.id)
+        exemption_form = create(:exemption_application_form, certification_case_id: certification_case.id)
+
+        create(:activity_report_information_request,
+               application_form_id: older_activity_report.id,
+               staff_comment: "Please clarify your earlier submission.")
+        create(:exemption_information_request,
+               application_form_id: exemption_form.id,
+               staff_comment: "Please provide exemption documentation.")
+      end
+
+      it "loads information requests for every form on the case" do
+        get "/staff/certification_cases/#{certification_case.id}"
+
+        expect(response.body).to include("Activity Report Information Request")
+        expect(response.body).to include("Exemption Information Request")
+      end
+    end
+
     context "with doc_ai feature flag" do
       let(:ai_user) { create(:user) }
       let(:form) do

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe "/staff/certification_cases", type: :request do
         older_form = create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
         older_form.activities.create!(hours: 40, name: "Older Employer Inc", type: "WorkActivity", month: month)
         task = create(:review_activity_report_task, application_form: older_form, case: certification_case)
-        task.update!(approval_status: :denied)
+        task.approval_status = :denied
         task.completed!
 
         newer_form = create(:activity_report_application_form, certification_case_id: certification_case.id)


### PR DESCRIPTION
## Ticket

Resolves #656

## Changes

Update the staff certification case detail page (`CertificationCasesController#show`) to handle
**multiple forms of each type per case**. The page was built when a case could only have one
activity report and one exemption form, so it loaded a single `@activity_report` and surfaced at
most one form (and one set of information requests) per type.

- **Controller loads every activity report form** (`@activity_reports`, most-recent first). The
  most-recent form becomes `@activity_report`, which drives the existing case-level compliance
  summary and the External Data section unchanged.
- **Information requests load for all forms** of both types — `application_form_ids` now returns
  every form's id (`where(...).pluck(:id)`) instead of one per type, so requests tied to an older
  activity report or to an exemption form are no longer dropped.
- **DocAI confidence spans all forms** — confidence is now built from the activities of every
  activity report on the case, not just one.
- **View renders line items per form**, each labeled with a status tag + submission date when
  there is more than one form, so re-submissions are distinguishable. The status tag reads each
  form's **own** decision via the per-form `approval_status` (#659), falling back to the form's
  workflow status when undecided.

## Context for reviewers

OSCER-637 (multiple exemption forms) and OSCER-638 (multiple activity reports) removed the
one-form-per-case constraint on the member side but left the staff view single-form. A case with
a denied activity report followed by a re-submission would show staff only one form, and
information requests tied to the others were silently dropped.

Key design decisions:
- **Single-form behavior is preserved exactly.** `@activity_report` is now the most-recent form
  (where there's only one, it's that one), so the compliance summary and the
  `_external_data_section` "summarized under Activity Report" branching render byte-for-byte as
  before. The per-form line-items loop only adds a status/date header when `size > 1`; a lone
  form still shows line items only under DocAI, with no header.
- **Per-form status, not the case-level fact.** Each form's status tag derives from its own
  review-task decision (`approval_status`, #659) rather than the shared, last-write-wins
  case-level `activity_report_approval_status` that `flow_status` reads — so on a multi-form case
  a denied form and its approved re-submission each show their own outcome.
- **Compliance computation is untouched.** The hours/income summary remains a case-level roll-up
  driven by the representative (most-recent) form — this ticket changes display only, not how
  determinations or totals are computed.
- **Exemption form display is out of scope.** Exemptions aren't rendered on the staff show page
  today; this PR only ensures their information requests load.

## Testing

- New request specs (red → green) cover multiple activity report forms (both forms' line items
  render, distinguishable by status, works with DocAI off, compliance summary still renders) and
  information requests spanning more than one form. Existing single-form examples are untouched.
- `make lint` — no offenses.
- `make test` — 2207 examples, 0 failures (96.03% line / 82.1% branch coverage).

**Manual testing.** Verified locally on the staff case show page:
- **Single activity report** — renders as before (no regression).
- **Multiple activity reports** — both forms' line items render, distinguishable by status/date.
- **Multiple information requests** — requests for every form on the case are listed.

<img width="519" height="887" alt="many_forms" src="https://github.com/user-attachments/assets/e42243bd-2030-455c-8370-d720981d8bf6" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->