### PR TITLE
OSCER-716: Income-aware current-period compliance summary

### DIFF
--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -55,19 +55,15 @@ class CertificationCase < Strata::Case
 
   def accept_activity_report(user, application_form)
     certification = Certification.find(certification_id)
-    hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(certification, application_form:)
 
     transaction do
       self.activity_report_approval_status = "approved"
       self.activity_report_approval_status_updated_at = Time.current
       close!
 
-      certification.record_determination!(
-        decision_method: :manual,
-        reasons: [ Determination::REASON_CODE_MAPPING[:hours_reported_compliant] ],
-        outcome: :compliant,
-        determination_data: Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,
-        determined_at: certification.certification_requirements.certification_date,
+      record_approved_activity_report_determination(
+        certification: certification,
+        application_form: application_form,
         actor: user
       )
     end
@@ -322,6 +318,86 @@ class CertificationCase < Strata::Case
         actor:
       )
     end
+  end
+
+  # Records the compliant determination for a staff-approved activity report. The calculation
+  # type follows what the member reported on the form (income, hours, or both) so the member
+  # dashboard current-period summary surfaces the matching totals instead of defaulting to a
+  # 0-hour hours-based row when the member reported income (OSCER-716). Approval is a staff
+  # decision, so the outcome is always +:compliant+ regardless of whether either track meets
+  # its threshold.
+  #
+  # @param certification [Certification] aggregate root for +record_determination!+
+  # @param application_form [ActivityReportApplicationForm] the reviewed report
+  # @param actor [User] approving staff member
+  def record_approved_activity_report_determination(certification:, application_form:, actor:)
+    reported_income = IncomeComplianceDeterminationService
+      .member_income_activities_for_certification(certification, application_form:).exists?
+    reported_hours = HoursComplianceDeterminationService
+      .member_hour_activities_for_certification(certification, application_form:).exists?
+
+    determination_data, reasons =
+      if reported_income && reported_hours
+        approved_combined_determination(certification:, application_form:)
+      elsif reported_income
+        approved_income_determination(certification:, application_form:)
+      else
+        approved_hours_determination(certification:, application_form:)
+      end
+
+    certification.record_determination!(
+      decision_method: :manual,
+      reasons: reasons,
+      outcome: :compliant,
+      determination_data: determination_data,
+      determined_at: certification.certification_requirements.certification_date,
+      actor: actor
+    )
+  end
+
+  # @return [Array(Hash, Array<String>)] determination_data payload and reason codes
+  def approved_hours_determination(certification:, application_form:)
+    hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(certification, application_form:)
+    [
+      Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,
+      [ Determination::REASON_CODE_MAPPING[:hours_reported_compliant] ]
+    ]
+  end
+
+  # @return [Array(Hash, Array<String>)] determination_data payload and reason codes
+  def approved_income_determination(certification:, application_form:)
+    income_data = IncomeComplianceDeterminationService.aggregate_income_for_certification(certification, application_form:)
+    [
+      Determinations::IncomeBasedDeterminationData.from_aggregate(income_data).to_h,
+      [ Determination::REASON_CODE_MAPPING[:income_reported_compliant] ]
+    ]
+  end
+
+  # Mixed report: record one combined determination carrying both tracks. +hours_ok+/+income_ok+
+  # reflect each track's threshold for the stored payload, but staff approval keeps both compliant
+  # reason codes (the outcome is +:compliant+ either way) so reasons stay non-empty and consistent
+  # with the approval.
+  # @return [Array(Hash, Array<String>)] determination_data payload and reason codes
+  def approved_combined_determination(certification:, application_form:)
+    hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(certification, application_form:)
+    income_data = IncomeComplianceDeterminationService.aggregate_income_for_certification(certification, application_form:)
+    hours_ok = HoursComplianceDeterminationService.compliant_for_total_hours?(hours_data[:total_hours])
+    income_ok = IncomeComplianceDeterminationService.compliant_for_total_income?(income_data[:total_income])
+
+    determination_data = Determinations::ExternalCECombinedDeterminationData.build(
+      hours_data: hours_data,
+      income_data: income_data,
+      hours_ok: hours_ok,
+      income_ok: income_ok
+    ).to_h
+
+    [
+      determination_data,
+      [
+        Determination::REASON_CODE_MAPPING[:hours_reported_compliant],
+        Determination::REASON_CODE_MAPPING[:income_reported_compliant]
+      ]
+    ]
   end
 
   def external_ce_combined_reason_codes(outcome:, hours_ok:, income_ok:)

