### PR TITLE
OSCER-733: Rename exemption in backend flow

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -2,7 +2,7 @@
 
 class CertificationBusinessProcess < Strata::BusinessProcess
   # Determination steps
-  EXTERNAL_EXEMPTION_CHECK_STEP = "external_exemption_check"
+  EXTERNAL_EXCLUSION_CHECK_STEP = "external_exclusion_check"
   EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP = "external_community_engagement_check"
 
   # User task steps
@@ -15,8 +15,8 @@ class CertificationBusinessProcess < Strata::BusinessProcess
 
   # --- System processes: Determination ---
   # Notifications are sent via NotificationsEventListener which subscribes to domain events
-  system_process(EXTERNAL_EXEMPTION_CHECK_STEP, ->(kase) {
-    ExemptionDeterminationService.determine(kase)
+  system_process(EXTERNAL_EXCLUSION_CHECK_STEP, ->(kase) {
+    ExclusionDeterminationService.determine(kase)
   })
 
   # External CE: see CommunityEngagementCheckService (combined hours/income determination + events).
@@ -31,13 +31,13 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   staff_task(REVIEW_DENIAL_RESPONSE_STEP, ReviewDenialResponseTask)
 
   # --- Start ---
-  start(EXTERNAL_EXEMPTION_CHECK_STEP, on: "CertificationCreated") do |event|
+  start(EXTERNAL_EXCLUSION_CHECK_STEP, on: "CertificationCreated") do |event|
     CertificationCase.new(certification_id: event[:payload][:certification_id])
   end
 
-  # --- Transitions: External exemption check ---
-  transition(EXTERNAL_EXEMPTION_CHECK_STEP, "DeterminedNotExempt", EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP)
-  transition(EXTERNAL_EXEMPTION_CHECK_STEP, "DeterminedExempt", END_STEP)
+  # --- Transitions: External exclusion check ---
+  transition(EXTERNAL_EXCLUSION_CHECK_STEP, "DeterminedNotExcluded", EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP)
+  transition(EXTERNAL_EXCLUSION_CHECK_STEP, "DeterminedExcluded", END_STEP)
 
   # --- Transitions: External CE check (combined hours/income; generic community-engagement event names) ---
   # DeterminedCommunityEngagementMet: At least one CE track (hours or income) satisfied

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -183,11 +183,11 @@ class CertificationCase < Strata::Case
     Strata::EventManager.publish(event_name, { case_id: id, certification_id: certification_id, application_form_id: application_form.id })
   end
 
-  # Called by ExemptionDeterminationService to record exemption determination
+  # Called by ExclusionDeterminationService to record exclusion determination
   # Model only handles state changes - service handles events
   # @param eligibility_fact [Strata::RulesEngine::Fact] the evaluation result
-  # @param actor [Strata::VirtualActor] recording the exemption
-  def record_exemption_determination(eligibility_fact, actor)
+  # @param actor [Strata::VirtualActor] recording the exclusion
+  def record_exclusion_determination(eligibility_fact, actor)
     certification = Certification.find(certification_id)
 
     transaction do
@@ -199,14 +199,14 @@ class CertificationCase < Strata::Case
       certification.record_determination!(
         decision_method: :automated,
         reasons: reason_codes,
-        outcome: :exempt,
+        outcome: :excluded,
         # determination_data is a jsonb column holding a structured Hash (OSCER convention; see
-        # the Determination docs). For automated exemptions the type is carried by the reason
+        # the Determination docs). For automated exclusions the type is carried by the reason
         # codes, which the dashboard reads via decision_method branching, so we record those
         # codes here. It must stay a Hash: writing a JSON String (e.g. reasons.to_json)
         # double-encodes into the jsonb column and reads back as a String, which 500'd the
         # member dashboard. See https://github.com/navapbc/oscer/issues/680.
-        determination_data: { "exemption_reasons" => reason_codes },
+        determination_data: { "exclusion_reasons" => reason_codes },
         determined_at: certification.certification_requirements.certification_date,
         actor:
       )

--- a/reporting-app/app/models/concerns/determinable.rb
+++ b/reporting-app/app/models/concerns/determinable.rb
@@ -18,7 +18,7 @@
 #   record.record_determination!(
 #     decision_method: :automated,
 #     reasons: ["pregnant_member"],
-#     outcome: :automated_exemption,
+#     outcome: :automated_exclusion,
 #     determination_data: rules_engine.evaluate(:pregnant_member).reasons,
 #     determined_at: Time.current
 #   )
@@ -59,7 +59,9 @@ module Determinable
     )
 
     determination_method =
-      if (reasons & Determination::EXEMPTION_REASONS).any?
+      if outcome.to_sym == :excluded
+        :exclusion
+      elsif (reasons & Determination::EXEMPTION_REASONS).any?
         :exemption
       elsif (reasons & Determination::DENIAL_RESPONSE_REASONS).any?
         :denial_response

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -62,16 +62,16 @@ class Determination < Strata::Determination
   CALCULATION_METHOD_AUTOMATED_INCOME_INTAKE = "automated_income_intake"
 
   REASON_CODE_MAPPING = {
-    age_under_19: "age_under_19_exempt",
-    age_over_65: "age_over_65_exempt",
-    is_pregnant: "pregnancy_exempt",
-    is_american_indian_or_alaska_native: "american_indian_alaska_native_exempt",
+    age_under_19: "age_under_19_excluded",
+    age_over_65: "age_over_65_excluded",
+    is_pregnant: "pregnancy_excluded",
+    is_american_indian_or_alaska_native: "american_indian_alaska_native_excluded",
     income_reported_compliant: "income_reported_compliant",
     income_reported_insufficient: "income_reported_insufficient",
     hours_reported_compliant: "hours_reported_compliant",
     hours_reported_insufficient: "hours_reported_insufficient",
     exemption_request_compliant: "exemption_request_compliant",
-    is_veteran_with_disability: "veteran_disability_exempt",
+    is_veteran_with_disability: "veteran_disability_excluded",
     denial_response_convincing: "denial_response_convincing",
     denial_response_not_convincing: "denial_response_not_convincing"
   }.freeze
@@ -94,7 +94,7 @@ class Determination < Strata::Determination
   VALID_REASONS = REASON_CODE_MAPPING.values.freeze
 
   enum :decision_method, { automated: "automated", manual: "manual" }
-  enum :outcome, { compliant: "compliant", exempt: "exempt", not_compliant: "not_compliant" }
+  enum :outcome, { compliant: "compliant", exempt: "exempt", excluded: "excluded", not_compliant: "not_compliant" }
 
   validates :reasons, presence: true, inclusion: { in: VALID_REASONS }
 

--- a/reporting-app/app/models/member_dashboard_compliance.rb
+++ b/reporting-app/app/models/member_dashboard_compliance.rb
@@ -404,15 +404,17 @@ class MemberDashboardCompliance
     rows
   end
 
-  # Exempt-outcome determinations (automated eligibility and staff/form approvals) plus
-  # in-flight exemption application rows when the case is not yet approved.
+  # Exemption/exclusion-outcome determinations (automated exclusion eligibility and staff/form
+  # approvals) plus in-flight exemption application rows when the case is not yet approved.
+  # Automated exclusions record +outcome: :excluded+; manual exemption approvals record
+  # +outcome: :exempt+ — both belong in this history.
   def build_exemption_history
     entries = []
 
     determination_rows = Determination
       .unscope(:order)
       .where(subject_type: "Certification", subject_id: @certification.id)
-      .where(outcome: :exempt)
+      .where(outcome: [ :exempt, :excluded ])
       .order(determined_at: :desc, created_at: :desc)
       .to_a
 
@@ -474,7 +476,7 @@ class MemberDashboardCompliance
   # automated row from ever reaching the Hash read (see #680).
   def exemption_history_type_for_determination(det)
     if det.decision_method == "automated"
-      # The row is already +outcome: :exempt+, so its reasons are exemption reasons; the
+      # The row is already +outcome: :excluded+, so its reasons are exclusion reasons; the
       # reason code is the type. No need to inspect determination_data.
       reason = Array(det.reasons).first
       reason ? [ reason, exemption_reason_label(reason) ] : unknown_exemption_type

--- a/reporting-app/app/models/member_status.rb
+++ b/reporting-app/app/models/member_status.rb
@@ -29,7 +29,7 @@
 #   status = MemberStatusService.determine(certification)
 #   status.status # => "compliant"
 #   status.determination_method # => "automated"
-#   status.reason_codes # => ["age_under_19_exempt"]
+#   status.reason_codes # => ["age_under_19_excluded"]
 #   status.latest_determination # => <Determination ...> or nil
 class MemberStatus < Strata::ValueObject
   # Stable tokens for member dashboard / OSCER-480 (display copy is client-side i18n).

--- a/reporting-app/app/models/rules/custom/README.md
+++ b/reporting-app/app/models/rules/custom/README.md
@@ -5,10 +5,10 @@ here, namespaced under `Rules::Custom::`.
 
 ## Example
 
-    # app/models/rules/custom/exemption_ruleset.rb
+    # app/models/rules/custom/exclusion_ruleset.rb
     module Rules
       module Custom
-        class ExemptionRuleset < Rules::ExemptionRuleset
+        class ExclusionRuleset < Rules::ExclusionRuleset
           # deployment-specific rule methods + composition override
         end
       end

--- a/reporting-app/app/models/rules/exclusion_ruleset.rb
+++ b/reporting-app/app/models/rules/exclusion_ruleset.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Rules
-  # Implements eligibility rules for age-based Medicaid exemptions.
-  # Inherits from Strata::Rules::MedicaidRuleset and adds exemption-specific logic.
-  class ExemptionRuleset < Strata::Rules::MedicaidRuleset
+  # Implements eligibility rules for age-based Medicaid exclusions.
+  # Inherits from Strata::Rules::MedicaidRuleset and adds exclusion-specific logic.
+  class ExclusionRuleset < Strata::Rules::MedicaidRuleset
     AMERICAN_INDIAN_OR_ALASKA_NATIVE = [ "american_indian_or_alaska_native", "american_indian", "alaska_native" ].freeze
 
     def age_under_19(age)
@@ -33,7 +33,7 @@ module Rules
       combined_rating.to_i == 100
     end
 
-    def eligible_for_exemption(age_under_19, age_over_65, is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability)
+    def eligible_for_exclusion(age_under_19, age_over_65, is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability)
       facts = [ age_under_19, age_over_65, is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability ]
       return if facts.all?(&:nil?)
 

--- a/reporting-app/app/services/custom/README.md
+++ b/reporting-app/app/services/custom/README.md
@@ -5,16 +5,16 @@ here, namespaced under `Custom::`.
 
 ## Example
 
-    # app/services/custom/exemption_determination_service.rb
+    # app/services/custom/exclusion_determination_service.rb
     module Custom
-      class ExemptionDeterminationService < ::ExemptionDeterminationService
+      class ExclusionDeterminationService < ::ExclusionDeterminationService
         # deployment-specific overrides
       end
     end
 
 Note: OSCER's services live flat under `app/services/` with no `Services::`
 namespace, so the parent class is referenced as
-`::ExemptionDeterminationService` (not `::Services::ExemptionDeterminationService`).
+`::ExclusionDeterminationService` (not `::Services::ExclusionDeterminationService`).
 By contrast, `Rules::` and `Custom::` ARE proper namespaces. The full
 namespacing guidance is in CUSTOMIZATION.md.
 

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-class ExemptionDeterminationService
+class ExclusionDeterminationService
   include Strata::VirtualActor
   class << self
-    # Called by CertificationBusinessProcess at EXTERNAL_EXEMPTION_CHECK_STEP
+    # Called by CertificationBusinessProcess at EXTERNAL_EXCLUSION_CHECK_STEP
     # Service handles: evaluation, recording via model, and publishing events
     # Business process handles: transitions and notifications
     # @param kase [CertificationCase]
     def determine(kase)
       certification = Certification.find(kase.certification_id)
-      eligibility_fact = evaluate_exemption_eligibility(certification)
+      eligibility_fact = evaluate_exclusion_eligibility(certification)
 
       if eligibility_fact.value
-        kase.record_exemption_determination(eligibility_fact, self)
-        Strata::EventManager.publish("DeterminedExempt", { case_id: kase.id, certification_id: kase.certification_id })
+        kase.record_exclusion_determination(eligibility_fact, self)
+        Strata::EventManager.publish("DeterminedExcluded", { case_id: kase.id, certification_id: kase.certification_id })
       else
         Strata::AuditLog.write!(
           action: "case.exemption.denied",
           actor: self,
           subject: certification,
         )
-        Strata::EventManager.publish("DeterminedNotExempt", { case_id: kase.id, certification_id: kase.certification_id })
+        Strata::EventManager.publish("DeterminedNotExcluded", { case_id: kase.id, certification_id: kase.certification_id })
       end
     end
 
     private
 
-    def evaluate_exemption_eligibility(certification)
-      ruleset = Rules::ExemptionRuleset.new
+    def evaluate_exclusion_eligibility(certification)
+      ruleset = Rules::ExclusionRuleset.new
       engine = Strata::RulesEngine.new(ruleset)
 
       evaluation_date = extract_evaluation_date(certification)
@@ -44,7 +44,7 @@ class ExemptionDeterminationService
         veteran_disability_rating: veteran_disability_rating
       )
 
