### PR TITLE
Member dashboard shows "Placeholder" as the exemption type for staff-approved exemptions

### DIFF
--- a/reporting-app/app/controllers/review_exemption_claim_tasks_controller.rb
+++ b/reporting-app/app/controllers/review_exemption_claim_tasks_controller.rb
@@ -5,7 +5,7 @@ class ReviewExemptionClaimTasksController < TasksController
     kase = @task.case
 
     if approving?
-      kase.accept_exemption_request(current_user)
+      kase.accept_exemption_request(current_user, @task.application_form)
       @task.approval_status = :approved
       notice = t("tasks.details.approved_message")
     elsif denying?

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -99,7 +99,7 @@ class CertificationCase < Strata::Case
     Strata::EventManager.publish(event_name, { case_id: id, certification_id: certification_id, application_form_id: application_form.id })
   end
 
-  def accept_exemption_request(user)
+  def accept_exemption_request(user, application_form)
     transaction do
       self.exemption_request_approval_status = "approved"
       self.exemption_request_approval_status_updated_at = Time.current
@@ -112,7 +112,7 @@ class CertificationCase < Strata::Case
         outcome: :exempt,
         determined_at: certification.certification_requirements.certification_date,
         determination_data: {
-          exemption_type: "placeholder"
+          exemption_type: application_form.exemption_type
         },
         actor: user
       )

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       expect(certification_case).to be_open
 
       # Step 3: Staff approves exemption
-      certification_case.accept_exemption_request(user)
+      certification_case.accept_exemption_request(user, exemption)
       certification_case.reload
 
       expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
@@ -278,7 +278,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
 
       # Approve exemption
       expect {
-        certification_case.accept_exemption_request(user)
+        certification_case.accept_exemption_request(user, exemption)
       }.to have_published_event("DeterminedExempt")
     end
   end

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -189,10 +189,12 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#accept_exemption_request' do
+    let(:application_form) { create(:exemption_application_form, certification_case_id: certification_case.id) }
+
     before { allow(Strata::EventManager).to receive(:publish) }
 
     it 'sets approval status and closes case' do
-      certification_case.accept_exemption_request(user)
+      certification_case.accept_exemption_request(user, application_form)
       certification_case.reload
 
       expect(certification_case.exemption_request_approval_status).to eq("approved")
@@ -205,11 +207,19 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.reasons).to include("exemption_request_compliant")
       expect(determination.outcome).to eq("exempt")
       expect(determination.determined_at).to be_present
-      expect(determination.determination_data).to eq({ "exemption_type" => "placeholder" })
+      expect(determination.determination_data).to eq({ "exemption_type" => "short_term_hardship" })
+    end
+
+    it 'records the approved exemption type from the application form' do
+      incarceration_form = create(:exemption_application_form, :incarceration, certification_case_id: certification_case.id)
+
+      certification_case.accept_exemption_request(user, incarceration_form)
+
+      expect(Determination.first.determination_data).to eq({ "exemption_type" => "incarceration" })
     end
 
     it 'publishes DeterminedExempt event' do