--- a/reporting-app/app/models/member_dashboard_compliance.rb
+++ b/reporting-app/app/models/member_dashboard_compliance.rb
@@ -120,6 +120,24 @@ class MemberDashboardCompliance
     latest_determination&.ce_calculation_type
   end
 
+  # Display mode for the current-period compliance summary partial
+  # (+dashboard/_compliance_status+). Derived from +show_income_summary+ and
+  # +ce_calculation_type+ so the view switches on a single intent-revealing token
+  # instead of re-deriving the determination semantics inline.
+  #
+  # - +:hours_only+ — hours-based CE (or income hidden / pre-build legacy path): hours block only.
+  # - +:income_only+ — income-based CE: income block only (hours omitted, OSCER-716).
+  # - +:combined+ — combined CE, satisfied by hours OR income (also the pre-determination
+  #   default, where +ce_calculation_type+ is +nil+ but income is assumed visible).
+  #
+  # @return [Symbol] one of +:hours_only+, +:income_only+, +:combined+
+  def compliance_summary_mode
+    return :hours_only unless show_income_summary
+    return :income_only if ce_calculation_type == Determination::CALCULATION_TYPE_INCOME_BASED
+
+    :combined
+  end
+
   # --- Lazy income fields ---
   # All six readers return +nil+ when +show_income_summary+ is false; otherwise they share a
   # single memoized aggregation (one external + one member query, computed once).

--- a/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
@@ -23,6 +23,7 @@
 
 <div class="grid-container">
   <%= render "dashboard/compliance_status",
+             compliance: local_assigns[:compliance],
              current_period: current_period,
              target_hours: target_hours,
              period_end_date: period_end_date,

--- a/reporting-app/app/views/dashboard/_compliance_status.html.erb
+++ b/reporting-app/app/views/dashboard/_compliance_status.html.erb
@@ -1,42 +1,103 @@
-<%# Shared partial for displaying current period compliance status %>
+<%# Shared partial for displaying current period compliance status. %>
 <%# Required locals: current_period, target_hours, period_end_date, total_hours_reported, hours_needed %>
+<%# Optional local: compliance (MemberDashboardCompliance). Drives whether the summary shows
+    hours, income, or both (OSCER-716). When absent (the legacy nil-compliance fallback path in
+    dashboard/_new_certification), the partial renders the hours-only layout unchanged. %>
+
+<% i18n = "dashboard.new_certification.current_period" %>
+<% mode = compliance&.compliance_summary_mode || :hours_only %>
+<% period_end_display = period_end_date&.strftime("%B %d, %Y") %>
+<% target_income_display = compliance && number_to_currency(compliance.target_income, precision: 0) %>
+
+<%# Met state. In :combined the requirement is satisfied by hours OR income, so either side
+    meeting the target counts as met. Income reads stay gated: they only run for the income
+    modes, where compliance#show_income_summary is true. %>
+<% summary_met =
+     case mode
+     when :income_only then !compliance.income_needed.to_d.positive?
+     when :combined    then hours_needed.to_i <= 0 || !compliance.income_needed.to_d.positive?
+     else                   hours_needed.to_i <= 0
+     end %>
+<% status_icon = summary_met ?
+     uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-1") :
+     uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
 
 <%# Current Period Compliance Status Section %>
 <h2 class="font-heading-xl margin-bottom-2">
-  <%= t("dashboard.new_certification.current_period.header", period: current_period&.strftime("%B %Y")) %>
+  <%= t("#{i18n}.header", period: current_period&.strftime("%B %Y")) %>
 </h2>
 <p class="margin-bottom-4">
-  <%= t("dashboard.new_certification.current_period.requirement_info", 
-        target_hours: target_hours, 
-        period_end_date: period_end_date&.strftime("%B %d, %Y")) %>
+  <% case mode %>
+  <% when :income_only %>
+    <%= t("#{i18n}.requirement_info_income", target_income: target_income_display, period_end_date: period_end_display) %>
+  <% when :combined %>
+    <%= t("#{i18n}.requirement_info_combined", target_hours: target_hours, target_income: target_income_display, period_end_date: period_end_display) %>
+  <% else %>
+    <%= t("#{i18n}.requirement_info", target_hours: target_hours, period_end_date: period_end_display) %>
+  <% end %>
 </p>
 