-      engine.evaluate(:eligible_for_exemption)
+      engine.evaluate(:eligible_for_exclusion)
     end
 
     def extract_evaluation_date(certification)

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -16,7 +16,7 @@ class ExclusionDeterminationService
         Strata::EventManager.publish("DeterminedExcluded", { case_id: kase.id, certification_id: kase.certification_id })
       else
         Strata::AuditLog.write!(
-          action: "case.exemption.denied",
+          action: "case.exclusion.denied",
           actor: self,
           subject: certification,
         )

--- a/reporting-app/app/services/member_status_service.rb
+++ b/reporting-app/app/services/member_status_service.rb
@@ -161,7 +161,11 @@ class MemberStatusService
 
     def status_from_determination(determination)
       MemberStatus.new(
-        status: determination.outcome,
+        # Automated exclusions record +outcome: "excluded"+, but the member-facing status
+        # (dashboards, staff filters) treats them identically to manual exemptions, so surface
+        # them as +MemberStatus::EXEMPT+. Only the Determination enum, domain events, and API
+        # outcome carry the distinct "excluded" value.
+        status: determination.outcome == "excluded" ? MemberStatus::EXEMPT : determination.outcome,
         determination_method: determination.decision_method,
         reason_codes: determination.reasons,
         human_readable_reason_codes: human_readable_reason_codes(determination.reasons),

--- a/reporting-app/app/services/notifications_event_listener.rb
+++ b/reporting-app/app/services/notifications_event_listener.rb
@@ -4,7 +4,8 @@
 # This decouples notifications from the business process workflow.
 #
 # Subscribed events and their notifications:
-# - DeterminedExempt → exempt_email
+# - DeterminedExempt (manual exemption approval) → exempt_email
+# - DeterminedExcluded (automated exclusion) → exempt_email
 # - DeterminedHoursMet / DeterminedCommunityEngagementMet → compliant_email
 # - DeterminedCommunityEngagementActionRequired → action_required_email
 # - DeterminedHoursInsufficient → insufficient_hours_email
@@ -32,6 +33,7 @@ class NotificationsEventListener
   class << self
     def subscribe
       Strata::EventManager.subscribe("DeterminedExempt", method(:handle_exempt))
+      Strata::EventManager.subscribe("DeterminedExcluded", method(:handle_exempt))
       Strata::EventManager.subscribe("DeterminedHoursMet", method(:handle_compliant))
       Strata::EventManager.subscribe("DeterminedCommunityEngagementMet", method(:handle_compliant))
       Strata::EventManager.subscribe("DeterminedCommunityEngagementActionRequired", method(:handle_action_required))

--- a/reporting-app/config/locales/services/en.yml
+++ b/reporting-app/config/locales/services/en.yml
@@ -2,11 +2,11 @@ en:
   services:
     member_status_service:
       reason_codes:
-        age_under_19_exempt: "Age under 19"
-        age_over_65_exempt: "Age over 65"
-        pregnancy_exempt: "Pregnant"
-        american_indian_alaska_native_exempt: "American Indian or Alaska Native"
-        veteran_disability_exempt: "Veteran with a disability"
+        age_under_19_excluded: "Age under 19"
+        age_over_65_excluded: "Age over 65"
+        pregnancy_excluded: "Pregnant"
+        american_indian_alaska_native_excluded: "American Indian or Alaska Native"
+        veteran_disability_excluded: "Veteran with a disability"
         income_reported_compliant: "Income reported compliant"
         income_reported_insufficient: "Insufficient community engagement income"
         hours_reported_compliant: "Hours reported compliant"

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -455,12 +455,12 @@
           "properties": {
             "status": {
               "type": "string",
-              "enum": ["compliant", "exempt", "indeterminate", "not_compliant"],
+              "enum": ["compliant", "excluded", "exempt", "indeterminate", "not_compliant"],
               "description": "Current status of community engagement requirement checks"
             },
             "reason": {
               "type": ["string", "null"],
-              "description": "Which exemption or community engagement requirement led to the decision"
+              "description": "Which exclusion, exemption, or community engagement requirement led to the decision"
             },
             "source": {
               "type": ["string", "null"],

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -411,6 +411,7 @@ components:
           type: string
           enum:
           - compliant
+          - excluded
           - exempt
           - indeterminate
           - not_compliant
@@ -419,8 +420,8 @@ components:
           type:
           - string
           - 'null'
-          description: Which exemption or community engagement requirement led to
-            the decision
+          description: Which exclusion, exemption, or community engagement requirement
+            led to the decision
         source:
           type:
           - string
@@ -544,67 +545,67 @@ components:
       required:
       - status
   responses:
-    bbc58451e136445e51391950dfc43e52:
+    b8f2f38bc8c2f6235cbe11844e1f22e6:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    413df1346fbd78e0037f734a39d43471:
+    83f294ae63467238e4f35a0cad57a3ea:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    a9c14c94489f2b6c680cc7fff0d981b1:
+    503ff0a2127a2fff361cb1db9ebe3428:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    b705e43dde6e758df805ef7d6179338d:
+    a27e926ab0dbb7017819cbd94b436cb0:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    ae98cd8787744c5b8f9cebfa21ed232f:
+    14dcafc2f5493e99a23abd80ec1c0d54:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    947f8afb8a1d8ec3dc134063f5d248b8:
+    ef12758e50a588b4630a6c74ce376fd2:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    2ea54980a924f49960f28c36d53b8b29:
+    71f1a8f0db1028f1e43e425cfbcdc546:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    2f9f0898599a96c58cc458e912534842:
+    8a9bf8f59f62d05218c6701932491f46:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    cbcaae5073d0b2840911a702b0f2b7ec:
+    bb50fff96a9fd952e87329ae102a1d6b:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    6fd40f52462b56742fc75e6a3a029ce2:
+    9dc2f80603cf140b44be92b75d34f111:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    a9e22e7abc08f3257262c111ae4e414e:
+    74d65d516ee19718a9f33d523da50238:
       description: Response
       content:
         application/json:
@@ -636,7 +637,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    06d01602213d6565834a7d60cde121c5:
+    bf9dfb13c9c40fce7127413e9a7d0f6e:
       description: The Certification data.
       content:
         application/json:
@@ -729,11 +730,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/bbc58451e136445e51391950dfc43e52"
+          "$ref": "#/components/responses/b8f2f38bc8c2f6235cbe11844e1f22e6"
         '202':
-          "$ref": "#/components/responses/413df1346fbd78e0037f734a39d43471"
+          "$ref": "#/components/responses/83f294ae63467238e4f35a0cad57a3ea"
         '404':
-          "$ref": "#/components/responses/a9c14c94489f2b6c680cc7fff0d981b1"
+          "$ref": "#/components/responses/503ff0a2127a2fff361cb1db9ebe3428"
       security:
       - hmac: []
       deprecated: false
@@ -747,16 +748,16 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/06d01602213d6565834a7d60cde121c5"
+        "$ref": "#/components/requestBodies/bf9dfb13c9c40fce7127413e9a7d0f6e"
       responses:
         '201':
-          "$ref": "#/components/responses/b705e43dde6e758df805ef7d6179338d"
+          "$ref": "#/components/responses/a27e926ab0dbb7017819cbd94b436cb0"
         '202':
-          "$ref": "#/components/responses/ae98cd8787744c5b8f9cebfa21ed232f"
+          "$ref": "#/components/responses/14dcafc2f5493e99a23abd80ec1c0d54"
         '400':
-          "$ref": "#/components/responses/947f8afb8a1d8ec3dc134063f5d248b8"
+          "$ref": "#/components/responses/ef12758e50a588b4630a6c74ce376fd2"
         '422':
-          "$ref": "#/components/responses/2ea54980a924f49960f28c36d53b8b29"
+          "$ref": "#/components/responses/71f1a8f0db1028f1e43e425cfbcdc546"
       security:
       - hmac: []
       deprecated: false
@@ -771,9 +772,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/2f9f0898599a96c58cc458e912534842"
+          "$ref": "#/components/responses/8a9bf8f59f62d05218c6701932491f46"
         '404':
-          "$ref": "#/components/responses/cbcaae5073d0b2840911a702b0f2b7ec"
+          "$ref": "#/components/responses/bb50fff96a9fd952e87329ae102a1d6b"
       security:
       - hmac: []
       deprecated: false
@@ -808,9 +809,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/6fd40f52462b56742fc75e6a3a029ce2"
+          "$ref": "#/components/responses/9dc2f80603cf140b44be92b75d34f111"
         '503':
-          "$ref": "#/components/responses/a9e22e7abc08f3257262c111ae4e414e"
+          "$ref": "#/components/responses/74d65d516ee19718a9f33d523da50238"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       })
   end
 
-  describe 'external_exemption_check' do
+  describe 'external_exclusion_check' do
     before do
       certification_case.update!(
-        business_process_current_step: CertificationBusinessProcess::EXTERNAL_EXEMPTION_CHECK_STEP
+        business_process_current_step: CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP
       )
     end
 
-    context 'when applicant is eligible for exemption' do
+    context 'when applicant is eligible for exclusion' do
       let(:age_fact) do
         Strata::RulesEngine::Fact.new(
           :age_under_19, true, reasons: []
@@ -58,14 +58,14 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       end
 
       it 'transitions to end' do
-        # Step 1: Case has been created and is on external_exemption_check step
-        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXEMPTION_CHECK_STEP)
+        # Step 1: Case has been created and is on external_exclusion_check step
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP)
         expect(certification_case.member_status).to eq(MemberStatus::AWAITING_REPORT)
         expect(certification_case).to be_open
 
