### PR TITLE
OSCER-717: Remove duplicate previous requirements section on member dashboard

### DIFF
--- a/reporting-app/app/assets/stylesheets/_member_dashboard.scss
+++ b/reporting-app/app/assets/stylesheets/_member_dashboard.scss
@@ -44,23 +44,6 @@
   margin: 0 0 units(2);
 }
 
-.member-dashboard-previous-certifications {
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
-  gap: units(2);
-  margin-top: units(3);
-  padding-bottom: units(4);
-
-  &__intro {
-    max-width: measure(4);
-  }
-
-  .usa-button {
-    width: auto;
-  }
-}
-
 // Get started frame (OSCER-639)
 .member-dashboard-compliance {
   &__alert {

--- a/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
+++ b/reporting-app/app/views/dashboard/_activity_report_approved.html.erb
@@ -33,9 +33,4 @@
   <div class="margin-bottom-4">
     <%= link_to t(".view_activity_report_button"), activity_report_application_form_path(activity_report), class: "usa-button" %>
   </div>
-
-  <%# Previously Completed Requirements Section %>
-  <h2 class="font-heading-lg margin-top-6 margin-bottom-2"><%= t("dashboard.new_certification.previous_requirements.header") %></h2>
-  <p class="margin-bottom-2"><%= t("dashboard.new_certification.previous_requirements.intro") %></p>
-  <%= link_to t("dashboard.new_certification.previous_requirements.button"), certifications_path, class: "usa-button usa-button--outline" %>
 </div>

--- a/reporting-app/app/views/dashboard/_previous_certifications.html.erb
+++ b/reporting-app/app/views/dashboard/_previous_certifications.html.erb
@@ -1,10 +1,10 @@
-<%# Rendered once from dashboard/index when the member has prior completed certification periods. %>
-<section class="member-dashboard-previous-certifications" aria-labelledby="previous-certifications-heading">
-  <h2 id="previous-certifications-heading" class="font-heading-lg margin-0"><%= t("dashboard.index.previous_certifications.title") %></h2>
-  <p class="member-dashboard-previous-certifications__intro font-serif-md margin-0">
-    <%= t("dashboard.index.previous_certifications.intro") %>
-  </p>
+<%# Rendered once from dashboard/index when the member has prior completed certification
+    periods. In-div placement inside the content column (OSCER-717) — the canonical
+    "previously completed requirements" block for every dashboard frame. %>
+<div class="grid-container">
+  <h2 class="font-heading-lg margin-top-6 margin-bottom-2"><%= t("dashboard.index.previous_certifications.title") %></h2>
+  <p class="margin-bottom-2"><%= t("dashboard.index.previous_certifications.intro") %></p>
   <%= link_to t("dashboard.index.previous_certifications.review_previous_certifications_button"),
         certifications_path,
         class: "usa-button usa-button--outline" %>
-</section>
+</div>

--- a/reporting-app/app/views/dashboard/_previous_certifications.html.erb
+++ b/reporting-app/app/views/dashboard/_previous_certifications.html.erb
@@ -1,10 +1,12 @@
 <%# Rendered once from dashboard/index when the member has prior completed certification
     periods. In-div placement inside the content column (OSCER-717) — the canonical
     "previously completed requirements" block for every dashboard frame. %>
-<div class="grid-container">
-  <h2 class="font-heading-lg margin-top-6 margin-bottom-2"><%= t("dashboard.index.previous_certifications.title") %></h2>
-  <p class="margin-bottom-2"><%= t("dashboard.index.previous_certifications.intro") %></p>
-  <%= link_to t("dashboard.index.previous_certifications.review_previous_certifications_button"),
-        certifications_path,
-        class: "usa-button usa-button--outline" %>
-</div>
+<section aria-labelledby="previous-certifications-heading">
+  <div class="grid-container">
+    <h2 id="previous-certifications-heading" class="font-heading-lg margin-top-6 margin-bottom-2"><%= t("dashboard.index.previous_certifications.title") %></h2>
+    <p class="margin-bottom-2"><%= t("dashboard.index.previous_certifications.intro") %></p>
+    <%= link_to t("dashboard.index.previous_certifications.review_previous_certifications_button"),
+          certifications_path,
+          class: "usa-button usa-button--outline" %>
+  </div>
+</section>

--- a/reporting-app/config/locales/views/dashboard/en.yml
+++ b/reporting-app/config/locales/views/dashboard/en.yml
@@ -20,7 +20,7 @@ en:
         in_progress_applications:
           heading: "In-progress exemption applications"
       previous_certifications:
-        title: "Previous completed requirements"
+        title: "Previously completed requirements"
         intro: "Review previously-completed certifications."
         review_previous_certifications_button: "Review previous certifications"
     member_compliance:

--- a/reporting-app/config/locales/views/dashboard/new_certification.yml
+++ b/reporting-app/config/locales/views/dashboard/new_certification.yml
@@ -16,10 +16,6 @@ en:
         report_activities_button: "Report activities for the current period"
         request_exemption_button: "Request exemption"
         view_activity_report_button: "View activity report"
-      previous_requirements:
-        header: "Previously completed requirements"
-        intro: "Review previously-completed certifications."
-        button: "Review previous certifications"
       activities:
         header: "Activities & Exemptions"
       activity_report:

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -415,6 +415,34 @@ RSpec.describe "dashboard/index", type: :view do
       render
       expect(rendered).not_to have_css('.member-dashboard-compliance__onboarding')
     end
+
+    context "with a completed prior certification period (OSCER-717)" do
+      let(:older_certification) { create(:certification, member_data: member_data) }
+
+      before do
+        create(:certification_case, certification: older_certification)
+        create(:determination,
+               subject: older_certification,
+               outcome: "compliant",
+               decision_method: "manual",
+               reasons: [ "hours_reported_compliant" ])
+        older_certification.update!(created_at: 2.months.ago)
+        certification.update!(created_at: 1.day.ago)
+        assign(:all_certifications, [ certification, older_certification ])
+        assign(:previous_completed_certifications,
+               MemberStatusService.previous_completed_certifications(
+                 [ certification, older_certification ],
+                 current_certification: certification
+               ))
+      end
+
+      it 'renders the previously-completed requirements section exactly once' do
+        render
+        title = I18n.t('dashboard.index.previous_certifications.title')
+        expect(rendered.scan(title).length).to eq(1)
+        expect(rendered).to have_selector('h2', text: title)
+      end
+    end
   end
 
   context "with an approved exemption request" do

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -436,6 +436,7 @@ RSpec.describe "dashboard/index", type: :view do
 
     context "with a completed prior certification period (OSCER-717)" do
       before { assign_previous_completed_certification_period }
+
       it 'renders the previously-completed requirements section exactly once after the approved-frame CTA' do
         render
         title = I18n.t('dashboard.index.previous_certifications.title')
@@ -973,6 +974,7 @@ RSpec.describe "dashboard/index", type: :view do
 
   context "with a completed prior certification period" do
     before { assign_previous_completed_certification_period }
+
     it 'renders a section for previous certifications' do
       render
       expect(rendered).to have_selector('h2', text: I18n.t('dashboard.index.previous_certifications.title'))

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe "dashboard/index", type: :view do
            ))
   end
 