-<%# Total Hours Reported %>
-<div class="margin-bottom-3">
-  <p class="margin-bottom-05 text-base"><%= t("dashboard.new_certification.current_period.total_hours_label") %></p>
-  <p class="display-flex flex-align-center margin-top-0">
-    <% if hours_needed > 0 %>
-      <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
-    <% else %>
-      <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-1") %>
-    <% end %>
-    <span class="font-body-lg text-bold"><%= t("dashboard.new_certification.current_period.hours_value", hours: total_hours_reported) %></span>
-  </p>
-</div>
-
-<%# Additional Hours Needed %>
-<div class="margin-bottom-4">
-  <p class="margin-bottom-05 text-base"><%= t("dashboard.new_certification.current_period.additional_hours_label", target_hours: target_hours) %></p>
-  <% if hours_needed > 0 %>
+<%# Totals — hours shown unless the requirement is income-only; income shown for both income modes. %>
+<% if mode != :income_only %>
+  <div class="margin-bottom-3">
+    <p class="margin-bottom-05 text-base"><%= t("#{i18n}.total_hours_label") %></p>
     <p class="display-flex flex-align-center margin-top-0">
-      <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
-      <span class="font-body-lg text-bold"><%= t("dashboard.new_certification.current_period.hours_value", hours: hours_needed) %></span>
+      <%= status_icon %>
+      <span class="font-body-lg text-bold"><%= t("#{i18n}.hours_value", hours: total_hours_reported) %></span>
     </p>
+  </div>
+<% end %>
+
+<% if mode == :income_only || mode == :combined %>
+  <div class="margin-bottom-3">
+    <p class="margin-bottom-05 text-base"><%= t("#{i18n}.total_income_label") %></p>
+    <p class="display-flex flex-align-center margin-top-0">
+      <%= status_icon %>
+      <span class="font-body-lg text-bold"><%= number_to_currency(compliance.total_income, precision: 2) %></span>
+    </p>
+  </div>
+<% end %>
+
+<%# Additional needed / requirements met. %>
+<div class="margin-bottom-4">
+  <% case mode %>
+  <% when :income_only %>
+    <p class="margin-bottom-05 text-base"><%= t("#{i18n}.additional_income_label", target_income: target_income_display) %></p>
+    <% if compliance.income_needed.to_d.positive? %>
+      <p class="display-flex flex-align-center margin-top-0">
+        <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
+        <span class="font-body-lg text-bold"><%= number_to_currency(compliance.income_needed, precision: 2) %></span>
+      </p>
+    <% else %>
+      <div class="margin-top-0">
+        <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-05", style: "vertical-align: middle;") %>
+        <span class="font-body-lg text-bold" style="vertical-align: middle;"><%= t("#{i18n}.requirements_met", period: current_period&.strftime("%B %Y")) %></span>
+      </div>
+    <% end %>
+  <% when :combined %>
+    <% if summary_met %>
+      <div class="margin-top-0">
+        <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-05", style: "vertical-align: middle;") %>
+        <span class="font-body-lg text-bold" style="vertical-align: middle;"><%= t("#{i18n}.requirements_met", period: current_period&.strftime("%B %Y")) %></span>
+      </div>
+    <% else %>
+      <p class="display-flex flex-align-center margin-top-0">
+        <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
+        <span class="font-body-lg text-bold"><%= t("#{i18n}.combined_additional_needed", target_hours: target_hours, target_income: target_income_display, period_end_date: period_end_display) %></span>
+      </p>
+    <% end %>
   <% else %>
-    <div class="margin-top-0">
-      <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-05", style: "vertical-align: middle;") %>
-      <span class="font-body-lg text-bold" style="vertical-align: middle;"><%= t("dashboard.new_certification.current_period.requirements_met", period: current_period&.strftime("%B %Y")) %></span>
-    </div>
+    <p class="margin-bottom-05 text-base"><%= t("#{i18n}.additional_hours_label", target_hours: target_hours) %></p>
+    <% if hours_needed > 0 %>
+      <p class="display-flex flex-align-center margin-top-0">
+        <%= uswds_icon("warning", size: 4, css_class: "text-gold margin-right-1") %>
+        <span class="font-body-lg text-bold"><%= t("#{i18n}.hours_value", hours: hours_needed) %></span>
+      </p>
+    <% else %>
+      <div class="margin-top-0">
+        <%= uswds_icon("check_circle", size: 4, css_class: "text-green margin-right-05", style: "vertical-align: middle;") %>
+        <span class="font-body-lg text-bold" style="vertical-align: middle;"><%= t("#{i18n}.requirements_met", period: current_period&.strftime("%B %Y")) %></span>
+      </div>
+    <% end %>
   <% end %>
 </div>