-        # Step 2: System process determines applicant is eligible for exemption
-        certification_case.record_exemption_determination(eligibility_fact, ExemptionDeterminationService)
-        Strata::EventManager.publish("DeterminedExempt", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        # Step 2: System process determines applicant is eligible for exclusion
+        certification_case.record_exclusion_determination(eligibility_fact, ExclusionDeterminationService)
+        Strata::EventManager.publish("DeterminedExcluded", { case_id: certification_case.id, certification_id: certification_case.certification_id })
         certification_case.reload
 
         expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
@@ -74,7 +74,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       end
     end
 
-    context 'when applicant is not eligible for exemption' do
+    context 'when applicant is not eligible for exclusion' do
       let(:eligibility_fact) do
         Strata::RulesEngine::Fact.new(
           "no-op",
@@ -83,13 +83,13 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
       end
 
       it 'transitions to external_community_engagement_check' do
-        # Step 1: Case has been created and is on external_exemption_check step
-        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXEMPTION_CHECK_STEP)
+        # Step 1: Case has been created and is on external_exclusion_check step
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP)
         expect(certification_case.member_status).to eq(MemberStatus::AWAITING_REPORT)
         expect(certification_case).to be_open
 
-        # Step 2: System process determines applicant is not eligible for exemption
-        Strata::EventManager.publish("DeterminedNotExempt", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        # Step 2: System process determines applicant is not eligible for exclusion
+        Strata::EventManager.publish("DeterminedNotExcluded", { case_id: certification_case.id, certification_id: certification_case.certification_id })
         certification_case.reload
 
         # Case transitions to report_activities step is hardcoded in the business process

--- a/reporting-app/spec/controllers/staff/certification_batch_uploads_controller_spec.rb
+++ b/reporting-app/spec/controllers/staff/certification_batch_uploads_controller_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Staff::CertificationBatchUploadsController, type: :controller do
         allow(MemberStatusService).to receive(:determine_many).and_return(
           {
             [ "CertificationCase", compliant_case.id ] => MemberStatus.new(status: MemberStatus::COMPLIANT, determination_method: "automated", reason_codes: []),
-            [ "CertificationCase", exempt_case.id ] => MemberStatus.new(status: MemberStatus::EXEMPT, determination_method: "automated", reason_codes: [ "age_under_19_exempt" ]),
+            [ "CertificationCase", exempt_case.id ] => MemberStatus.new(status: MemberStatus::EXEMPT, determination_method: "automated", reason_codes: [ "age_under_19_excluded" ]),
             [ "CertificationCase", not_compliant_case.id ] => MemberStatus.new(status: MemberStatus::NOT_COMPLIANT, determination_method: "automated", reason_codes: []),
             [ "CertificationCase", pending_review_case.id ] => MemberStatus.new(status: pending_review_cert_status, determination_method: "manual", reason_codes: [])
           }

--- a/reporting-app/spec/factories/determination_factory.rb
+++ b/reporting-app/spec/factories/determination_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :determination do
     subject { association :certification }
     decision_method { 'automated' }
-    reasons { [ 'age_under_19_exempt' ] }
+    reasons { [ 'age_under_19_excluded' ] }
     outcome { 'exempt' }
     determination_data { { reasons: { rule: 'passed' } } }
     determined_at { Time.current }

--- a/reporting-app/spec/helpers/dashboard_helper_spec.rb
+++ b/reporting-app/spec/helpers/dashboard_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DashboardHelper, type: :helper do
 
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 

--- a/reporting-app/spec/mailers/member_mailer_spec.rb
+++ b/reporting-app/spec/mailers/member_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MemberMailer, type: :mailer do
   # Stub business process to prevent auto-triggering when creating certifications
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 

--- a/reporting-app/spec/models/api/certifications/outcome_spec.rb
+++ b/reporting-app/spec/models/api/certifications/outcome_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::Certifications::Outcome, type: :model do
+  describe ".from_certification" do
+    let(:certification) { create(:certification) }
+
+    # Stub the business process so creating a certification does not auto-record a determination.
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+      allow(NotificationService).to receive(:send_email_notification)
+    end
+
+    it "returns nil when there is no determination" do
+      expect(described_class.from_certification(certification)).to be_nil
+    end
+
+    context "when the automated exclusion determination excluded the member" do
+      before do
+        create(:determination,
+               subject: certification,
+               outcome: "excluded",
+               decision_method: "automated",
+               reasons: [ "age_under_19_excluded" ])
+      end
+
+      it "returns status 'excluded' sourced from the API" do
+        outcome = described_class.from_certification(certification)
+
+        expect(outcome.status).to eq("excluded")
+        expect(outcome.reason).to eq("age_under_19_excluded")
+        expect(outcome.source).to eq("api")
+      end
+    end
+
+    context "when a staff reviewer approved a manual exemption" do
+      before do
+        create(:determination,
+               subject: certification,
+               outcome: "exempt",
+               decision_method: "manual",
+               reasons: [ "exemption_request_compliant" ])
+      end
+
+      it "keeps the 'exempt' status distinct from an automated exclusion" do
+        outcome = described_class.from_certification(certification)
+
+        expect(outcome.status).to eq("exempt")
+        expect(outcome.source).to eq("member")
+      end
+    end
+  end
+end

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe CertificationCase, type: :model do
       certification = Certification.find(certification_case.certification_id)
       expect do
         certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
-      end.to change { Strata::AuditLine.where(subject: certification, actor_type: MockSubmitter.name, action: "case.exemption.approved").count }.by(1)
+      end.to change { Strata::AuditLine.where(subject: certification, actor_type: MockSubmitter.name, action: "case.exclusion.approved").count }.by(1)
     end
 
     it 'creates determination with correct attributes' do

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe CertificationCase, type: :model do
     end
   end
 
-  describe '#record_exemption_determination' do
+  describe '#record_exclusion_determination' do
     # Model only records state - service handles conditional logic and events
     before { stub_const("MockSubmitter", Class.new { include Strata::VirtualActor }) }
 
@@ -393,7 +393,7 @@ RSpec.describe CertificationCase, type: :model do
       eligibility_fact = Strata::RulesEngine::Fact.new(
         :age_eligibility, true, reasons: [ age_fact ]
       )
-      certification_case.record_exemption_determination(eligibility_fact, MockSubmitter)
+      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
       certification_case.reload
 
       expect(certification_case.exemption_request_approval_status).to eq("approved")
@@ -411,7 +411,7 @@ RSpec.describe CertificationCase, type: :model do
       )
       certification = Certification.find(certification_case.certification_id)
       expect do
-        certification_case.record_exemption_determination(eligibility_fact, MockSubmitter)
+        certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
       end.to change { Strata::AuditLine.where(subject: certification, actor_type: MockSubmitter.name, action: "case.exemption.approved").count }.by(1)
     end
 
@@ -422,19 +422,19 @@ RSpec.describe CertificationCase, type: :model do
       eligibility_fact = Strata::RulesEngine::Fact.new(
         :age_eligibility, true, reasons: [ age_fact ]
       )
-      certification_case.record_exemption_determination(eligibility_fact, MockSubmitter)
+      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
 
       determination = Determination.first
 
       expect(determination.decision_method).to eq("automated")
-      expect(determination.reasons).to include("age_under_19_exempt")
-      expect(determination.outcome).to eq("exempt")
+      expect(determination.reasons).to include("age_under_19_excluded")
+      expect(determination.outcome).to eq("excluded")
       expect(determination.determined_at).to be_present
       # determination_data is a jsonb column and must be stored as a Hash, never a JSON
       # String (writing reasons.to_json double-encodes it into a String — see #680). For
-      # automated exemptions it records the granting reason codes.
+      # automated exclusions it records the granting reason codes.
       expect(determination.determination_data).to be_a(Hash)
-      expect(determination.determination_data).to eq({ "exemption_reasons" => [ "age_under_19_exempt" ] })
+      expect(determination.determination_data).to eq({ "exclusion_reasons" => [ "age_under_19_excluded" ] })
     end
 
     it 'records multiple reasons (age and pregnancy)' do
@@ -445,14 +445,14 @@ RSpec.describe CertificationCase, type: :model do
         :is_pregnant, true, reasons: []
       )
       eligibility_fact = Strata::RulesEngine::Fact.new(
-        :eligible_for_exemption, true, reasons: [ age_fact, pregnant_fact ]
+        :eligible_for_exclusion, true, reasons: [ age_fact, pregnant_fact ]
       )
