### PR TITLE
Add document-ai service infrastructure

### DIFF
--- a/document-ai/Dockerfile
+++ b/document-ai/Dockerfile
@@ -2,7 +2,7 @@
 
 # renovate: datasource=docker depName=ghcr.io/navapbc/strata-service-document-ai
 ARG UPSTREAM_VERSION=v0.4.0
-FROM ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
+FROM --platform=linux/amd64 ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
 
 # Copy project-specific schema definitions.
 # SCHEMAS_MODE=replace means only schemas defined here are registered;

--- a/document-ai/Dockerfile
+++ b/document-ai/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # renovate: datasource=docker depName=ghcr.io/navapbc/strata-service-document-ai
-ARG UPSTREAM_VERSION=0.5.0
+ARG UPSTREAM_VERSION=0.5.1
 FROM --platform=linux/amd64 ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
 
 # Copy project-specific schema definitions.

--- a/document-ai/Dockerfile
+++ b/document-ai/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # renovate: datasource=docker depName=ghcr.io/navapbc/strata-service-document-ai
-ARG UPSTREAM_VERSION=v0.4.0
+ARG UPSTREAM_VERSION=0.4.0
 FROM --platform=linux/amd64 ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
 
 # Copy project-specific schema definitions.

--- a/document-ai/Dockerfile
+++ b/document-ai/Dockerfile
@@ -1,0 +1,12 @@
+# syntax = docker/dockerfile:1
+
+# renovate: datasource=docker depName=ghcr.io/navapbc/strata-service-document-ai
+ARG UPSTREAM_VERSION=v0.4.0
+FROM ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
+
+# Copy project-specific schema definitions.
+# SCHEMAS_MODE=replace means only schemas defined here are registered;
+COPY schema.json /app/schemas/schema.json
+
+ENV SCHEMAS_CONFIG_FILE=/app/schemas/schema.json
+ENV SCHEMAS_MODE=replace

--- a/document-ai/Dockerfile
+++ b/document-ai/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # renovate: datasource=docker depName=ghcr.io/navapbc/strata-service-document-ai
-ARG UPSTREAM_VERSION=0.4.0
+ARG UPSTREAM_VERSION=0.5.0
 FROM --platform=linux/amd64 ghcr.io/navapbc/strata-service-document-ai:${UPSTREAM_VERSION}
 
 # Copy project-specific schema definitions.