-

--- a/reporting-app/app/views/dashboard/_new_certification.html.erb
+++ b/reporting-app/app/views/dashboard/_new_certification.html.erb
@@ -14,6 +14,7 @@
 <% else %>
   <div>
     <%= render "dashboard/compliance_status",
+               compliance: local_assigns[:compliance],
                current_period: current_period,
                target_hours: target_hours,
                period_end_date: period_end_date,

--- a/reporting-app/config/locales/views/dashboard/new_certification.yml
+++ b/reporting-app/config/locales/views/dashboard/new_certification.yml
@@ -9,8 +9,13 @@ en:
       current_period:
         header: "Current period: %{period}"
         requirement_info: "For this period, you will need to report at least %{target_hours} hours of Community Engagement activities by %{period_end_date} in order to keep your Medicaid coverage."
+        requirement_info_income: "For this period, you will need to report at least %{target_income} of income by %{period_end_date} in order to keep your Medicaid coverage."
+        requirement_info_combined: "For this period, you will need to report at least %{target_hours} hours of Community Engagement activities or %{target_income} of income by %{period_end_date} in order to keep your Medicaid coverage."
         total_hours_label: "Total hours reported"
+        total_income_label: "Total income reported"
         additional_hours_label: "Additional hours needed to meet the %{target_hours}-hour requirement"
+        additional_income_label: "Additional income needed to meet the %{target_income} requirement"
+        combined_additional_needed: "Report %{target_hours} hours or %{target_income} of income by %{period_end_date}."
         hours_value: "%{hours} hours"
         requirements_met: "None. You have met the requirement for %{period}."
         report_activities_button: "Report activities for the current period"

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -74,6 +74,57 @@ RSpec.describe CertificationCase, type: :model do
         certification_case.accept_activity_report(user, application_form)
       end.to change { Strata::AuditLine.where(actor: user, subject: certification, action: "case.activity_report.approved").count }.by(1)
     end
+
+    context 'when the member reported income (no hours)' do
+      let(:certification) { Certification.find(certification_case.certification_id) }
+      let(:application_form) { create(:activity_report_application_form, certification_case_id: certification_case.id) }
+      let(:lookback) { certification.certification_requirements.continuous_lookback_period }
+
+      before do
+        create(:income_activity,
+               activity_report_application_form_id: application_form.id,
+               month: lookback.start.to_date.beginning_of_month,
+               income: 70_000)
+      end
+
+      it 'records an income-based compliant determination' do
+        certification_case.accept_activity_report(user, application_form)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.outcome).to eq("compliant")
+        expect(determination.decision_method).to eq("manual")
+        expect(determination.ce_calculation_type).to eq(Determination::CALCULATION_TYPE_INCOME_BASED)
+        expect(determination.reasons).to include("income_reported_compliant")
+        expect(determination.determination_data["total_income"]).to eq(700.0)
+      end
+    end
+
+    context 'when the member reported both income and hours' do
+      let(:certification) { Certification.find(certification_case.certification_id) }
+      let(:application_form) { create(:activity_report_application_form, certification_case_id: certification_case.id) }
+      let(:lookback) { certification.certification_requirements.continuous_lookback_period }
+
+      before do
+        create(:income_activity,
+               activity_report_application_form_id: application_form.id,
+               month: lookback.start.to_date.beginning_of_month,
+               income: 70_000)
+        create(:work_activity,
+               activity_report_application_form_id: application_form.id,
+               month: lookback.start.to_date.beginning_of_month,
+               hours: 90)
+      end
+
+      it 'records a combined compliant determination carrying both tracks' do
+        certification_case.accept_activity_report(user, application_form)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.outcome).to eq("compliant")
+        expect(determination.decision_method).to eq("manual")
+        expect(determination.ce_calculation_type).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+        expect(determination.reasons).to include("hours_reported_compliant", "income_reported_compliant")
+      end
+    end
   end
 
   describe '#deny_activity_report' do