-      certification_case.record_exemption_determination(eligibility_fact, MockSubmitter)
+      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
 
       determination = Determination.first
 
-      expect(determination.reasons).to include("age_under_19_exempt", "pregnancy_exempt")
-      expect(determination.outcome).to eq("exempt")
+      expect(determination.reasons).to include("age_under_19_excluded", "pregnancy_excluded")
+      expect(determination.outcome).to eq("excluded")
     end
   end
 

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -164,11 +164,11 @@ RSpec.describe Certification, type: :model do
                               subject: certification,
                               outcome: 'exempt',
                               decision_method: 'automated',
-                              reasons: [ 'age_under_19_exempt' ],
+                              reasons: [ 'age_under_19_excluded' ],
                               created_at: 2.days.ago)
       outcome = certification.outcome
       expect(outcome.status).to eq 'exempt'
-      expect(outcome.reason).to eq 'age_under_19_exempt'
+      expect(outcome.reason).to eq 'age_under_19_excluded'
       expect(outcome.source).to eq 'api'
       expect(outcome.timestamp).to eq determination.created_at
     end

--- a/reporting-app/spec/models/concerns/determinable_spec.rb
+++ b/reporting-app/spec/models/concerns/determinable_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe Determinable, type: :model do
     end
   end
 
+  RSpec.shared_examples "an exclusion" do |reason_code|
+    let(:params) do
+      {
+        reasons: [ Determination::REASON_CODE_MAPPING[reason_code] ],
+        decision_method: :automated,
+        outcome: :excluded,
+        determination_data: { foo: :bar },
+        determined_at: Time.now
+      }
+    end
+
+    it "creates an audit log with the exclusion action" do
+      expect do
+        certification.record_determination!(**params)
+      end.to change { Strata::AuditLine.where(subject: certification, actor: nil, action: "case.exclusion.approved").count }.by(1)
+    end
+  end
+
   RSpec.shared_examples "an activity report" do |reason_code|
     let(:base_params) do
       {
@@ -126,6 +144,17 @@ RSpec.describe Determinable, type: :model do
       context reason_code do
         it_behaves_like "a submitted determination", reason_code
         it_behaves_like "an exemption", reason_code
+      end
+    end
+  end
+
+  # The automated ExternalExclusionCheck system process records +outcome: :excluded+ with these
+  # exclusion reason codes. The audit action for that path is renamed to +case.exclusion.*+ while
+  # manual exemption approvals (+outcome: :exempt+) keep +case.exemption.*+.
+  describe 'Exclusion outcome' do
+    %i[age_under_19 age_over_65 is_pregnant is_american_indian_or_alaska_native is_veteran_with_disability].each do |reason_code|
+      context reason_code do
+        it_behaves_like "an exclusion", reason_code
       end
     end
   end

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Determination, type: :model do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe Determination, type: :model do
 
     describe 'outcome' do
       it 'defines the outcome enum with correct values' do
-        expect(described_class.outcomes.keys).to contain_exactly('compliant', 'exempt', 'not_compliant')
+        expect(described_class.outcomes.keys).to contain_exactly('compliant', 'exempt', 'excluded', 'not_compliant')
       end
     end
   end
@@ -28,16 +28,16 @@ RSpec.describe Determination, type: :model do
     describe 'reasons' do
       it 'defines valid reason constants' do
         expected_reasons = %w[
-          age_under_19_exempt
-          age_over_65_exempt
-          pregnancy_exempt
-          american_indian_alaska_native_exempt
+          age_under_19_excluded
+          age_over_65_excluded
+          pregnancy_excluded
+          american_indian_alaska_native_excluded
           income_reported_compliant
           income_reported_insufficient
           hours_reported_compliant
           hours_reported_insufficient
           exemption_request_compliant
-          veteran_disability_exempt
+          veteran_disability_excluded
           denial_response_convincing
           denial_response_not_convincing
         ]
@@ -57,12 +57,12 @@ RSpec.describe Determination, type: :model do
       end
 
       it 'allows valid reasons' do
-        determination = build(:determination, reasons: [ 'age_under_19_exempt' ])
+        determination = build(:determination, reasons: [ 'age_under_19_excluded' ])
         expect(determination).to be_valid
       end
 
       it 'allows multiple valid reasons' do
-        determination = build(:determination, reasons: [ 'age_under_19_exempt', 'pregnancy_exempt' ])
+        determination = build(:determination, reasons: [ 'age_under_19_excluded', 'pregnancy_excluded' ])
         expect(determination).to be_valid
       end
 
@@ -73,7 +73,7 @@ RSpec.describe Determination, type: :model do
       end
 
       it 'rejects mixed valid and invalid reasons' do
-        determination = build(:determination, reasons: [ 'age_under_19_exempt', 'invalid_reason' ])
+        determination = build(:determination, reasons: [ 'age_under_19_excluded', 'invalid_reason' ])
         expect(determination).not_to be_valid
         expect(determination.errors[:reasons]).to include(match(/must contain only valid reason values/))
       end
@@ -103,7 +103,7 @@ RSpec.describe Determination, type: :model do
 
       before do
         create(:determination, subject: compliant_cert, outcome: 'compliant', reasons: [ 'hours_reported_compliant' ])
-        create(:determination, subject: exempt_cert, outcome: 'exempt', reasons: [ 'age_under_19_exempt' ])
+        create(:determination, subject: exempt_cert, outcome: 'exempt', reasons: [ 'age_under_19_excluded' ])
       end
 
       it 'returns determinations for specified certification IDs' do
@@ -143,7 +143,7 @@ RSpec.describe Determination, type: :model do
         create(:determination,
                subject: compliant_cert,
                outcome: 'compliant',
-               reasons: [ 'age_under_19_exempt' ],
+               reasons: [ 'age_under_19_excluded' ],
                created_at: 2.days.ago)
 
         # Create multiple determinations for exempt_cert
@@ -155,7 +155,7 @@ RSpec.describe Determination, type: :model do
         create(:determination,
                subject: exempt_cert,
                outcome: 'exempt',
-               reasons: [ 'pregnancy_exempt' ],
+               reasons: [ 'pregnancy_excluded' ],
                created_at: 1.day.ago)
       end
 
@@ -212,7 +212,7 @@ RSpec.describe Determination, type: :model do
         create(:determination,
                subject: compliant_cert,
                outcome: 'exempt',
-               reasons: [ 'age_under_19_exempt' ],
+               reasons: [ 'age_under_19_excluded' ],
                created_at: 2.days.ago)
         create(:determination,
                subject: compliant_cert,
@@ -229,7 +229,7 @@ RSpec.describe Determination, type: :model do
         create(:determination,
                subject: exempt_cert,
                outcome: 'exempt',
-               reasons: [ 'pregnancy_exempt' ],
+               reasons: [ 'pregnancy_excluded' ],
                created_at: 1.day.ago)
 
         # cert3: 1 determination

--- a/reporting-app/spec/models/member_dashboard_compliance_spec.rb
+++ b/reporting-app/spec/models/member_dashboard_compliance_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MemberDashboardCompliance do
 
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 

--- a/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Rules::ExemptionRuleset do
+RSpec.describe Rules::ExclusionRuleset do
   let(:ruleset) { described_class.new }
 
   describe '#age_under_19' do
@@ -115,70 +115,70 @@ RSpec.describe Rules::ExemptionRuleset do
     end
   end
 
-  describe '#eligible_for_exemption' do
+  describe '#eligible_for_exclusion' do
     context 'when all parameters are nil' do
       it 'returns nil' do
-        expect(ruleset.eligible_for_exemption(nil, nil, nil, nil, nil)).to be_nil
+        expect(ruleset.eligible_for_exclusion(nil, nil, nil, nil, nil)).to be_nil
       end
     end
 
     context 'when only is_pregnant is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exemption(nil, nil, true, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, nil, true, nil, nil)).to be true
       end
     end
 
     context 'when only age_under_19 is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exemption(true, nil, nil, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(true, nil, nil, nil, nil)).to be true
       end
     end
 
     context 'when only age_over_65 is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exemption(nil, true, nil, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, true, nil, nil, nil)).to be true
       end
     end
 
     context 'when only is_american_indian_or_alaska_native is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exemption(nil, nil, nil, true, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, nil, nil, true, nil)).to be true
       end
     end
 
     context 'when only is_veteran_with_disability is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exemption(nil, nil, nil, nil, true)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, nil, nil, nil, true)).to be true
       end
     end
 
     context 'when age_under_19 and is_pregnant are both true' do
       it 'returns true (multiple reasons)' do
-        expect(ruleset.eligible_for_exemption(true, nil, true, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(true, nil, true, nil, nil)).to be true
       end
     end
 
     context 'when all are true' do
       it 'returns true (all reasons)' do
-        expect(ruleset.eligible_for_exemption(true, true, true, true, true)).to be true
+        expect(ruleset.eligible_for_exclusion(true, true, true, true, true)).to be true
       end
     end
 
     context 'when all are false' do
       it 'returns false (no exemption)' do
-        expect(ruleset.eligible_for_exemption(false, false, false, false, false)).to be false
+        expect(ruleset.eligible_for_exclusion(false, false, false, false, false)).to be false
       end
     end
 
     context 'when age-based exemption is false but is_american_indian_or_alaska_native is true' do
       it 'returns true (race-based exemption)' do
-        expect(ruleset.eligible_for_exemption(false, false, false, true, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(false, false, false, true, nil)).to be true
       end
     end
 
     context 'when age-based exemption is false but pregnant is true' do
       it 'returns true (pregnant exemption)' do
-        expect(ruleset.eligible_for_exemption(false, false, true, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(false, false, true, nil, nil)).to be true
       end
     end
   end

--- a/reporting-app/spec/requests/certification_cases_spec.rb
+++ b/reporting-app/spec/requests/certification_cases_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "/staff/certification_cases", type: :request do
     login_as user
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 

--- a/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
+++ b/reporting-app/spec/requests/staff/certification_batch_uploads_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
     login_as user
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 
@@ -289,7 +289,7 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
                subject_type: "Certification",
                subject_id: exempt_cert.id,
                outcome: MemberStatus::EXEMPT,
-               reasons: [ "age_under_19_exempt" ])
+               reasons: [ "age_under_19_excluded" ])
       end
       let(:not_compliant_determination) do
         create(:determination,
@@ -311,7 +311,7 @@ RSpec.describe "Staff::CertificationBatchUploads", type: :request do
       before do
         # Stub services to prevent auto-triggering during certification creation
         allow(Strata::EventManager).to receive(:publish).and_call_original
-        allow(ExemptionDeterminationService).to receive(:determine)
+        allow(ExclusionDeterminationService).to receive(:determine)
         allow(NotificationService).to receive(:send_email_notification)
 
         # Force creation of all test data

--- a/reporting-app/spec/services/activity_report_statistics_service_spec.rb
+++ b/reporting-app/spec/services/activity_report_statistics_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ActivityReportStatisticsService do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ExemptionDeterminationService do
+RSpec.describe ExclusionDeterminationService do
   let(:service) { described_class }
   let(:cert_date) { Date.new(2025, 7, 1) }
   let(:member_data) { build(:certification_member_data, date_of_birth: dob, cert_date: cert_date) }
@@ -34,9 +34,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when applicant is under 19 years old' do
       let(:dob) { cert_date - 18.years }
 
-      it 'publishes DeterminedExempt event' do
+      it 'publishes DeterminedExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'closes the case' do
@@ -67,9 +67,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when applicant is 65 years old or older' do
       let(:dob) { cert_date - 65.years }
 
-      it 'publishes DeterminedExempt event' do
+      it 'publishes DeterminedExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'closes the case' do
@@ -94,9 +94,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when applicant is 19 years old' do
       let(:dob) { cert_date - 19.years }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -115,9 +115,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when applicant is 64 years old' do
       let(:dob) { cert_date - 64.years }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -136,9 +136,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when member_data has no date_of_birth' do
       let(:dob) { nil }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -163,10 +163,10 @@ RSpec.describe ExemptionDeterminationService do
     context 'when date_of_birth is invalid format' do
       let(:dob) { "invalid-date-format" }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         allow(Rails.logger).to receive(:warn)
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -182,9 +182,9 @@ RSpec.describe ExemptionDeterminationService do
         build(:certification_member_data, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
       end
 
-      it 'publishes DeterminedExempt event' do
+      it 'publishes DeterminedExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'closes the case' do
@@ -211,9 +211,9 @@ RSpec.describe ExemptionDeterminationService do
         build(:certification_member_data, race_ethnicity: "white", cert_date: cert_date)
       end
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -234,9 +234,9 @@ RSpec.describe ExemptionDeterminationService do
         build(:certification_member_data, pregnancy_status: true, cert_date: cert_date)
       end
 
-      it 'publishes DeterminedExempt event' do
+      it 'publishes DeterminedExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'closes the case' do
@@ -263,9 +263,9 @@ RSpec.describe ExemptionDeterminationService do
         build(:certification_member_data, pregnancy_status: false, cert_date: cert_date)
       end
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -285,9 +285,9 @@ RSpec.describe ExemptionDeterminationService do
       let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
       let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
-      it 'publishes DeterminedExempt event' do
+      it 'publishes DeterminedExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'closes the case' do
@@ -307,9 +307,9 @@ RSpec.describe ExemptionDeterminationService do
       let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
       let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 70 } } } }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
 
       it 'does not close the case' do
@@ -322,9 +322,9 @@ RSpec.describe ExemptionDeterminationService do
     context 'when VA service returns nil (fail-open)' do
       let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
 
-      it 'publishes DeterminedNotExempt event' do
+      it 'publishes DeterminedNotExcluded event' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExempt', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
       end
     end
   end

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ExclusionDeterminationService do
       it 'logs approved event' do
         expect do
           service.determine(kase)
-        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exemption.approved').count }.by(1)
+        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exclusion.approved').count }.by(1)
       end
     end
 
@@ -156,7 +156,7 @@ RSpec.describe ExclusionDeterminationService do
       it 'logs denied event' do
         expect do
           service.determine(kase)
-        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exemption.denied').count }.by(1)
+        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exclusion.denied').count }.by(1)
       end
     end
 

--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe MemberDashboardComplianceService do
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 
@@ -154,13 +154,13 @@ RSpec.describe MemberDashboardComplianceService do
       end
     end
 
-    context "when member status is exempt" do
+    context "when member status is exempt (automated exclusion)" do
       before do
         create(:determination,
                subject: certification,
-               outcome: "exempt",
+               outcome: "excluded",
                decision_method: "automated",
-               reasons: [ "age_under_19_exempt" ])
+               reasons: [ "age_under_19_excluded" ])
       end
 
       let(:member_status) { MemberStatusService.determine(certification) }
