### PR TITLE
Add pagination to the staff certification cases index

### DIFF
--- a/reporting-app/Gemfile
+++ b/reporting-app/Gemfile
@@ -20,6 +20,9 @@ gem "sprockets-rails"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.6"
 
+# Pagination for index pages [https://github.com/ddnexus/pagy]
+gem "pagy", "~> 9.3"
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 

--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -411,6 +411,7 @@ GEM
       webfinger (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
+    pagy (9.4.0)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -723,6 +724,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openapi_contracts
+  pagy (~> 9.3)
   pg (~> 1.6)
   pg-aws_rds_iam (~> 0.8.0)
   puma (>= 5.0)

--- a/reporting-app/app/controllers/application_controller.rb
+++ b/reporting-app/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
   include FeatureFlagHelper
+  include Pagy::Backend
 
   helper_method :feature_enabled?
 

--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -7,12 +7,14 @@ class CertificationCasesController < StaffController
   before_action :set_certification, only: %i[ show tasks documents notes ]
 
   def index
-    @cases = policy_scope(CertificationCase).open
+    # Newest first, with an id tiebreaker so the order is total and OFFSET paging is stable.
+    @pagy, @cases = pagy(policy_scope(CertificationCase).open.order(created_at: :desc, id: :desc))
     certification_service.hydrate_cases_with_certifications!(@cases)
   end
 
   def closed
-    @cases = policy_scope(CertificationCase).closed
+    # The closed scope already orders by created_at :desc; add the id tiebreaker for stable paging.
+    @pagy, @cases = pagy(policy_scope(CertificationCase).closed.order(id: :desc))
     certification_service.hydrate_cases_with_certifications!(@cases)
     render :index
   end

--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -13,7 +13,8 @@ class CertificationCasesController < StaffController
   end
 
   def closed
-    # The closed scope already orders by created_at :desc; add the id tiebreaker for stable paging.
+    # `closed` is defined in the Strata SDK (Strata::Case) and already orders by
+    # created_at :desc; we only add the id tiebreaker here for stable OFFSET paging.
     @pagy, @cases = pagy(policy_scope(CertificationCase).closed.order(id: :desc))
     certification_service.hydrate_cases_with_certifications!(@cases)
     render :index

--- a/reporting-app/app/helpers/application_helper.rb
+++ b/reporting-app/app/helpers/application_helper.rb
@@ -5,6 +5,9 @@ module ApplicationHelper
   # ViewComponent tests use ApplicationHelper as the view context; include here so render_inline works.
   include Strata::DateHelper
 
+  # Provides pagy_url_for and related helpers to the view layer for USWDS pagination controls.
+  include Pagy::Frontend
+
   # Display name for the state in staff certification copy (e.g. "From %{state_name}").
   def state_name
     ENV.fetch("STATE_NAME", "the State")

--- a/reporting-app/app/views/certification_cases/index.html.erb
+++ b/reporting-app/app/views/certification_cases/index.html.erb
@@ -4,3 +4,5 @@
   title: t(".title"),
   case_row_component_class: CertificationCases::CaseRowComponent
 ) %>
+
+<%= render "shared/pagination", pagy: @pagy %>

--- a/reporting-app/app/views/shared/_pagination.html.erb
+++ b/reporting-app/app/views/shared/_pagination.html.erb
@@ -15,6 +15,10 @@
         </li>
       <% end %>
 
+      <%# pagy.series(size: 7) returns one entry per slot, signaled by type:
+          Integer -> a page to link to; String -> the current page; :gap -> an elision ("…").
+          size >= 7 is what enables the first/last anchoring and :gap markers; 7 is also
+          Pagy's default, passed explicitly here to keep that behavior legible at the call site. %>
       <% pagy.series(size: 7).each do |item| %>
         <% if item == :gap %>
           <li class="usa-pagination__item usa-pagination__overflow" role="presentation">

