### PR TITLE
Member dashboard 500s for automated exemption determinations

### DIFF
--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -149,11 +149,18 @@ class CertificationCase < Strata::Case
       self.exemption_request_approval_status_updated_at = Time.current
       close!
 
+      reason_codes = Determination.to_reason_codes(eligibility_fact)
       certification.record_determination!(
         decision_method: :automated,
-        reasons: Determination.to_reason_codes(eligibility_fact),
+        reasons: reason_codes,
         outcome: :exempt,
-        determination_data: eligibility_fact.reasons.to_json,
+        # determination_data is a jsonb column holding a structured Hash (OSCER convention; see
+        # the Determination docs). For automated exemptions the type is carried by the reason
+        # codes, which the dashboard reads via decision_method branching, so we record those
+        # codes here. It must stay a Hash: writing a JSON String (e.g. reasons.to_json)
+        # double-encodes into the jsonb column and reads back as a String, which 500'd the
+        # member dashboard. See https://github.com/navapbc/oscer/issues/680.
+        determination_data: { "exemption_reasons" => reason_codes },
         determined_at: certification.certification_requirements.certification_date,
         actor:
       )

--- a/reporting-app/app/models/member_dashboard_compliance.rb
+++ b/reporting-app/app/models/member_dashboard_compliance.rb
@@ -274,26 +274,41 @@ class MemberDashboardCompliance
     I18n.t("exemption_types.#{key}.title", default: key.to_s.humanize)
   end
 
+  # The exemption type lives in different places depending on how the exemption was decided.
+  # Automated (eligibility-derived) exemptions encode the type in their reason codes, while
+  # manual (staff-reviewed) exemptions record the member's claimed type in
+  # +determination_data["exemption_type"]+. Branch on +decision_method+ so each reads its
+  # authoritative source — this also keeps a legacy/malformed +determination_data+ on an
+  # automated row from ever reaching the Hash read (see #680).
   def exemption_history_type_for_determination(det)
-    type_key = exemption_type_key_from_determination_data(det.determination_data)
-    return [ type_key, exemption_type_label(type_key) ] if type_key.present?
-
-    exempt_reason = Array(det.reasons).find { |r| r.to_s.end_with?("_exempt") }
-    if exempt_reason
-      label = I18n.t(
-        "services.member_status_service.reason_codes.#{exempt_reason}",
-        default: exempt_reason.to_s.humanize
-      )
-      return [ exempt_reason, label ]
+    if det.decision_method == "automated"
+      # The row is already +outcome: :exempt+, so its reasons are exemption reasons; the
+      # reason code is the type. No need to inspect determination_data.
+      reason = Array(det.reasons).first
+      reason ? [ reason, exemption_reason_label(reason) ] : unknown_exemption_type
+    else
+      label_from_determination_data(det.determination_data) || unknown_exemption_type
     end
-
-    [ "exemption", I18n.t("dashboard.member_compliance.exemption_type_unknown") ]
   end
 
-  # +Determination#determination_data+ is +jsonb+, so AR returns a +Hash+ (or nil).
-  def exemption_type_key_from_determination_data(data)
-    return nil if data.blank?
+  # Manual (staff-reviewed) exemptions record the member's claimed type on the determination.
+  # Returns +nil+ (so the caller falls back) when no usable type is present. Guards the shape:
+  # +determination_data+ is +jsonb+ and should be a Hash, but a malformed row must not raise.
+  def label_from_determination_data(data)
+    return nil unless data.is_a?(Hash)
 
-    data.stringify_keys["exemption_type"].presence
+    key = data.stringify_keys["exemption_type"].presence
+    key && [ key, exemption_type_label(key) ]
+  end
+
+  def exemption_reason_label(reason)
+    I18n.t(
+      "services.member_status_service.reason_codes.#{reason}",
+      default: reason.to_s.humanize
+    )
+  end
+
+  def unknown_exemption_type
+    [ "exemption", I18n.t("dashboard.member_compliance.exemption_type_unknown") ]
   end
 end

--- a/reporting-app/config/locales/services/en.yml
+++ b/reporting-app/config/locales/services/en.yml
@@ -6,6 +6,7 @@ en:
         age_over_65_exempt: "Age over 65"
         pregnancy_exempt: "Pregnant"
         american_indian_alaska_native_exempt: "American Indian or Alaska Native"
+        veteran_disability_exempt: "Veteran with a disability"
         income_reported_compliant: "Income reported compliant"
         income_reported_insufficient: "Insufficient community engagement income"
         hours_reported_compliant: "Hours reported compliant"

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -302,7 +302,11 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.reasons).to include("age_under_19_exempt")
       expect(determination.outcome).to eq("exempt")
       expect(determination.determined_at).to be_present
-      expect(determination.determination_data).to eq(eligibility_fact.reasons.to_json)
+      # determination_data is a jsonb column and must be stored as a Hash, never a JSON
+      # String (writing reasons.to_json double-encodes it into a String — see #680). For
+      # automated exemptions it records the granting reason codes.
+      expect(determination.determination_data).to be_a(Hash)
+      expect(determination.determination_data).to eq({ "exemption_reasons" => [ "age_under_19_exempt" ] })
     end
 
     it 'records multiple reasons (age and pregnancy)' do

--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe MemberDashboardComplianceService do
            period_start: period_start, period_end: period_end, gross_income: gross_income, **attrs)
   end
 