--- a/document-ai/schema.json
+++ b/document-ai/schema.json
@@ -1,0 +1,321 @@
+[
+  {
+    "id": "Payslip",
+    "version": "1.0.0",
+    "mimeTypes": ["application/pdf", "image/jpeg", "image/png", "image/tiff"],
+    "typeAliases": [
+      "pay_stub",
+      "paystub",
+      "paycheck",
+      "earnings_statement",
+      "pay_statement"
+    ],
+    "fields": [
+      {
+        "name": "pay_period_start_date",
+        "type": "date",
+        "required": true,
+        "confidenceFloor": 0.7,
+        "description": "First day of the pay period in ISO format. Used to derive the reporting month."
+      },
+      {
+        "name": "pay_period_end_date",
+        "type": "date",
+        "required": false,
+        "confidenceFloor": 0.7,
+        "description": "Last day of the pay period in ISO format."
+      },
+      {
+        "name": "pay_date",
+        "type": "date",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Date the employee was paid."
+      },
+
+      {
+        "name": "current_gross_pay",
+        "type": "currency",
+        "required": true,
+        "confidenceFloor": 0.7,
+        "description": "Total gross earnings for the current pay period before deductions. Used to populate the income activity."
+      },
+      {
+        "name": "current_net_pay",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.7,
+        "description": "Take-home pay after all deductions for the current pay period."
+      },
+      {
+        "name": "current_total_deductions",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Total deductions withheld during the current pay period."
+      },
+
+      {
+        "name": "ytd_gross_pay",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date gross earnings before deductions."
+      },
+      {
+        "name": "ytd_net_pay",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date net (take-home) pay."
+      },
+      {
+        "name": "ytd_federal_tax",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date federal income tax withheld."
+      },
+      {
+        "name": "ytd_state_tax",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date state income tax withheld."
+      },
+      {
+        "name": "ytd_city_tax",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date city/local income tax withheld."
+      },
+      {
+        "name": "ytd_total_deductions",
+        "type": "currency",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date total deductions."
+      },
+      {
+        "name": "regular_hourly_rate",
+        "type": "number",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's regular hourly rate of pay."
+      },
+      {
+        "name": "holiday_hourly_rate",
+        "type": "number",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's holiday or premium hourly rate of pay."
+      },
+      {
+        "name": "federal_filing_status",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's federal tax filing status (e.g. Single, Married)."
+      },
+      {
+        "name": "state_filing_status",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's state tax filing status."
+      },
+      {
+        "name": "employee_number",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employer-assigned employee identification number."
+      },
+      {
+        "name": "payroll_number",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Payroll run or check number."
+      },
+      {
+        "name": "currency",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "ISO 4217 currency code for all monetary amounts on the payslip (e.g. USD)."
+      },
+      {
+        "name": "employee_name.first_name",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's first (given) name."
+      },
+      {
+        "name": "employee_name.middle_name",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's middle name or initial."
+      },
+      {
+        "name": "employee_name.last_name",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's last (family) name."
+      },
+      {
+        "name": "employee_name.suffix_name",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Employee's name suffix (e.g. Jr., Sr., III)."
+      },
+      {
+        "name": "employee_address.line1",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "First line of the employee's mailing address."
+      },
+      {
+        "name": "employee_address.line2",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Second line of the employee's mailing address (apt, suite, etc.)."
+      },
+      {
+        "name": "employee_address.city",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "City of the employee's mailing address."
+      },
+      {
+        "name": "employee_address.state",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "State/territory abbreviation of the employee's mailing address."
+      },
+      {
+        "name": "employee_address.zipcode",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "ZIP or postal code of the employee's mailing address."
+      },
+      {
+        "name": "company_address.line1",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "First line of the employer's business address."
+      },
+      {
+        "name": "company_address.line2",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "Second line of the employer's business address."
+      },
+      {
+        "name": "company_address.city",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "City of the employer's business address."
+      },
+      {
+        "name": "company_address.state",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "State/territory abbreviation of the employer's business address."
+      },
+      {
+        "name": "company_address.zipcode",
+        "type": "string",
+        "required": false,
+        "confidenceFloor": 0.65,
+        "description": "ZIP or postal code of the employer's business address."
+      },
+      {
+        "name": "federal_taxes.item_description",
+        "type": "string",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Label for a federal tax line item (e.g. Federal Income Tax)."
+      },
+      {
+        "name": "federal_taxes.period",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Current period amount for a federal tax line item."
+      },
+      {
+        "name": "federal_taxes.ytd",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date amount for a federal tax line item."
+      },
+      {
+        "name": "state_taxes.item_description",
+        "type": "string",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Label for a state tax line item."
+      },
+      {
+        "name": "state_taxes.period",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Current period amount for a state tax line item."
+      },
+      {
+        "name": "state_taxes.ytd",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date amount for a state tax line item."
+      },
+      {
+        "name": "city_taxes.item_description",
+        "type": "string",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Label for a city/local tax line item."
+      },
+      {
+        "name": "city_taxes.period",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Current period amount for a city/local tax line item."
+      },
+      {
+        "name": "city_taxes.ytd",
+        "type": "currency",
+        "required": false,
+        "repeated": true,
+        "confidenceFloor": 0.65,
+        "description": "Year-to-date amount for a city/local tax line item."
+      }
+    ]
+  }
+]

--- a/infra/README.md
+++ b/infra/README.md
@@ -162,7 +162,7 @@ The cert for `document-ai.dev.medicaid.navateam.com` is defined in `infra/projec
 ```sh
 cd infra/networks
 terraform init -backend-config=dev.s3.tfbackend
-terraform apply
+terraform apply -var network_name=dev
 ```
 
 **2. Create the ECR repository**

--- a/infra/README.md
+++ b/infra/README.md
@@ -175,7 +175,19 @@ terraform apply
 
 **3. Push a container image**
 
-Build and push an image tagged with the version you want to deploy (e.g. `latest` for dev):
+Build and push an image tagged with the version you want to deploy (e.g. `latest` for dev).
+
+Authenticate with GHCR first (the upstream image is published there):
+
+```sh
+# Grant your local token read:packages scope
+gh auth refresh -s read:packages
+
+# Log Docker into GHCR using your GitHub token
+echo $(gh auth token) | docker login ghcr.io -u $(gh api user -q .login) --password-stdin
+```
+
+Then log into ECR, build, and push:
 
 ```sh
 aws ecr get-login-password --region us-east-1 \

