### PR TITLE
Bump crass from 1.0.6 to 1.0.7 (OSCER-719)

### DIFF
--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (2.1.0)
       addressable
     cssbundling-rails (1.4.3)


### PR DESCRIPTION
## Ticket

Resolves [OSCER-719](https://github.com/navapbc/oscer/issues/719)

## Changes

- Bump `crass` from `1.0.6` to `1.0.7` in `reporting-app/Gemfile.lock` (lockfile-only; no `Gemfile` change).

## Context for reviewers

The **Security audit** CI job (`make audit` → `bundler-audit check --update`) was failing on four `crass` advisories, all fixed in `>= 1.0.7`:

- [GHSA-6jxj-px6v-747w](https://github.com/rgrove/crass/security/advisories/GHSA-6jxj-px6v-747w) — deeply nested CSS → `SystemStackError`/memory
- [GHSA-6wmf-3r64-vcwv](https://github.com/rgrove/crass/security/advisories/GHSA-6wmf-3r64-vcwv) — large numeric exponents → CPU/memory DoS
- [GHSA-8vfg-2r28-hvhj](https://github.com/rgrove/crass/security/advisories/GHSA-8vfg-2r28-hvhj) — non-ASCII → superlinear CPU
- [GHSA-wwpr-jff3-395c](https://github.com/rgrove/crass/security/advisories/GHSA-wwpr-jff3-395c) — adjacent comments → `SystemStackError`

`crass` is a transitive dependency via `loofah` (`crass (~> 1.0.2)`), which already permits `1.0.7`, so a conservative bump touches only the lockfile.

## Testing

Ran the audit in-container against the updated lockfile:

\`\`\`bash
cd reporting-app
docker compose run --rm reporting-app sh -c "./bin/bundle install --quiet && ./bin/bundle exec bundler-audit check --update"
\`\`\`

Result: \`No vulnerabilities found\`

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->