+  def assign_previous_completed_certification_period
+    older_certification = create(:certification, member_data: member_data)
+    create(:certification_case, certification: older_certification)
+    create(:determination,
+           subject: older_certification,
+           outcome: "compliant",
+           decision_method: "manual",
+           reasons: [ "hours_reported_compliant" ])
+    older_certification.update!(created_at: 2.months.ago)
+    certification.update!(created_at: 1.day.ago)
+    assign(:all_certifications, [ certification, older_certification ])
+    assign(:previous_completed_certifications,
+           MemberStatusService.previous_completed_certifications(
+             [ certification, older_certification ],
+             current_certification: certification
+           ))
+  end
+
   context 'with no current exemption or activity report' do
     it 'renders the Figma welcome hero copy via the dashboard layout banner' do
       render inline: <<~ERB.squish, type: :erb
@@ -417,30 +435,17 @@ RSpec.describe "dashboard/index", type: :view do
     end
 
     context "with a completed prior certification period (OSCER-717)" do
-      let(:older_certification) { create(:certification, member_data: member_data) }
-
-      before do
-        create(:certification_case, certification: older_certification)
-        create(:determination,
-               subject: older_certification,
-               outcome: "compliant",
-               decision_method: "manual",
-               reasons: [ "hours_reported_compliant" ])
-        older_certification.update!(created_at: 2.months.ago)
-        certification.update!(created_at: 1.day.ago)
-        assign(:all_certifications, [ certification, older_certification ])
-        assign(:previous_completed_certifications,
-               MemberStatusService.previous_completed_certifications(
-                 [ certification, older_certification ],
-                 current_certification: certification
-               ))
-      end
-
-      it 'renders the previously-completed requirements section exactly once' do
+      before { assign_previous_completed_certification_period }
+      it 'renders the previously-completed requirements section exactly once after the approved-frame CTA' do
         render
         title = I18n.t('dashboard.index.previous_certifications.title')