--- a/infra/README.md
+++ b/infra/README.md
@@ -136,6 +136,92 @@ Set up the following before launching to end users in production:
 - [Web application firewall (WAF)](/docs/infra/web-application-firewall.md)
 - [Staging and production environments](../docs/infra/staging-and-production-environments.md)
 
+## 🤖 Document AI service
+
+The `infra/document-ai/` directory provisions the [strata-service-document-ai](https://github.com/navapbc/strata-service-document-ai) microservice, which processes and extracts text from documents using Amazon Textract + Bedrock.
+
+### Architecture
+
+| Component | Details |
+|---|---|
+| Service | ECS Fargate behind an ALB |
+| AI backend | Amazon Textract + Bedrock (`aws_model = "textract"`) |
+| Storage | S3 + DynamoDB for document jobs |
+| Domain | `document-ai.dev.medicaid.navateam.com` |
+| ECR | `community-engagement-medicaid-document-ai` |
+| Network | Shares the existing `dev` VPC |
+
+### First-time setup
+
+Run these steps in order. Steps 1 and 2 are one-time; step 3 is repeated for each release.
+
+**1. Provision the ACM certificate (if not already done)**
+
+The cert for `document-ai.dev.medicaid.navateam.com` is defined in `infra/project-config/networks.tf` and provisioned alongside the network:
+
+```sh
+cd infra/networks
+terraform init -backend-config=dev.s3.tfbackend
+terraform apply
+```
+
+**2. Create the ECR repository**
+
+```sh
+cd infra/document-ai/build-repository
+terraform init -backend-config=shared.s3.tfbackend
+terraform apply
+```
+
+**3. Push a container image**
+
+Build and push an image tagged with the version you want to deploy (e.g. `latest` for dev):
+
+```sh
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS \
+    --password-stdin <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
+
+docker build -t community-engagement-medicaid-document-ai:latest .
+docker tag  community-engagement-medicaid-document-ai:latest \
+  <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/community-engagement-medicaid-document-ai:latest
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/community-engagement-medicaid-document-ai:latest
+```
+
+**4. Deploy the service**
+
+```sh
+cd infra/document-ai/service
+terraform init -backend-config=dev.s3.tfbackend
+terraform apply -var environment_name=dev
+```
+
+Pass a specific image tag with `-var image_tag=<tag>` if you are not using `latest`.
+
+### ⚠️ Post-deploy: set the API auth key
+
+The module creates a Secrets Manager secret named `cem-docai-dev-api-auth-key` with an **empty value**. The service will not authenticate requests until this is set.
+
+After the first `terraform apply`, set the key:
+
+```sh
+aws secretsmanager put-secret-value \
+  --secret-id cem-docai-dev-api-auth-key \
+  --secret-string "<your-secret-key>"
+```
+
+Generate a strong random key with `openssl rand -hex 32`. The value is passed to the service as the `API_AUTH_INSECURE_SHARED_KEY` environment variable and must be included in requests as a bearer token.
+
+### Destroying the dev environment
+
+Deletion protection is disabled for dev, so a clean destroy is possible:
+
+```sh
+# Service first, then ECR
+cd infra/document-ai/service && terraform destroy -var environment_name=dev
+cd infra/document-ai/build-repository && terraform destroy
+```
+
 ### Setting up additional capabilities
 
 - [Additional applications](../docs/infra/add-application.md)

--- a/infra/README.md
+++ b/infra/README.md
@@ -194,7 +194,7 @@ aws ecr get-login-password --region us-east-1 \
   | docker login --username AWS \
     --password-stdin <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
 
-docker build -t community-engagement-medicaid-document-ai:latest .
+docker build -t community-engagement-medicaid-document-ai:latest document-ai/
 docker tag  community-engagement-medicaid-document-ai:latest \
   <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/community-engagement-medicaid-document-ai:latest
 docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/community-engagement-medicaid-document-ai:latest

--- a/infra/document-ai/build-repository/main.tf
+++ b/infra/document-ai/build-repository/main.tf
@@ -1,0 +1,54 @@
+data "aws_iam_role" "github_actions" {
+  name = module.project_config.github_actions_role_name
+}
+
+data "external" "account_ids_by_name" {
+  program = ["${path.module}/../../../bin/account-ids-by-name"]
+}
+
+locals {
+  tags = merge(module.project_config.default_tags, {
+    application      = "document-ai"
+    application_role = "build-repository"
+    description      = "Backend resources required for storing built release candidate artifacts to be used for deploying to environments."
+  })
+
+  # document-ai currently deploys only to the dev network
+  dev_account_name = module.project_config.network_configs["dev"].account_name
+  dev_account_id   = data.external.account_ids_by_name.result[local.dev_account_name]
+
+  ecr_repo_name = "${module.project_config.project_name}-document-ai"
+}
+
+terraform {
+  required_version = "~>1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>4.20.1"
+    }
+  }
+
+  backend "s3" {
+    encrypt = "true"
+  }
+}
+
+provider "aws" {
+  region = module.project_config.default_region
+  default_tags {
+    tags = local.tags
+  }
+}
+
+module "project_config" {
+  source = "../../project-config"
+}
+
+module "container_image_repository" {
+  source               = "../../modules/container-image-repository"
+  name                 = local.ecr_repo_name
+  push_access_role_arn = data.aws_iam_role.github_actions.arn
+  app_account_ids      = [local.dev_account_id]
+}

