### PR TITLE
Declare ruby-vips explicitly for image_processing 2.0

### DIFF
--- a/reporting-app/Gemfile
+++ b/reporting-app/Gemfile
@@ -67,6 +67,8 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.14"
+# image_processing 2.0 makes ruby-vips a peer dependency; declare the Vips backend explicitly.
+gem "ruby-vips", "~> 2.0"
 
 # Authentication and Authorization
 gem "aws-sdk-cognitoidentityprovider", "~> 1.145"

--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -742,6 +742,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-lsp
   ruby-lsp-rails
+  ruby-vips (~> 2.0)
   selenium-webdriver
   simplecov
   sprockets-rails


### PR DESCRIPTION
## Ticket

No standalone issue. Prerequisite for #591 (Bump image_processing from 1.14.0 to 2.0.1 in /reporting-app).

## Changes

- Declare `gem "ruby-vips", "~> 2.0"` as a direct dependency (Gemfile + Gemfile.lock).

## Context for reviewers

image_processing 2.0 demotes `ruby-vips` and `mini_magick` from hard dependencies to peer dependencies, so the chosen backend must be declared explicitly. `ImageToPdfConversionService` does `require "image_processing/vips"` to convert images over 5MB to PDF for the DocAI API, which under 2.0 fails at load with `LoadError: cannot load such file -- vips`.

Declaring `ruby-vips` is a no-op on the current 1.14 line (ruby-vips 2.3.0 is already resolved transitively), so this PR is safe to merge on its own. Merge order: land this first, then `@dependabot rebase` #591 so it picks up the declaration and goes green.

`mini_magick` is intentionally not declared: the app uses only the Vips backend.

## Testing

Verified in-container: with image_processing temporarily bumped to 2.0 and `ruby-vips` declared, `spec/services/image_to_pdf_conversion_service_spec.rb` passed (12 examples, 0 failures). Reverted the temporary bump so the branch contains only the `ruby-vips` declaration.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->