@@ -182,9 +182,9 @@ RSpec.describe MemberDashboardComplianceService do
         expect(read_model.exemption_flow_state).to eq(MemberDashboardCompliance::EXEMPTION_APPROVED)
       end
 
-      it "includes automated exempt determination in exemption history" do
+      it "includes automated exclusion determination in exemption history" do
         expect(read_model.exemption_history.size).to eq(1)
-        expect(read_model.exemption_history.first.exemption_type_key).to eq("age_under_19_exempt")
+        expect(read_model.exemption_history.first.exemption_type_key).to eq("age_under_19_excluded")
         expect(read_model.exemption_history.first.status_token).to eq(MemberDashboardCompliance::EXEMPTION_APPROVED)
       end
 
@@ -327,23 +327,23 @@ RSpec.describe MemberDashboardComplianceService do
       end
     end
 
-    context "when an automated exempt determination has a legacy String determination_data" do
-      # Reproduces the production shape that 500'd the dashboard: the automated exemption
+    context "when an automated exclusion determination has a legacy String determination_data" do
+      # Reproduces the production shape that 500'd the dashboard: the automated exclusion
       # path historically wrote reasons.to_json (a String) into the jsonb column, so AR
       # reads it back as a String instead of a Hash.
       before do
         det = create(:determination,
                      subject: certification,
-                     outcome: "exempt",
+                     outcome: "excluded",
                      decision_method: "automated",
-                     reasons: [ "age_under_19_exempt" ])
+                     reasons: [ "age_under_19_excluded" ])
         force_string_determination_data(det)
       end
 
       it "builds exemption history without raising and labels from the reason code" do
         expect { read_model.exemption_history }.not_to raise_error
         entry = read_model.exemption_history.first