--- a/infra/document-ai/build-repository/shared.s3.tfbackend
+++ b/infra/document-ai/build-repository/shared.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket       = "community-engagement-medicaid-065727387448-us-east-1-tf"
+key          = "infra/document-ai/build-repository/shared.tfstate"
+region       = "us-east-1"
+use_lockfile = true

--- a/infra/document-ai/service/dev.s3.tfbackend
+++ b/infra/document-ai/service/dev.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket       = "community-engagement-medicaid-065727387448-us-east-1-tf"
+key          = "infra/document-ai/service/dev.tfstate"
+region       = "us-east-1"
+use_lockfile = true

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -123,6 +123,33 @@ module "document_ai" {
   dynamodb_deletion_protection = false
 }
 
+# Look up the ECS security group created by the external module (not exposed as an output)
+data "aws_security_groups" "document_ai_ecs" {
+  depends_on = [module.document_ai]
+
+  filter {
+    name   = "group-name"
+    values = ["${local.doc_ai_project_name}-ecs-*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [module.network.vpc_id]
+  }
+}
+
+# Grant document-ai ECS tasks access to the shared VPC endpoints (Secrets Manager, ECR, logs, etc.)
+# The VPC endpoint security group only allows inbound HTTPS from explicitly referenced security groups.
+# This mirrors what modules/service/networking.tf does for reporting-app.
+resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_document_ai" {
+  security_group_id            = module.network.aws_services_security_group_id
+  description                  = "Allow HTTPS to VPC endpoints from document-ai ECS tasks"
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = data.aws_security_groups.document_ai_ecs.ids[0]
+}
+
 # Route53 alias record pointing the domain at the service ALB
 resource "aws_route53_record" "document_ai" {
   zone_id = data.aws_route53_zone.zone.zone_id

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -1,0 +1,139 @@
+locals {
+  environment  = var.environment_name
+  aws_region   = module.project_config.default_region
+  project_name = module.project_config.project_name
+
+  tags = merge(module.project_config.default_tags, {
+    environment = local.environment
+    application = "document-ai"
+    description = "Document AI service resources created in ${local.environment} environment"
+  })
+
+  # document-ai uses the dev network (expand this map when adding more environments)
+  network_name = {
+    dev = "dev"
+  }[local.environment]
+
+  domain_name = "document-ai.${local.environment}.medicaid.navateam.com"
+  hosted_zone = module.project_config.network_configs[local.network_name].domain_config.hosted_zone
+
+  # Prefix for resources created by the external module.
+  # Keep short: ALB name is "${doc_ai_project_name}-alb" (32-char AWS limit).
+  # "cem-docai-dev-alb" = 18 chars ✓
+  doc_ai_project_name = "cem-docai-${local.environment}"
+
+  # S3 bucket for document storage (must be globally unique)
+  s3_bucket_name = "community-engagement-medicaid-document-ai-${local.environment}"
+
+  # ECR repository created by the build-repository layer
+  ecr_repo_name = "${local.project_name}-document-ai"
+
+  # Extract bare ALB hostname from the module's service_url output (strips https://)
+  alb_dns_name = trimprefix(trimprefix(module.document_ai.service_url, "https://"), "http://")
+}
+
+terraform {
+  required_version = "~>1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.81.0, < 6.47.1"
+    }
+  }
+
+  backend "s3" {
+    encrypt = "true"
+  }
+}
+
+provider "aws" {
+  region = local.aws_region
+  default_tags {
+    tags = local.tags
+  }
+}
+
+module "project_config" {
+  source = "../../project-config"
+}
+
+# Look up the existing VPC and subnets via tags set by infra/networks
+module "network" {
+  source       = "../../modules/network/data"
+  name         = local.network_name
+  project_name = local.project_name
+}
+
+# ECR repository created by infra/document-ai/build-repository
+data "aws_ecr_repository" "document_ai" {
+  name = local.ecr_repo_name
+}
+
+# ACM certificate for the document-ai domain (provisioned via infra/networks)
+data "aws_acm_certificate" "document_ai" {
+  domain   = local.domain_name
+  statuses = ["ISSUED"]
+}
+
+# Route53 hosted zone for creating the service's DNS record
+data "aws_route53_zone" "zone" {
+  name = local.hosted_zone
+}
+
+# Canonical ALB hosted zone ID for Route53 alias records (us-east-1 ALBs)
+data "aws_elb_hosted_zone_id" "main" {
+  load_balancer_type = "application"
+}
+
+# ---------------------------------------------------------------------------
+# Document AI service
+# ---------------------------------------------------------------------------
+module "document_ai" {
+  source = "github.com/navapbc/strata-service-document-ai//deploy/terraform/aws?ref=main"
+
+  project_name = local.doc_ai_project_name
+  environment  = local.environment
+  aws_region   = local.aws_region
+
+  # Networking — use the existing project VPC
+  create_vpc         = false
+  vpc_id             = module.network.vpc_id
+  private_subnet_ids = module.network.private_subnet_ids
+  public_subnet_ids  = module.network.public_subnet_ids
+
+  # Container image from the project ECR (build-repository must be applied first)
+  create_ecr      = false
+  container_image = "${data.aws_ecr_repository.document_ai.repository_url}:${var.image_tag}"
+
+  # Storage
+  s3_bucket_name = local.s3_bucket_name
+
+  # AI backend
+  aws_model = "textract"
+
+  # TLS — uses the cert provisioned in infra/networks
+  acm_certificate_arn = data.aws_acm_certificate.document_ai.arn
+
+  # WAF disabled for dev to reduce cost
+  create_waf = false
+
+  # Dev-safe: allow terraform destroy without manual intervention
+  enable_deletion_protection   = false
+  kms_deletion_window_days     = 7
+  secrets_recovery_window_days = 0
+  dynamodb_deletion_protection = false
+}
+
+# Route53 alias record pointing the domain at the service ALB
+resource "aws_route53_record" "document_ai" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.domain_name
+  type    = "A"
+
+  alias {
+    name                   = local.alb_dns_name
+    zone_id                = data.aws_elb_hosted_zone_id.main.id
+    evaluate_target_health = true
+  }
+}

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -109,7 +109,7 @@ module "document_ai" {
 
   # AI backend
   aws_model        = "textract"
-  bedrock_model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+  bedrock_model_id = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
   # TLS — uses the cert provisioned in infra/networks
   acm_certificate_arn = data.aws_acm_certificate.document_ai.arn
@@ -167,7 +167,7 @@ resource "aws_iam_role_policy" "docai_bedrock_foundation_models" {
       Effect = "Allow"
       Action = ["bedrock:InvokeModel"]
       # Wildcard region covers all regions the us. cross-region profile may route to
-      Resource = "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0"
+      Resource = "arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
     }]
   })
 }

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -88,7 +88,7 @@ data "aws_elb_hosted_zone_id" "main" {}
 # Document AI service
 # ---------------------------------------------------------------------------
 module "document_ai" {
-  source = "github.com/navapbc/strata-service-document-ai//deploy/terraform/aws?ref=main"
+  source = "git@github.com:navapbc/strata-service-document-ai//deploy/terraform/aws?ref=main"
 
   project_name = local.doc_ai_project_name
   environment  = local.environment

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -151,6 +151,27 @@ resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_ingress_from_docum
   referenced_security_group_id = data.aws_security_groups.document_ai_ecs.ids[0]
 }
 