--- a/reporting-app/spec/models/member_dashboard_compliance_spec.rb
+++ b/reporting-app/spec/models/member_dashboard_compliance_spec.rb
@@ -116,6 +116,42 @@ RSpec.describe MemberDashboardCompliance do
     end
   end
 
+  describe "#compliance_summary_mode (OSCER-716)" do
+    def determine(calculation_type, outcome: "compliant", reasons: [ "hours_reported_compliant" ])
+      create(:determination,
+             subject: certification,
+             outcome: outcome,
+             decision_method: "automated",
+             reasons: reasons,
+             determination_data: { "calculation_type" => calculation_type })
+    end
+
+    it "is :combined before any determination (income assumed until product narrows it)" do
+      expect(read_model.compliance_summary_mode).to eq(:combined)
+    end
+
+    it "is :hours_only for an hours-based requirement" do
+      determine(Determination::CALCULATION_TYPE_HOURS_BASED)
+      expect(read_model.compliance_summary_mode).to eq(:hours_only)
+    end
+
+    it "is :income_only for an income-based requirement" do
+      determine(Determination::CALCULATION_TYPE_INCOME_BASED, reasons: [ "income_reported_compliant" ])
+      expect(read_model.compliance_summary_mode).to eq(:income_only)
+    end
+
+    it "is :combined for a combined requirement (hours or income)" do
+      determine(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+      expect(read_model.compliance_summary_mode).to eq(:combined)
+    end
+
+    it "is :hours_only when income is hidden (e.g. an exempt member)" do
+      determine("age_under_19_exempt", outcome: "exempt", reasons: [ "age_under_19_exempt" ])
+      expect(read_model.show_income_summary).to be false
+      expect(read_model.compliance_summary_mode).to eq(:hours_only)
+    end
+  end
+
   describe "#hour_table_rows" do
     before { create_external_hourly(hours: 40, category: "employment") }
 

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -417,6 +417,159 @@ RSpec.describe "dashboard/index", type: :view do
     end
   end
 
+  # The approved-activity-report frame is the surviving render path for the shared
+  # dashboard/_compliance_status current-period summary. OSCER-716 makes that summary show
+  # income / hours / both, driven by MemberDashboardCompliance#compliance_summary_mode, which is
+  # derived from the latest determination's calculation type. Each context pins a calculation type
+  # via a determination, rebuilds the read model, and asserts which summary blocks render.
+  context "when an approved report's CE calculation type drives the current-period summary (OSCER-716)" do
+    let(:activity_report_application_form) do
+      create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+    end
+    let(:lookback) { certification.certification_requirements.continuous_lookback_period }
+    let(:total_hours_label) { I18n.t("dashboard.new_certification.current_period.total_hours_label") }
+    let(:total_income_label) { I18n.t("dashboard.new_certification.current_period.total_income_label") }
+    let(:target_income_display) do
+      ActiveSupport::NumberHelper.number_to_currency(
+        IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY, precision: 0
+      )
+    end
+
+    before do
+      assign(:activity_report_application_form, activity_report_application_form)
+      assign(:certification_case, certification_case)
+      assign(:hours_needed, 0)
+      assign(:total_hours_reported, HoursComplianceDeterminationService::TARGET_HOURS)
+
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
+        total_hours: 85, hours_by_category: {}, hours_by_source: { external: 85, activity: 0 },
+        external_hourly_activity_ids: [], activity_ids: []
+      })
+      ReviewActivityReportTask.find_by(application_form: activity_report_application_form).completed!
+      certification_case.accept_activity_report(nil, activity_report_application_form)
+    end
+
+    # Records a compliant determination of the given calculation type as the latest decision, then
+    # rebuilds the read model so #compliance_summary_mode reflects it.
+    def approve_with_calculation_type(calculation_type, satisfied_by: nil)
+      data = { "calculation_type" => calculation_type }
+      data["satisfied_by"] = satisfied_by if satisfied_by
+      create(:determination, subject: certification, outcome: "compliant", decision_method: "automated",
+             reasons: [ "hours_reported_compliant" ], determination_data: data)
+      reassign_compliance_read_model
+    end
+
+    def create_external_income(gross_income:)
+      create(:external_income_activity, member_id: certification.member_id, category: "employment",
+             gross_income: gross_income, period_start: lookback.start.to_date,
+             period_end: lookback.start.to_date.end_of_month)
+    end
+
+    context "when the CE requirement is hours-based" do
+      before { approve_with_calculation_type(Determination::CALCULATION_TYPE_HOURS_BASED) }
+
+      it "shows the hours summary only, not income" do
+        render
+        expect(rendered).to have_text(total_hours_label)
+        expect(rendered).not_to have_text(total_income_label)
+      end
+
+      it "uses the hours-only requirement intro" do
+        render
+        expect(rendered).to have_text(
+          I18n.t("dashboard.new_certification.current_period.requirement_info",
+                 target_hours: HoursComplianceDeterminationService::TARGET_HOURS,
+                 period_end_date: certification.certification_requirements.due_date.strftime("%B %d, %Y"))
+        )
+      end
+    end
+
+    context "when the CE requirement is income-based" do
+      context "when income still falls short of the target" do
+        before { approve_with_calculation_type(Determination::CALCULATION_TYPE_INCOME_BASED) }
+
+        it "shows the income summary only, not hours" do
+          render
+          expect(rendered).to have_text(total_income_label)
+          expect(rendered).not_to have_text(total_hours_label)
+        end
+
+        it "shows the additional-income-needed label and intro, without the requirements-met message" do
+          render
+          expect(rendered).to have_text(
+            I18n.t("dashboard.new_certification.current_period.additional_income_label",
+                   target_income: target_income_display)
+          )
+          expect(rendered).to have_text(
+            I18n.t("dashboard.new_certification.current_period.requirement_info_income",
+                   target_income: target_income_display,
+                   period_end_date: certification.certification_requirements.due_date.strftime("%B %d, %Y"))
+          )
+          expect(rendered).not_to have_text(
+            I18n.t("dashboard.new_certification.current_period.requirements_met",
+                   period: certification.certification_requirements.certification_date.strftime("%B %Y"))
+          )
+        end
+      end
+
+      context "when income meets the target" do
+        before do
+          create_external_income(gross_income: IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY * 2)
+          approve_with_calculation_type(Determination::CALCULATION_TYPE_INCOME_BASED)
+        end
+
+        it "shows the requirements-met message under the income summary" do
+          render
+          expect(rendered).to have_text(total_income_label)
+          expect(rendered).to have_text(
+            I18n.t("dashboard.new_certification.current_period.requirements_met",
+                   period: certification.certification_requirements.certification_date.strftime("%B %Y"))
+          )
+        end
+      end
+    end
+
+    context "when the CE requirement is combined (hours or income)" do
+      it "shows both the hours and income summaries with the combined intro" do
+        approve_with_calculation_type(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED,
+                                      satisfied_by: Determination::SATISFIED_BY_BOTH)
+        render
+        expect(rendered).to have_text(total_hours_label)
+        expect(rendered).to have_text(total_income_label)
+        expect(rendered).to have_text(
+          I18n.t("dashboard.new_certification.current_period.requirement_info_combined",
+                 target_hours: HoursComplianceDeterminationService::TARGET_HOURS,
+                 target_income: target_income_display,
+                 period_end_date: certification.certification_requirements.due_date.strftime("%B %d, %Y"))
+        )
+      end
+
+      it "shows the single combined 'report hours or income' line when neither target is met" do
+        assign(:hours_needed, HoursComplianceDeterminationService::TARGET_HOURS)
+        assign(:total_hours_reported, 0)
+        approve_with_calculation_type(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED,
+                                      satisfied_by: Determination::SATISFIED_BY_NEITHER)
+        render
+        expect(rendered).to have_text(
+          I18n.t("dashboard.new_certification.current_period.combined_additional_needed",
+                 target_hours: HoursComplianceDeterminationService::TARGET_HOURS,
+                 target_income: target_income_display,
+                 period_end_date: certification.certification_requirements.due_date.strftime("%B %d, %Y"))
+        )
+      end
+
+      it "shows the requirements-met message when hours satisfy the combined requirement" do
+        approve_with_calculation_type(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED,
+                                      satisfied_by: Determination::SATISFIED_BY_HOURS)
+        render
+        expect(rendered).to have_text(
+          I18n.t("dashboard.new_certification.current_period.requirements_met",
+                 period: certification.certification_requirements.certification_date.strftime("%B %Y"))
+        )
+      end
+    end
+  end
+
   context "with an approved exemption request" do
     let (:exemption_application_form) { create(:exemption_application_form, :with_submitted_status, :incarceration, certification_case_id: certification_case.id) }
 


