### PR TITLE
OSCER-657 denial response: migration

### DIFF
--- a/reporting-app/db/migrate/20260616170507_create_denial_response_application_forms.rb
+++ b/reporting-app/db/migrate/20260616170507_create_denial_response_application_forms.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateDenialResponseApplicationForms < ActiveRecord::Migration[8.0]
+  def change
+    create_table :denial_response_application_forms, id: :uuid do |t|
+      t.uuid :user_id
+      t.integer :status
+      t.datetime :submitted_at
+      t.uuid :certification_case_id
+      t.text :comment
+
+      t.timestamps
+    end
+
+    add_index :denial_response_application_forms, :certification_case_id
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_12_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_16_170507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -143,6 +143,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_12_120000) do
     t.datetime "updated_at", null: false
     t.index ["case_number"], name: "index_certifications_on_case_number"
     t.index ["member_id"], name: "index_certifications_on_member_id"
+  end
+
+  create_table "denial_response_application_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.integer "status"
+    t.datetime "submitted_at"
+    t.uuid "certification_case_id"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["certification_case_id"], name: "idx_on_certification_case_id_689075d6b3"
   end
 
   create_table "exemption_application_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Ticket

Step one of #657

## Changes

Add the `denial_response_application_forms` table — the storage layer for the new denial-response
flow, in which a member resolves a denied certification case with a short written comment plus
optional supporting documents.

- New migration `CreateDenialResponseApplicationForms`
- `db/schema.rb` regenerated (schema version bumped to `2026_06_16_170507`).

## Context for reviewers

This is the **migration-only** PR at the base of a three-PR stack for the denial-response backend.
It is split out on its own per the e2e constraint that migrations and the code that uses them ship
in separate PRs. The table columns intentionally mirror the existing `exemption_application_forms`
and `activity_report_application_forms` shapes, since `DenialResponseApplicationForm` (next PR in
the stack) is a `Strata::ApplicationForm` like those.

No model, validations, or behavior land here — those arrive in the follow-up
`denial-response-form-and-process` PR, where they can be tested against this table.

If anyone has a better name than `DenialResponseApplicationForm`, please let me know!

## Testing

- Schema-only change. `make db-migrate` applies cleanly and `make db-reset` rebuilds from
  `schema.rb` without drift.
- `make lint` — no offenses.
- `make test` — 2248 examples, 0 failures (96.03% line / 82.37% branch coverage).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->