-        expect(entry.exemption_type_key).to eq("age_under_19_exempt")
+        expect(entry.exemption_type_key).to eq("age_under_19_excluded")
         expect(entry.exemption_type_label).to eq("Age under 19")
       end
     end
@@ -364,17 +364,17 @@ RSpec.describe MemberDashboardComplianceService do
       end
     end
 
-    context "when an automated exemption is for veteran disability" do
+    context "when an automated exclusion is for veteran disability" do
       before do
         create(:determination,
                subject: certification,
-               outcome: "exempt",
+               outcome: "excluded",
                decision_method: "automated",
-               reasons: [ "veteran_disability_exempt" ])
+               reasons: [ "veteran_disability_excluded" ])
       end
 
       it "labels it with the curated reason-code translation" do
-        entry = read_model.exemption_history.find { |e| e.exemption_type_key == "veteran_disability_exempt" }
+        entry = read_model.exemption_history.find { |e| e.exemption_type_key == "veteran_disability_excluded" }
         expect(entry.exemption_type_label).to eq("Veteran with a disability")
       end
     end

--- a/reporting-app/spec/services/member_status_service_spec.rb
+++ b/reporting-app/spec/services/member_status_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MemberStatusService do
   # Stub business process to prevent auto-triggering determinations when creating certifications
   before do
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
   end
 