--- a/reporting-app/app/views/shared/_pagination.html.erb
+++ b/reporting-app/app/views/shared/_pagination.html.erb
@@ -1,0 +1,45 @@
+<%# Reusable USWDS pagination controls driven by a Pagy object.
+    Renders nothing unless there is more than one page.
+    See https://designsystem.digital.gov/components/pagination/ %>
+<% if pagy && pagy.pages > 1 %>
+  <nav aria-label="<%= t("pagination.aria_label") %>" class="usa-pagination">
+    <ul class="usa-pagination__list">
+      <% if pagy.prev %>
+        <li class="usa-pagination__item usa-pagination__arrow">
+          <%= link_to pagy_url_for(pagy, pagy.prev),
+                class: "usa-pagination__link usa-pagination__previous-page",
+                aria: { label: t("pagination.previous") } do %>
+            <%= uswds_icon("navigate_before") %>
+            <span class="usa-pagination__link-text"><%= t("pagination.previous") %></span>
+          <% end %>
+        </li>
+      <% end %>
+
+      <% pagy.series(size: 7).each do |item| %>
+        <% if item == :gap %>
+          <li class="usa-pagination__item usa-pagination__overflow" role="presentation">
+            <span>&hellip;</span>
+          </li>
+        <% else %>
+          <% current = item.is_a?(String) %>
+          <li class="usa-pagination__item usa-pagination__page-no">
+            <%= link_to item, pagy_url_for(pagy, item),
+                  class: class_names("usa-pagination__button", "usa-current" => current),
+                  aria: { label: t("pagination.page", number: item), current: (current ? "page" : nil) } %>
+          </li>
+        <% end %>
+      <% end %>
+
+      <% if pagy.next %>
+        <li class="usa-pagination__item usa-pagination__arrow">
+          <%= link_to pagy_url_for(pagy, pagy.next),
+                class: "usa-pagination__link usa-pagination__next-page",
+                aria: { label: t("pagination.next") } do %>
+            <span class="usa-pagination__link-text"><%= t("pagination.next") %></span>
+            <%= uswds_icon("navigate_next") %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/reporting-app/config/initializers/pagy.rb
+++ b/reporting-app/config/initializers/pagy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Pagy pagination configuration.
+# See https://ddnexus.github.io/pagy/
+
+# Gracefully clamp out-of-range ?page= values (e.g. ?page=99999) to the last page
+# instead of raising Pagy::OverflowError.
+require "pagy/extras/overflow"
+
+# Default number of records per page across paginated index pages.
+Pagy::DEFAULT[:limit] = 25
+Pagy::DEFAULT[:overflow] = :last_page

--- a/reporting-app/config/locales/pagination.en.yml
+++ b/reporting-app/config/locales/pagination.en.yml
@@ -1,0 +1,6 @@
+en:
+  pagination:
+    aria_label: "Pagination"
+    previous: "Previous"
+    next: "Next"
+    page: "Page %{number}"

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -419,4 +419,96 @@ RSpec.describe "/staff/certification_cases", type: :request do
       expect(response.body).not_to include("open_case")
     end
   end