-      certification_case.accept_exemption_request(user)
+      certification_case.accept_exemption_request(user, application_form)
 
       expect(Strata::EventManager).to have_received(:publish).with(
         "DeterminedExempt",
@@ -220,7 +230,7 @@ RSpec.describe CertificationCase, type: :model do
     it 'logs decision to audit log' do
       certification = Certification.find(certification_case.certification_id)
       expect do
-        certification_case.accept_exemption_request(user)
+        certification_case.accept_exemption_request(user, application_form)
       end.to change { Strata::AuditLine.where(actor: user, subject: certification, action: "case.exemption.approved").count }.by(1)
     end
   end

--- a/reporting-app/spec/models/exemption_application_form_spec.rb
+++ b/reporting-app/spec/models/exemption_application_form_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ExemptionApplicationForm, type: :model do
         form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
         task = create(:review_exemption_claim_task, application_form: form, case: certification_case)
         task.completed!
-        certification_case.accept_exemption_request(nil)
+        certification_case.accept_exemption_request(nil, form)
         expect(form.flow_status).to eq "approved"
       end
 
@@ -206,7 +206,7 @@ RSpec.describe ExemptionApplicationForm, type: :model do
         form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
         task = create(:review_exemption_claim_task, application_form: form, case: certification_case)
         task.completed!
-        certification_case.accept_exemption_request(nil)
+        certification_case.accept_exemption_request(nil, form)
         expect(form.flow_status).to eq "approved"
       end
 

--- a/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_exemption_claim_tasks_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe "/review_exemption_claim_tasks", type: :request do
         expect(task.application_form.approval_status).to eq("approved")
       end
 
+      it "records the form's exemption type on the determination" do
+        patch review_exemption_claim_task_url(task), params: approve_params
+
+        determination = Determination.find_by(subject: certification, outcome: "exempt")
+        expect(determination.determination_data).to eq({ "exemption_type" => task.application_form.exemption_type })
+      end
+
       it "redirects back to the task" do
         patch review_exemption_claim_task_url(task), params: approve_params
         expect(response).to redirect_to(task_path(task))

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -278,14 +278,14 @@ RSpec.describe "dashboard/index", type: :view do
   end
 
   context "with an approved exemption request" do
-    let (:exemption_application_form) { create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
+    let (:exemption_application_form) { create(:exemption_application_form, :with_submitted_status, :incarceration, certification_case_id: certification_case.id) }
 
     before do
       assign(:exemption_application_form, exemption_application_form)
       assign(:certification_case, certification_case)
 
       ReviewExemptionClaimTask.find_by(application_form: exemption_application_form).completed!
-      certification_case.accept_exemption_request(nil)
+      certification_case.accept_exemption_request(nil, exemption_application_form)
       reassign_compliance_read_model
     end
 
@@ -300,6 +300,11 @@ RSpec.describe "dashboard/index", type: :view do
       expect(rendered).to have_selector('h2', text: I18n.t('dashboard.member_compliance.exemption_details_heading'))
       expect(rendered).to have_selector('.member-dashboard-compliance__badge--exempt',
                                         text: I18n.t('dashboard.member_compliance.exemption_badges.exempt'))
+    end
+
+    it 'renders the approved exemption type label from the form' do
+      render
+      expect(rendered).to have_text(I18n.t("exemption_types.incarceration.title"))
     end
 
     it 'has a button to view the completed certification' do


### PR DESCRIPTION
## Ticket

Resolves #681

## Changes

- Change `CertificationCase#accept_exemption_request(user)` to `accept_exemption_request(user, application_form)` and record the form's real `exemption_type` in `determination_data` instead of the hard-coded `"placeholder"` stub.
- Pass `@task.application_form` from `ReviewExemptionClaimTasksController#update`.
- Update the existing call sites in the model, business-process, exemption-form, and dashboard-view specs to pass the reviewed form.
- Add specs: the model records the form's type (with an `incarceration` case proving it is sourced from the form), the controller flow records it (request spec), and the dashboard renders the real type label (view spec).

## Context for reviewers

When staff approved an exemption, `accept_exemption_request` recorded `determination_data: { exemption_type: "placeholder" }` because the method had no access to the reviewed form. The member dashboard reads that value back, so approved exemptions displayed their type as the literal "Placeholder".

The fix mirrors the existing `accept_activity_report(user, application_form)` sibling: the controller already holds the review task's bound `application_form`, so it threads that through and the determination records `application_form.exemption_type` as a snapshot at approval time. This is the OSCER convention for `determination_data` (a structured Hash describing the determination), consistent with how the hours/income paths use the column.

Out of scope, intentionally: data backfill (verified on dev that zero determinations carry the "placeholder" value; no production). Pairs with #683 (the automated-exemption 500 fix, #680); the two touch different methods in `certification_case.rb` and do not conflict.

## Testing

- TDD: red run showed `determination_data` recording `"placeholder"` against the expected form type; green after threading the form through.
- Reproduced and verified in the UI: a staff-approved exemption now shows its real type on the member dashboard instead of "Placeholder".
- `certification_case_spec.rb`, `review_exemption_claim_tasks_spec.rb` (request), and `index.html.erb_spec.rb` (view) cover the model recording, the controller flow, and the rendered label.
- Full suite green (2250 examples, 0 failures); dashboard view spec green including the added render assertion. RuboCop clean.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->