+        view_report_label = I18n.t('dashboard.activity_report_approved.view_activity_report_button')
+
         expect(rendered.scan(title).length).to eq(1)
-        expect(rendered).to have_selector('h2', text: title)
+        expect(rendered).to have_css('section[aria-labelledby="previous-certifications-heading"]')
+        expect(rendered).to have_selector('h2#previous-certifications-heading', text: title)
+        expect(rendered.index(view_report_label)).to be < rendered.index(title)
+        expect(rendered).not_to have_css('.member-dashboard-previous-certifications')
       end
     end
   end
@@ -967,25 +972,7 @@ RSpec.describe "dashboard/index", type: :view do
   end
 
   context "with a completed prior certification period" do
-    let(:older_certification) { create(:certification, member_data: member_data) }
-
-    before do
-      create(:certification_case, certification: older_certification)
-      create(:determination,
-             subject: older_certification,
-             outcome: "compliant",
-             decision_method: "manual",
-             reasons: [ "hours_reported_compliant" ])
-      older_certification.update!(created_at: 2.months.ago)
-      certification.update!(created_at: 1.day.ago)
-      assign(:all_certifications, [ certification, older_certification ])
-      assign(:previous_completed_certifications,
-             MemberStatusService.previous_completed_certifications(
-               [ certification, older_certification ],
-               current_certification: certification
-             ))
-    end
-
+    before { assign_previous_completed_certification_period }
     it 'renders a section for previous certifications' do
       render
       expect(rendered).to have_selector('h2', text: I18n.t('dashboard.index.previous_certifications.title'))


### PR DESCRIPTION
## Ticket

Resolves [OSCER-717](https://github.com/navapbc/oscer/issues/717)

## Changes

- Consolidate the member dashboard "previously completed requirements" section into the shared `_previous_certifications.html.erb` partial using in-div markup inside `div.grid-container` (content column), replacing the full-width `section.member-dashboard-previous-certifications` breakout.
- Remove the duplicate inline block from `_activity_report_approved.html.erb`; the section now renders once from `dashboard/index.html.erb` when `@previous_completed_certifications.present?`.
- Unify copy to **"Previously completed requirements"** under `dashboard.index.previous_certifications.title` and remove orphaned `dashboard.new_certification.previous_requirements` locale keys.
- Remove unused `.member-dashboard-previous-certifications` SCSS.
- Extend `spec/views/dashboard/index.html.erb_spec.rb` to assert the section renders exactly once on the approved activity-report frame when prior completed certifications exist.

## Context for reviewers

- Follows the recommended approach in OSCER-717: the in-div placement is canonical across all dashboard frames; deleting only the shared render would have stripped previous-certs from non-approved frames.
- The shared partial wraps content in `div.grid-container` so it aligns with frames like `_activity_report_approved` that use the same column layout.
- Out of scope: `certifications_path` link destination (still `/staff/certifications` per existing routing).

## Testing

- `cd reporting-app && make test args='spec/views/dashboard/index.html.erb_spec.rb'` — 78 examples, 0 failures (SimpleCov may exit non-zero on a single-file run).
- `cd reporting-app && make lint` — no offenses.
- Manual: log in as a member with a current certification and at least one prior completed period; on the post-approval dashboard, confirm "Previously completed requirements" appears once in the content column with the outline "Review previous certifications" button, and the old full-width bottom section is gone.

<img width="590" height="708" alt="Screenshot 2026-06-30 at 12 41 10 PM" src="https://github.com/user-attachments/assets/328089ce-7f52-4a63-ba79-60c71d266b57" />

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->