+
+  describe "GET /index pagination" do
+    let(:per_page) { 25 } # Pagy default configured in config/initializers/pagy.rb
+
+    context "when there are more open cases than fit on one page" do
+      before do
+        # case_01 is newest (1.day.ago) ... case_26 is oldest (26.days.ago)
+        (1..(per_page + 1)).each do |n|
+          create(
+            :certification_case, :actionable,
+            created_at: n.days.ago,
+            certification: create(
+              :certification,
+              case_number: "case_#{format('%02d', n)}",
+              certification_requirements: build(:certification_certification_requirements, region: "north")
+            )
+          )
+        end
+      end
+
+      it "limits page 1 to the 25 newest cases (oldest overflows to page 2)" do
+        get "/staff/certification_cases"
+        expect(response.body).to include("case_01") # newest, page 1
+        expect(response.body).to include("case_25") # 25th newest, still page 1
+        expect(response.body).not_to include("case_26") # oldest, pushed to page 2
+      end
+
+      it "shows the overflow (oldest) case on page 2" do
+        get "/staff/certification_cases", params: { page: 2 }
+        expect(response.body).to include("case_26")
+      end
+
+      it "renders USWDS pagination controls" do
+        get "/staff/certification_cases"
+        expect(Capybara.string(response.body)).to have_css("nav.usa-pagination")
+      end
+
+      it "clamps an out-of-range page to the last page" do
+        get "/staff/certification_cases", params: { page: 9999 }
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("case_26") # last page holds the oldest
+      end
+    end
+
+    context "when all open cases fit on one page" do
+      before do
+        create(
+          :certification_case, :actionable,
+          certification: create(
+            :certification, case_number: "only_case",
+            certification_requirements: build(:certification_certification_requirements, region: "north")
+          )
+        )
+      end
+
+      it "renders the case but omits pagination controls" do
+        get "/staff/certification_cases"
+        expect(response.body).to include("only_case") # page still has content
+        expect(Capybara.string(response.body)).not_to have_css("nav.usa-pagination")
+      end
+    end
+  end
+
+  describe "GET /closed pagination" do
+    let(:per_page) { 25 }
+
+    before do
+      (1..(per_page + 1)).each do |n|
+        create(
+          :certification_case, :with_closed_status,
+          created_at: n.days.ago,
+          certification: create(
+            :certification,
+            case_number: "closed_#{format('%02d', n)}",
+            certification_requirements: build(:certification_certification_requirements, region: "north")
+          )
+        )
+      end
+    end
+
+    it "limits page 1 to the 25 newest closed cases" do
+      get "/staff/certification_cases/closed"
+      expect(response.body).to include("closed_01") # newest, page 1
+      expect(response.body).not_to include("closed_26") # oldest, page 2
+    end
+
+    it "shows the overflow case on page 2 with pagination controls" do
+      get "/staff/certification_cases/closed", params: { page: 2 }
+      expect(response.body).to include("closed_26")
+      expect(Capybara.string(response.body)).to have_css("nav.usa-pagination")
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

Resolves #663

## Summary

The staff certification cases index loaded every case for the signed-in user's region in one unbounded query and hydrated each with its Certification, so the page got slower as case volume grew on the dev environment. This paginates both the open and closed tabs (25 per page) and gives the open tab a deterministic sort order, so each request loads and hydrates only one page of cases.

## Changes

- Add the `pagy` gem and a `config/initializers/pagy.rb` setting a default of 25 per page and clamping out-of-range `?page=` values to the last page.
- Paginate `CertificationCasesController#index` and `#closed`, applying the page limit before `hydrate_cases_with_certifications!` so only the current page's certifications are loaded.
- Order the open tab newest-first (`created_at DESC`) with an `id` tiebreaker; add the same tiebreaker to the closed tab (which the SDK already orders `created_at DESC`).
- Add a reusable `shared/_pagination` partial that renders USWDS pagination markup from the Pagy object, rendered around the unchanged Strata `IndexComponent`.
- Add `include Pagy::Backend` (controllers) and `include Pagy::Frontend` (helpers).
- Add en locale keys for the pagination controls.

## Notes

- The open tab previously had no `ORDER BY`; the apparent oldest-first ordering was PostgreSQL heap return order, not application logic, so it was unstable and unsafe for OFFSET paging. Newest-first also aligns it with the closed tab's existing intentional order.
- Pagy was chosen over Kaminari for its smaller footprint and because it does not monkeypatch ActiveRecord. The view-helper convenience Kaminari offers does not apply here, since the controls are hand-written USWDS markup either way.
- For large regions the `COUNT` and page queries still scan the unindexed `status` column behind the region join. A `(status, created_at)` index is a reasonable fast-follow and is tracked separately.

## Testing

- `make test`: 2209 examples, 0 failures (96.07% line / 82.12% branch coverage). New request specs cover the pagination behavior.
- `make lint`: no offenses.
- Manually verified the rendered page: with 31 open cases in one region, the USWDS pager shows two pages, page 1 lists the 25 newest with no Previous link, page 2 lists the remainder with no Next link, and the control is absent when results fit on one page. 
<img width="1104" height="1329" alt="Screenshot 2026-06-15 at 3 41 17 PM" src="https://github.com/user-attachments/assets/6fb109e3-5adc-40b2-b0c3-9bb958045879" />

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->