### PR DESCRIPTION
## Ticket

Resolves [OSCER-716](https://github.com/navapbc/oscer/issues/716)

## Changes

- Drives the member dashboard **current-period compliance summary** by the member's CE calculation type so it shows income, hours, or both:
  - Adds `MemberDashboardCompliance#compliance_summary_mode` (`:hours_only` / `:income_only` / `:combined`), a pure accessor derived from `show_income_summary` + `ce_calculation_type`.
  - Reworks `dashboard/_compliance_status` to render hours only (unchanged), income only (hours hidden), or both totals plus a single combined "report X hours or $Y of income" line. Income reads stay gated on `show_income_summary`; the legacy nil-compliance path stays hours-only.
  - Passes `compliance:` into the shared partial from `_activity_report_approved` and `_new_certification`; adds income/combined locale keys under `current_period`.
- Fixes income-reported reports never surfacing on the dashboard after approval: `CertificationCase#accept_activity_report` now records the determination whose **calculation type matches what the member reported** (income / hours / both) instead of always recording an hours-based, 0-hour determination.
  - New private `record_approved_activity_report_determination` branches on member-reported `IncomeActivity` / hourly rows → `income_based`, `hours_based` (unchanged legacy default), or `external_ce_combined`.
  - Outcome stays `:compliant` (approval is a staff decision); combined keeps both compliant reason codes so reasons stay non-empty.

## Context for reviewers

- **Root cause:** the OSCER-716 dashboard gates the income summary on the determination's `ce_calculation_type`. Staff approval always wrote `hours_based`, so an income-only report (e.g. `j1@test.com`, $700 reported) rendered "0 hours / 80 hours needed" and never showed income.
- **Fix location (decision):** corrected at the source (`accept_activity_report`) rather than only patching the dashboard gate, so `ce_calculation_type` is right for every reader (member dashboard, staff views, statistics/BI).
- **Manual approval (decision):** the calculation type is inferred from the reviewed report's activities, matching the existing yes/no approval UI (no staff type toggle).
- **Mixed reports:** a report with both income and hours records `external_ce_combined` with both compliant reason codes; stored `satisfied_by` / nested `compliant` flags still reflect each track's threshold.
- **Open question:** previously approved income reports already stored as `hours_based` are not backfilled — this change only affects new approvals. Confirm whether a backfill is wanted.

## Testing

From `reporting-app/`:

```bash
make lint
make test args='spec/models/certification_case_spec.rb spec/models/member_dashboard_compliance_spec.rb spec/views/dashboard/index.html.erb_spec.rb'
```

- Model spec (`#accept_activity_report`): income-only report records an `income_based` compliant determination; mixed report records an `external_ce_combined` compliant determination with both reason codes; existing hours-only behavior unchanged.
- Model spec: `compliance_summary_mode` returns `:hours_only` / `:income_only` / `:combined`.
- View specs: hours-only, income-only, and combined current-period states.
- Manual: member submits an income-only activity report → staff approve → member dashboard shows income total, $580 target, green "requirements met" (instead of "0 hours / 80 hours needed").

<img width="656" height="630" alt="Screenshot 2026-06-29 at 1 23 28 PM" src="https://github.com/user-attachments/assets/c7ad8359-59df-4df0-891c-e6864139a40f" />
<img width="663" height="655" alt="Screenshot 2026-06-29 at 1 26 41 PM" src="https://github.com/user-attachments/assets/2f8830b8-4cc5-4ad6-b2f2-e6efb48ff0d7" />
<img width="662" height="635" alt="Screenshot 2026-06-29 at 1 28 00 PM" src="https://github.com/user-attachments/assets/7f8b9f26-114f-4a60-b544-5641cc0f28cd" />

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
- Service endpoint: https://p-721-reporting-app-dev-1075019383.us-east-1.elb.amazonaws.com
- Deployed commit: 4cf9aff034f24152f9e976fc888817752f4d57fc
<!-- reporting-app - end PR environment info -->