+# The strata module's task_bedrock policy scopes the foundation-model ARN to
+# var.aws_region only, but cross-region inference profiles (us.anthropic.*)
+# can route to us-east-1, us-east-2, or us-west-2. AWS checks IAM against the
+# underlying foundation model in whichever region it routes to, so we need to
+# cover all three. We also use the bare model ID (strip "us." prefix) since
+# foundation model ARNs don't use regional prefixes.
+resource "aws_iam_role_policy" "docai_bedrock_foundation_models" {
+  name = "${local.doc_ai_project_name}-bedrock-foundation-models"
+  role = "${local.doc_ai_project_name}-ecs-task"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["bedrock:InvokeModel"]
+      # Wildcard region covers all regions the us. cross-region profile may route to
+      Resource = "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0"
+    }]
+  })
+}
+
 # Route53 alias record pointing the domain at the service ALB
 resource "aws_route53_record" "document_ai" {
   zone_id = data.aws_route53_zone.zone.zone_id

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -88,7 +88,7 @@ data "aws_elb_hosted_zone_id" "main" {}
 # Document AI service
 # ---------------------------------------------------------------------------
 module "document_ai" {
-  source = "git@github.com:navapbc/strata-service-document-ai//deploy/terraform/aws?ref=main"
+  source = "git@github.com:navapbc/strata-service-document-ai//deploy/terraform/aws?ref=48554af1334cb8450be79d70a153af715529cc20"
 
   project_name = local.doc_ai_project_name
   environment  = local.environment

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -108,7 +108,8 @@ module "document_ai" {
   s3_bucket_name = local.s3_bucket_name
 
   # AI backend
-  aws_model = "textract"
+  aws_model        = "textract"
+  bedrock_model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
 
   # TLS — uses the cert provisioned in infra/networks
   acm_certificate_arn = data.aws_acm_certificate.document_ai.arn

--- a/infra/document-ai/service/main.tf
+++ b/infra/document-ai/service/main.tf
@@ -82,9 +82,7 @@ data "aws_route53_zone" "zone" {
 }
 
 # Canonical ALB hosted zone ID for Route53 alias records (us-east-1 ALBs)
-data "aws_elb_hosted_zone_id" "main" {
-  load_balancer_type = "application"
-}
+data "aws_elb_hosted_zone_id" "main" {}
 
 # ---------------------------------------------------------------------------
 # Document AI service

--- a/infra/document-ai/service/variables.tf
+++ b/infra/document-ai/service/variables.tf
@@ -1,0 +1,10 @@
+variable "environment_name" {
+  type        = string
+  description = "name of the application environment"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "image tag to deploy to the environment"
+  default     = "latest"
+}

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -19,6 +19,10 @@ locals {
             source = "issued"
           }
 
+          "document-ai.dev.medicaid.navateam.com" = {
+            source = "issued"
+          }
+
           # Example certificate configuration for a certificate that is issued elsewhere and imported into the project
           # (currently not supported, will be supported via https://github.com/navapbc/template-infra/issues/559)
           # "platform-test-dev.navateam.com" = {


### PR DESCRIPTION
## Ticket

Part of #610

## Changes

Provisions the [strata-service-document-ai](https://github.com/navapbc/strata-service-document-ai) microservice into the project's existing AWS infrastructure using the upstream Terraform module.

- **`infra/document-ai/build-repository/`** — ECR repository for document-ai container images, following the same pattern as `reporting-app/build-repository`
- **`infra/document-ai/service/`** — service layer that calls the external module with:
  - `create_vpc = false` — wires into the existing dev VPC via tag-based lookup (`modules/network/data`)
  - `create_ecr = false` — uses the ECR repo from the build-repository layer
  - `aws_model = "textract"` — Amazon Textract + Bedrock backend
  - ACM cert + Route53 alias record for `document-ai.dev.medicaid.navateam.com`
  - Dev-safe settings: WAF off, deletion protection off, short KMS/Secrets recovery windows
- **`infra/project-config/networks.tf`** — adds ACM cert for `document-ai.dev.medicaid.navateam.com` to the dev network
- **`infra/README.md`** — new Document AI section with deploy order, push instructions, and a post-deploy note on setting the API auth key in Secrets Manager

## Context for reviewers

The service is self-contained — it does not share state with `reporting-app`. The upstream module creates its own ECS cluster, ALB, KMS key, DynamoDB table, and Secrets Manager secret (`cem-docai-dev-api-auth-key`).

**Deploy order (first time):**
1. `infra/networks` — provision the new ACM cert
2. `infra/document-ai/build-repository` — create ECR
3. Push a container image to ECR
4. `infra/document-ai/service` — deploy the service
5. Set the API key in Secrets Manager (see README)

The `API_AUTH_INSECURE_SHARED_KEY` secret is intentionally left blank at apply time — it must be set manually after first deploy. This matches how #610 expects the key to be wired: stored in Secrets Manager and consumed by `reporting-app` as `DOC_AI_API_KEY`.

## Testing

Infrastructure has not yet been applied to dev — this PR is intended to be reviewed before the first deploy. Terraform formatting passes (`terraform fmt -check`). The module source and all variable names were verified against the upstream repo at `navapbc/strata-service-document-ai` main.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->