### PR TITLE
Order closed cases explicitly instead of relying on the SDK scope

### DIFF
--- a/reporting-app/app/controllers/certification_cases_controller.rb
+++ b/reporting-app/app/controllers/certification_cases_controller.rb
@@ -13,9 +13,8 @@ class CertificationCasesController < StaffController
   end
 
   def closed
-    # `closed` is defined in the Strata SDK (Strata::Case) and already orders by
-    # created_at :desc; we only add the id tiebreaker here for stable OFFSET paging.
-    @pagy, @cases = pagy(policy_scope(CertificationCase).closed.order(id: :desc))
+    # Newest first, with an id tiebreaker so the order is total and OFFSET paging is stable.
+    @pagy, @cases = pagy(policy_scope(CertificationCase).closed.order(created_at: :desc, id: :desc))
     certification_service.hydrate_cases_with_certifications!(@cases)
     render :index
   end


### PR DESCRIPTION
Follow-up to #663 (shipped in #665). Pairs with navapbc/strata-sdk-rails#373 (merged).

## Summary

The staff certification cases `closed` action depended on the Strata SDK's `Strata::Case#closed` scope to supply newest-first (`created_at DESC`) ordering, appending only an `id` tiebreaker for stable OFFSET paging. strata-sdk-rails#373 removed that baked-in ordering so consumers own it. This makes the controller order the closed list explicitly, keeping newest-first paging correct once OSCER picks up the new SDK.

## Changes

- Order the `closed` action query explicitly by `created_at: :desc, id: :desc`, mirroring the `index` action.
- Update the controller comment that claimed the SDK supplies the ordering.

## Notes

Forward-compatible with both SDK versions, so it does not have to be coordinated with the strata pin bump: against the old SDK the appended `created_at` is a duplicate, harmless no-op; against the new SDK it is the sole source of order. The previous `order(id: :desc)` would sort by a random UUID once the SDK scope stops ordering, silently breaking newest-first paging.

No new test needed: the existing `GET /closed pagination` spec creates cases with staggered `created_at` and asserts the newest lands on page 1 and the oldest overflows to page 2, which locks in newest-first ordering and would fail under UUID ordering.

## Testing

- `make test args="spec/requests/certification_cases_spec.rb"`: 34 examples, 0 failures.
- RuboCop clean on the changed file.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->