### PR TITLE
Upgrade pagy to v43 and add a USWDS pagination style

### DIFF
--- a/reporting-app/Gemfile
+++ b/reporting-app/Gemfile
@@ -21,7 +21,7 @@ gem "sprockets-rails"
 gem "pg", "~> 1.6"
 
 # Pagination for index pages [https://github.com/ddnexus/pagy]
-gem "pagy", "~> 9.3"
+gem "pagy", "~> 43.5"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -411,7 +411,10 @@ GEM
       webfinger (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
-    pagy (9.4.0)
+    pagy (43.5.6)
+      json
+      uri
+      yaml
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -676,6 +679,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yaml (0.4.0)
     yard (0.9.43)
     zeitwerk (2.8.2)
 
@@ -724,7 +728,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openapi_contracts
-  pagy (~> 9.3)
+  pagy (~> 43.5)
   pg (~> 1.6)
   pg-aws_rds_iam (~> 0.8.0)
   puma (>= 5.0)

--- a/reporting-app/app/controllers/application_controller.rb
+++ b/reporting-app/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
   include FeatureFlagHelper
-  include Pagy::Backend
+  include Pagy::Method
 
   helper_method :feature_enabled?
 

--- a/reporting-app/app/helpers/application_helper.rb
+++ b/reporting-app/app/helpers/application_helper.rb
@@ -5,9 +5,6 @@ module ApplicationHelper
   # ViewComponent tests use ApplicationHelper as the view context; include here so render_inline works.
   include Strata::DateHelper
 
-  # Provides pagy_url_for and related helpers to the view layer for USWDS pagination controls.
-  include Pagy::Frontend
-
   # Display name for the state in staff certification copy (e.g. "From %{state_name}").
   def state_name
     ENV.fetch("STATE_NAME", "the State")

--- a/reporting-app/app/views/shared/_pagination.html.erb
+++ b/reporting-app/app/views/shared/_pagination.html.erb
@@ -1,49 +1,12 @@
 <%# Reusable USWDS pagination controls driven by a Pagy object.
     Renders nothing unless there is more than one page.
+
+    The markup is produced by the custom :uswds Pagy style (config/initializers/pagy.rb).
+    The prev/next chevron icons are rendered here, where uswds_icon's asset_path is
+    available, and passed into the style (which runs in the Pagy instance context).
     See https://designsystem.digital.gov/components/pagination/ %>
 <% if pagy && pagy.pages > 1 %>
-  <nav aria-label="<%= t("pagination.aria_label") %>" class="usa-pagination">
-    <ul class="usa-pagination__list">
-      <% if pagy.prev %>
-        <li class="usa-pagination__item usa-pagination__arrow">
-          <%= link_to pagy_url_for(pagy, pagy.prev),
-                class: "usa-pagination__link usa-pagination__previous-page",
-                aria: { label: t("pagination.previous") } do %>
-            <%= uswds_icon("navigate_before") %>
-            <span class="usa-pagination__link-text"><%= t("pagination.previous") %></span>
-          <% end %>
-        </li>
-      <% end %>
-
-      <%# pagy.series(size: 7) returns one entry per slot, signaled by type:
-          Integer -> a page to link to; String -> the current page; :gap -> an elision ("…").
-          size >= 7 is what enables the first/last anchoring and :gap markers; 7 is also
-          Pagy's default, passed explicitly here to keep that behavior legible at the call site. %>
-      <% pagy.series(size: 7).each do |item| %>
-        <% if item == :gap %>
-          <li class="usa-pagination__item usa-pagination__overflow" role="presentation">
-            <span>&hellip;</span>
-          </li>
-        <% else %>
-          <% current = item.is_a?(String) %>
-          <li class="usa-pagination__item usa-pagination__page-no">
-            <%= link_to item, pagy_url_for(pagy, item),
-                  class: class_names("usa-pagination__button", "usa-current" => current),
-                  aria: { label: t("pagination.page", number: item), current: (current ? "page" : nil) } %>
-          </li>
-        <% end %>
-      <% end %>
-
-      <% if pagy.next %>
-        <li class="usa-pagination__item usa-pagination__arrow">
-          <%= link_to pagy_url_for(pagy, pagy.next),
-                class: "usa-pagination__link usa-pagination__next-page",
-                aria: { label: t("pagination.next") } do %>
-            <span class="usa-pagination__link-text"><%= t("pagination.next") %></span>
-            <%= uswds_icon("navigate_next") %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
+  <%= pagy.series_nav(:uswds,
+        prev_icon: uswds_icon("navigate_before"),
+        next_icon: uswds_icon("navigate_next")) %>
 <% end %>

--- a/reporting-app/config/initializers/pagy.rb
+++ b/reporting-app/config/initializers/pagy.rb
@@ -3,10 +3,76 @@
 # Pagy pagination configuration.
 # See https://ddnexus.github.io/pagy/
 
-# Gracefully clamp out-of-range ?page= values (e.g. ?page=99999) to the last page
-# instead of raising Pagy::OverflowError.
-require "pagy/extras/overflow"
-
 # Default number of records per page across paginated index pages.
-Pagy::DEFAULT[:limit] = 25
-Pagy::DEFAULT[:overflow] = :last_page
+Pagy::OPTIONS[:limit] = 25
+
+# Page-number slots in the series. First/last anchoring and :gap (ellipsis) markers
+# kick in once the page count exceeds the slot count; 7 matches Pagy's own default.
+Pagy::OPTIONS[:slots] = 7
+
+# Out-of-range ?page= values (e.g. ?page=99999) render an empty page rather than
+# raising: Pagy v43 leaves :raise_range_error unset by default, and reports the last
+# real page via @pagy.previous so the pager still links back into range.
+
+Pagy::OPTIONS.freeze
+
+# USWDS-styled pagination nav for Pagy v43.
+#
+# Pagy ships Bootstrap/Bulma/Tailwind styles, not USWDS, so we register a custom
+# `:uswds` style. `pagy.series_nav(:uswds, ...)` dispatches here by convention
+# (`series_nav(style)` calls `#{style}_series_nav`). See:
+# https://designsystem.digital.gov/components/pagination/
+#
+# This runs in the Pagy instance context, which has no ActionView helpers, so:
+# - page hrefs come from Pagy's own #page_url,
+# - text comes from ::I18n.translate (fully qualified: a bare `I18n` here resolves
+#   lexically to Pagy::I18n, Pagy's own dictionary, not the Rails app's locales),
+# - the prev/next chevron <svg> icons are rendered by the view via uswds_icon
+#   (which needs asset_path) and passed in through :prev_icon / :next_icon.
+#
+# #series is Pagy's protected method (one entry per slot: Integer -> a linkable
+# page, String -> the current page, :gap -> an ellipsis); it is reachable here
+# because this method lives on the same Pagy instance.
+class Pagy
+  module NumericHelpers
+    private
+
+    def uswds_series_nav(prev_icon:, next_icon:, **opts)
+      items = series(**opts).map { |item| uswds_page_item(item) }
+      items.unshift(uswds_arrow_item(:previous, prev_icon)) if @previous
+      items.push(uswds_arrow_item(:next, next_icon)) if @next
+
+      # Marked html_safe here (app-owned markup); the view call site stays clean.
+      nav = %(<nav aria-label="#{::I18n.translate('pagination.aria_label')}" class="usa-pagination">) +
+        %(<ul class="usa-pagination__list">#{items.join}</ul></nav>)
+      nav.html_safe
+    end
+
+    # One <li> per series entry: an Integer is a linkable page, a String is the
+    # current page (gets usa-current + aria-current), and :gap is an ellipsis.
+    def uswds_page_item(item)
+      if item == :gap
+        return %(<li class="usa-pagination__item usa-pagination__overflow" role="presentation"><span>&hellip;</span></li>)
+      end
+
+      current = item.is_a?(String)
+      button_class = current ? "usa-pagination__button usa-current" : "usa-pagination__button"
+      aria_current = current ? %( aria-current="page") : ""
+      %(<li class="usa-pagination__item usa-pagination__page-no">) +
+        %(<a href="#{page_url(item)}" class="#{button_class}" ) +
+        %(aria-label="#{::I18n.translate('pagination.page', number: item)}"#{aria_current}>#{item}</a></li>)
+    end
+
+    # The previous/next arrow <li>. The chevron <svg> is rendered by the view
+    # (where asset_path lives) and passed in; the icon sits before the label for
+    # :previous and after it for :next, per USWDS.
+    def uswds_arrow_item(direction, icon)
+      page  = direction == :previous ? @previous : @next
+      label = ::I18n.translate("pagination.#{direction}")
+      text  = %(<span class="usa-pagination__link-text">#{label}</span>)
+      inner = direction == :previous ? "#{icon}#{text}" : "#{text}#{icon}"
+      %(<li class="usa-pagination__item usa-pagination__arrow">) +
+        %(<a href="#{page_url(page)}" class="usa-pagination__link usa-pagination__#{direction}-page" aria-label="#{label}">#{inner}</a></li>)
+    end
+  end
+end

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -456,10 +456,15 @@ RSpec.describe "/staff/certification_cases", type: :request do
         expect(Capybara.string(response.body)).to have_css("nav.usa-pagination")
       end
 
-      it "clamps an out-of-range page to the last page" do
+      it "renders an empty page whose pager links back into range when out of range" do
         get "/staff/certification_cases", params: { page: 9999 }
         expect(response).to have_http_status(:success)
-        expect(response.body).to include("case_26") # last page holds the oldest
+        # Pagy v43 serves an empty page for out-of-range requests (the v9 :last_page
+        # clamp was removed) while still rendering the pager with a Previous link to
+        # the last real page, so the user can navigate back into range.
+        # The Previous link targets page 2 (the last real page of 26 cases at 25/page).
+        expect(Capybara.string(response.body))
+          .to have_css("nav.usa-pagination a.usa-pagination__previous-page[href*='page=2']")
       end
     end
 


### PR DESCRIPTION
## Ticket

No linked issue. Supersedes the Dependabot bump in #674.

## Changes

- Bump `pagy` `9.4.0` to `43.5.6` (`Gemfile`, `Gemfile.lock`).
- Migrate the initializer to the v43 config API: `Pagy::DEFAULT` becomes `Pagy::OPTIONS` (frozen), set `:limit` and `:slots`, and drop the removed `require "pagy/extras/overflow"`.
- Swap `include Pagy::Backend` for `include Pagy::Method` in `ApplicationController` (the controller `pagy` method moved).
- Remove the now-removed `include Pagy::Frontend` from `ApplicationHelper`.
- Add a custom `:uswds` Pagy style (`uswds_series_nav` plus `uswds_page_item` / `uswds_arrow_item` helpers) in `config/initializers/pagy.rb`.
- Replace the v9 `_pagination` partial internals with a single `pagy.series_nav(:uswds, ...)` call, passing the prev/next chevron icons in from the view.
- Update the out-of-range pagination request spec to assert v43's empty-page-with-back-link behavior.

## Context for reviewers

Pagy 43 is a ground-up redesign, not a routine major: the version leap from 9 signals a full API rewrite, so the small Dependabot lockfile diff in #674 hides a breaking change that fails to boot (`LoadError` on the removed `pagy/extras/overflow`). This upgrades pagy and migrates the integration in one atomic PR, since there is no forward-compatible middle state.

The redesign removed three things the app relied on, each fixed here: the `extras/overflow` require, the `Pagy::Backend` controller mixin (now `Pagy::Method`), and the `Pagy::Frontend` view mixin (helpers are now instance methods on `@pagy`). It also dropped the `:last_page` overflow clamp, so an out-of-range page like `?page=9999` now renders an empty page whose pager links back to the last real page via `@pagy.previous`, rather than clamping to it. We accepted that as the new behavior (it still avoids the 500 the original clamp was guarding against).

Pagy ships Bootstrap/Bulma/Tailwind series styles but not USWDS, so rather than monkeypatch or reach into pagy's now-protected `series`, the pager uses pagy's blessed extension point: a custom `:uswds` style. It runs in the Pagy instance context (no ActionView), so it builds markup from `#page_url`/`#series`, reads copy from the fully-qualified `::I18n` (a bare `I18n` inside `class Pagy` resolves lexically to `Pagy::I18n`), and receives the chevron `<svg>` icons from the view, where `uswds_icon`'s `asset_path` is available.

To exercise locally: seed more than 25 cases in your staff region and visit the staff certification cases index (and `/closed`); a middle page shows the gap (ellipsis) markers, and `?page=9999` shows the empty-page behavior described above.

## Testing

- `bundle exec rspec spec/requests/`: 451 examples, 0 failures (full request suite; the app-wide controller/helper mixin changes are exercised broadly).
- `bundle exec rubocop`: clean on all changed Ruby files.
- Browser-verified the rendered pager: USWDS markup, member names, prev/next chevron icons, and gap (ellipsis) markers across a 10-page open list; the closed tab pager; and the out-of-range empty-page behavior.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->