### PR TITLE
update concurrent-ruby

### DIFF
--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     choice (0.2.0)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal


### PR DESCRIPTION
## Changes

concurrent-ruby gem updated

## Context for reviewers

Addresses security advisories:

- CVE: CVE-2026-54904
- CVE: CVE-2026-54905
- CVE: CVE-2026-54906

## Testing

`make build audit lint test` passes

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->