@@ -47,16 +47,16 @@ RSpec.describe MemberStatusService do
       end
     end
 
-    context 'when Determination exists with outcome "exempt"' do
+    context 'when Determination exists with automated outcome "excluded"' do
       before do
         create(:determination,
                subject: certification,
-               outcome: "exempt",
+               outcome: "excluded",
                decision_method: "automated",
-               reasons: [ "age_over_65_exempt", "pregnancy_exempt" ])
+               reasons: [ "age_over_65_excluded", "pregnancy_excluded" ])
       end
 
-      it 'returns status "exempt"' do
+      it 'surfaces the automated exclusion as status "exempt"' do
         result = service.determine(certification)
         expect(result.status).to eq("exempt")
       end
@@ -68,7 +68,7 @@ RSpec.describe MemberStatusService do
 
       it 'returns all reason_codes' do
         result = service.determine(certification)
-        expect(result.reason_codes).to eq([ "age_over_65_exempt", "pregnancy_exempt" ])
+        expect(result.reason_codes).to eq([ "age_over_65_excluded", "pregnancy_excluded" ])
       end
     end
 
@@ -124,13 +124,13 @@ RSpec.describe MemberStatusService do
                subject: certification,
                outcome: "exempt",
                decision_method: "automated",
-               reasons: [ "age_under_19_exempt" ],
+               reasons: [ "age_under_19_excluded" ],
                created_at: 1.day.ago)
         create(:determination,
                subject: certification,
                outcome: "compliant",
                decision_method: "manual",
-               reasons: [ "age_over_65_exempt" ],
+               reasons: [ "age_over_65_excluded" ],
                created_at: Time.current)
       end
 
