### PR TITLE
Ignore Dependabot Rails framework bumps (OSCER-700)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # Retained for visibility; all members are listed in ignore below.
       rails:
         patterns:
           - "rails"
@@ -28,6 +29,29 @@ updates:
         patterns:
           - "aws-sdk-*"
           - "aws-actionmailer-*"
+    ignore:
+      # Rails framework gems are upgraded intentionally, NOT via Dependabot.
+      # Team decision (Jun 2026): let navapbc/template-application-rails upgrade
+      # Rails first, then port framework changes here through a deliberate,
+      # tracked OSCER upgrade ticket/PR (config, initializers, gem constraints,
+      # and Strata SDK compatibility come from the template upgrade as the source
+      # of truth). Repeatedly triaging the same rejected grouped bump (e.g. PRs
+      # #568, #695) is the problem these ignore rules eliminate.
+      #
+      # Bare ignore (no update-types) suppresses both version-update AND security
+      # PRs for listed gems. Pick up Rails security patches manually via GitHub
+      # security advisories and template-app release notes, then apply through
+      # the tracked upgrade.
+      #
+      # Globs mirror the "rails" group patterns so partial framework bumps cannot
+      # slip through. rspec-rails is intentionally NOT ignored (separate "rspec"
+      # group; test dependency, not framework runtime). rails-dom-testing /
+      # rails-html-sanitizer / rails-erd are not in the "rails" group (exact
+      # "rails" pattern, no wildcard).
+      - dependency-name: "rails"
+      - dependency-name: "railties"
+      - dependency-name: "active*"
+      - dependency-name: "action*"
 
   - package-ecosystem: "npm"
     directory: "/reporting-app"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,15 +43,24 @@ updates:
       # security advisories and template-app release notes, then apply through
       # the tracked upgrade.
       #
-      # Globs mirror the "rails" group patterns so partial framework bumps cannot
-      # slip through. rspec-rails is intentionally NOT ignored (separate "rspec"
-      # group; test dependency, not framework runtime). rails-dom-testing /
-      # rails-html-sanitizer / rails-erd are not in the "rails" group (exact
-      # "rails" pattern, no wildcard).
+      # Listed explicitly (not globs) so the ignored set is obvious in review.
+      # rspec-rails is intentionally NOT ignored (separate "rspec" group; test
+      # dependency, not framework runtime). rails-dom-testing / rails-html-sanitizer
+      # / rails-erd are not in the "rails" group (exact "rails" pattern, no wildcard).
       - dependency-name: "rails"
       - dependency-name: "railties"
-      - dependency-name: "active*"
-      - dependency-name: "action*"
+      - dependency-name: "activesupport"
+      - dependency-name: "activemodel"
+      - dependency-name: "activerecord"
+      - dependency-name: "activejob"
+      - dependency-name: "activestorage"
+      - dependency-name: "active_storage_validations"
+      - dependency-name: "actioncable"
+      - dependency-name: "actionmailbox"
+      - dependency-name: "actionmailer"
+      - dependency-name: "actionpack"
+      - dependency-name: "actiontext"
+      - dependency-name: "actionview"
 
   - package-ecosystem: "npm"
     directory: "/reporting-app"

--- a/docs/reporting-app/application-security.md
+++ b/docs/reporting-app/application-security.md
@@ -117,7 +117,7 @@ Some effective admin protection strategies include:
 
 ## Dependency Management and CVEs'
 - [x] Use a service to be notified when libraries are outdated
-    - Note: We're using dependabot to notify us if we have outdated gems.
+    - Note: We're using Dependabot to notify us if we have outdated gems. Rails framework gems are excluded from Dependabot (see `.github/dependabot.yml`); upgrade those manually after [template-application-rails](https://github.com/navapbc/template-application-rails).
 
 ## Additional Reading
 * [Securing Rails Applications](https://guides.rubyonrails.org/security.html)


### PR DESCRIPTION
## Ticket

Resolves [OSCER-700](https://github.com/navapbc/oscer/issues/700)

## Changes

- Added `ignore` rules under the `reporting-app` Bundler entry in `.github/dependabot.yml` for Rails framework gems (`rails`, `railties`, `active*`, `action*`) so Dependabot stops opening grouped Rails minor bumps (e.g. PRs #568, #695).
- Documented in `dependabot.yml` why Rails is ignored (defer to [template-application-rails](https://github.com/navapbc/template-application-rails)) and how upgrades should happen (tracked OSCER upgrade ticket/PR).
- Clarified that bare `ignore` suppresses both version-update and security PRs for listed gems; manual pickup via GitHub advisories and template-app release notes.
- Retained the `rails` dependency group with a comment for visibility; all members are covered by `ignore`.
- Updated `docs/reporting-app/application-security.md` to note Rails framework gems are excluded from Dependabot.

## Context for reviewers

- **Team decision (Jun 2026):** Do not merge Dependabot Rails framework bumps in OSCER. Let template-application-rails upgrade first, then port changes here deliberately (config, initializers, gem constraints, Strata SDK compatibility).
- **`rspec-rails`** stays on the normal Dependabot schedule (separate `rspec` group, not ignored).
- **`rails-dom-testing`**, **`rails-html-sanitizer`**, and **`rails-erd`** are not in the `rails` group (exact `rails` pattern, no wildcard) and remain on Dependabot.
- After merge: close [PR #695](https://github.com/navapbc/oscer/pull/695) without merging.

## Testing

- Reviewed `.github/dependabot.yml` against [Dependabot ignore docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore); globs mirror existing `rails` group patterns.
- No application code changed; lint/tests not required.
- **Post-merge (maintainer):**
  1. Close PR #695 with a comment linking to this PR / OSCER-700.
  2. After the next weekly Dependabot run, confirm in **Insights → Dependency graph → Dependabot** (or repo Dependabot tab) that no new `rails` group bump PR opens for `reporting-app`.

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->