+  # Persists a JSON *string scalar* into the +determination_data+ jsonb column so
+  # ActiveRecord reads it back as a String, reproducing the double-encoded production rows
+  # (e.g. a historical +reasons.to_json+ write). Bypasses AR casting via raw SQL.
+  def force_string_determination_data(determination, value = "[]")
+    conn = ActiveRecord::Base.connection
+    conn.execute(
+      "UPDATE strata_determinations " \
+      "SET determination_data = #{conn.quote(value.to_json)}::jsonb " \
+      "WHERE id = #{conn.quote(determination.id)}"
+    )
+  end
+
   describe ".build" do
     subject(:read_model) do
       described_class.build(
@@ -312,6 +324,58 @@ RSpec.describe MemberDashboardComplianceService do
         expect(entry).to be_present
         expect(entry.exemption_type_label).to eq(I18n.t("exemption_types.medical_condition.title"))
         expect(entry.exemption_type_label).to be_a(String)
+      end
+    end
+
+    context "when an automated exempt determination has a legacy String determination_data" do
+      # Reproduces the production shape that 500'd the dashboard: the automated exemption
+      # path historically wrote reasons.to_json (a String) into the jsonb column, so AR
+      # reads it back as a String instead of a Hash.
+      before do
+        det = create(:determination,
+                     subject: certification,
+                     outcome: "exempt",
+                     decision_method: "automated",
+                     reasons: [ "age_under_19_exempt" ])
+        force_string_determination_data(det)
+      end
+
+      it "builds exemption history without raising and labels from the reason code" do
+        expect { read_model.exemption_history }.not_to raise_error
+        entry = read_model.exemption_history.first
+        expect(entry.exemption_type_key).to eq("age_under_19_exempt")
+        expect(entry.exemption_type_label).to eq("Age under 19")
+      end
+    end
+
+    context "when a manual exempt determination has a malformed (non-Hash) determination_data" do
+      before do
+        det = create(:determination,
+                     subject: certification,
+                     outcome: "exempt",
+                     decision_method: "manual",
+                     reasons: [ "exemption_request_compliant" ])
+        force_string_determination_data(det, "oops")
+      end
+
+      it "does not raise and falls back to the unknown exemption type" do
+        expect { read_model.exemption_history }.not_to raise_error
+        expect(read_model.exemption_history.first.exemption_type_key).to eq("exemption")
+      end
+    end
+
+    context "when an automated exemption is for veteran disability" do
+      before do
+        create(:determination,
+               subject: certification,
+               outcome: "exempt",
+               decision_method: "automated",
+               reasons: [ "veteran_disability_exempt" ])
+      end
+
+      it "labels it with the curated reason-code translation" do
+        entry = read_model.exemption_history.find { |e| e.exemption_type_key == "veteran_disability_exempt" }
+        expect(entry.exemption_type_label).to eq("Veteran with a disability")
       end
     end
 


### PR DESCRIPTION
## Ticket

Resolves #680

## Changes

- Stop `CertificationCase#record_exemption_determination` from writing `eligibility_fact.reasons.to_json` (a JSON String) into the jsonb `determination_data` column; it now stores a Hash (`{ "exemption_reasons" => reason_codes }`).
- Rewrite `MemberDashboardCompliance#exemption_history_type_for_determination` to resolve the exemption type by `decision_method`: automated determinations read the type from their reason code, manual determinations read `determination_data` behind an `is_a?(Hash)` guard.
- Add the missing `veteran_disability_exempt` key to `config/locales/services/en.yml` reason codes.
- Add specs covering the crash regression (legacy String `determination_data`), the non-Hash guard, the veteran-disability label, and the producer storing a Hash.

## Context for reviewers

The member dashboard 500s for any member whose certification has an automated exemption determination. `determination_data` is a `jsonb` column, but the automated exemption path serialized its payload with `.to_json` first, so Postgres stored a JSON string scalar and ActiveRecord read it back as a `String`. The dashboard's exemption-history read model assumed a `Hash` (`determination_data.stringify_keys[...]`) and raised `NoMethodError`. On the dev environment all 1,024 exempt determinations are stored this way.

Two design points worth knowing:

- **Why a Hash with reason codes, not `{}`.** `Strata::Determination` validates `determination_data` presence, and Rails treats `{}` as blank, so an empty hash is rejected. Across OSCER, `determination_data` is used as a structured Hash (CE determinations store `HoursBasedDeterminationData#to_h`, the manual exemption stores `{ exemption_type: ... }`), so the automated path now follows that convention by recording the granting reason codes.
- **Why branch on `decision_method`.** Automated exemptions carry their type in the reason code; manual (staff-reviewed) exemptions carry it in `determination_data`. Branching reads each from its authoritative source, and because the automated branch never touches `determination_data`, the existing String rows can no longer crash the page (they label from the reason code instead). The `is_a?(Hash)` guard on the manual branch keeps a malformed row from raising.

The staff-approved "Placeholder" exemption type is a separate, smaller defect tracked in #681. This PR intentionally leaves the manual path unchanged.

## Testing

- Reproduced the bug locally: created and approved an exemption, then confirmed an automated exemption determination 500s the dashboard before the fix.
- TDD: the red run reproduced the exact production failure (`NoMethodError: undefined method 'stringify_keys' for an instance of String`) and the double-encoded payload; green after the fix.
- Verified in the UI after the fix: the member dashboard renders the exemption history for an automated exemption determination without error.
- `member_dashboard_compliance_service_spec.rb`, `certification_case_spec.rb`, `determination_spec.rb`, `certification_business_process_spec.rb`: 101 examples, 0 failures.
- Related suites (dashboard views, compliance/dashboard helpers, `member_status_service`, review-exemption request + model specs): 149 examples, 0 failures.
- Full suite green. RuboCop clean.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->