@@ -138,7 +138,7 @@ RSpec.describe MemberStatusService do
         result = service.determine(certification)
         expect(result.status).to eq("compliant")
         expect(result.determination_method).to eq("manual")
-        expect(result.reason_codes).to eq([ "age_over_65_exempt" ])
+        expect(result.reason_codes).to eq([ "age_over_65_excluded" ])
       end
     end
 
@@ -337,7 +337,7 @@ RSpec.describe MemberStatusService do
                subject: certification,
                outcome: "exempt",
                decision_method: "automated",
-               reasons: [ "age_over_65_exempt" ])
+               reasons: [ "age_over_65_excluded" ])
         create(:determination,
                subject: create(:certification),
                outcome: "compliant",
@@ -366,7 +366,7 @@ RSpec.describe MemberStatusService do
                subject: cert,
                outcome: "compliant",
                decision_method: "automated",
-               reasons: [ "pregnancy_exempt" ],
+               reasons: [ "pregnancy_excluded" ],
                created_at: 1.hour.ago)
         create(:determination,
                subject: cert,
@@ -465,7 +465,7 @@ RSpec.describe MemberStatusService do
              subject: completed_certification,
              outcome: "exempt",
              decision_method: "automated",
-             reasons: [ "age_under_19_exempt" ])
+             reasons: [ "age_under_19_excluded" ])
     end
 
     it "returns only prior certifications with terminal outcomes" do

--- a/reporting-app/spec/services/notifications_event_listener_spec.rb
+++ b/reporting-app/spec/services/notifications_event_listener_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NotificationsEventListener, type: :service do
   before do
     allow(NotificationService).to receive(:send_email_notification)
     # Stub services that may publish events during certification creation
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
   end
 
   describe ".subscribe" do
@@ -25,6 +25,7 @@ RSpec.describe NotificationsEventListener, type: :service do
       described_class.subscribe
 
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedExempt", anything)
+      expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedExcluded", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedHoursMet", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementMet", anything)
       expect(Strata::EventManager).to have_received(:subscribe).with("DeterminedCommunityEngagementActionRequired", anything)

--- a/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
+++ b/reporting-app/spec/views/dashboard/index.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "dashboard/index", type: :view do
   before do
     # Prevent auto-triggering business process during test setup
     allow(Strata::EventManager).to receive(:publish).and_call_original
-    allow(ExemptionDeterminationService).to receive(:determine)
+    allow(ExclusionDeterminationService).to receive(:determine)
     allow(NotificationService).to receive(:send_email_notification)
 
     assign(:all_certifications, [
@@ -776,7 +776,7 @@ RSpec.describe "dashboard/index", type: :view do
              subject: certification,
              outcome: "exempt",
              decision_method: "automated",
-             reasons: [ "age_under_19_exempt" ])
+             reasons: [ "age_under_19_excluded" ])
       reassign_compliance_read_model
     end
 


### PR DESCRIPTION
## Ticket

Resolves #733

## Changes

- "exemption" replaced with "exclusion" for class and variable names related to the external exemption check in the business process
- "exempt" replaced with "excluded" in determination outcome resulting from this process
- Minor changes to ensure no impact on application or staff flows or UI

## Context for reviewers

We are moving towards using "exemption" as an umbrella term for "exclusions" and forthcoming "exceptions". There are technical distinctions between the two that make it useful to separate for the purposes of backend processing. However, the distinction between the two for public consumption makes combining them in an "exemption" flow make more sense. We therefore need to refactor the backend process without impacting the user-facing flow.

As no production services exist

## Testing

Automated and e2e tests pass.

Manual testing via demo uses 'exclusion' in audit log and determination.
Manual testing shows `excluded` as outcome.status in Certification API

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->