### PR TITLE
Extract OscerApplicationForm base for shared form lifecycle

### DIFF
--- a/reporting-app/app/models/activity_report_application_form.rb
+++ b/reporting-app/app/models/activity_report_application_form.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class ActivityReportApplicationForm < Strata::ApplicationForm
-  include FormApprovalStatus
+class ActivityReportApplicationForm < OscerApplicationForm
   has_review_task "ReviewActivityReportTask"
+  case_approval_status :activity_report_approval_status
 
   MINIMUM_MONTHLY_HOURS = 80
   MINIMUM_MONTHLY_INCOME = IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY
@@ -15,9 +15,6 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
   strata_attribute :number_of_months_to_certify, :integer
   strata_attribute :months_that_can_be_certified, :year_month, array: true
 
-  validates :certification_case_id, presence: true
-  validate :case_not_closed, on: :create
-  validate :no_pending_forms, on: :create
   validates :reporting_periods,
     length: {
       is: :number_of_months_to_certify,
@@ -41,15 +38,6 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
 
   accepts_nested_attributes_for :activities, allow_destroy: true
 
-  def self.find_by_certification_case_id(certification_case_id)
-    find_by(certification_case_id:)
-  end
-
-  # Include the case id
-  def event_payload
-    super.merge(case_id: certification_case_id)
-  end
-
   def self.information_request_class
     ActivityReportInformationRequest
   end
@@ -64,43 +52,7 @@ class ActivityReportApplicationForm < Strata::ApplicationForm
       .map { |ym| Date.new(ym.year, ym.month, 1) }
   end
 
-  def flow_status
-    unless @flow_status.present?
-      task_complete = ReviewActivityReportTask.where(case_id: certification_case_id,
-                                                     application_form: self,
-                                                     status: :completed).exists?
-      @flow_status = if task_complete
-                       CertificationCase.find(certification_case_id).activity_report_approval_status
-      else
-                       status
-      end
-    end
-
-    @flow_status
-  end
-
-  def self.has_pending_form(certification_case_id)
-    ActivityReportApplicationForm.where(certification_case_id:, status: :in_progress).exists? ||
-    ReviewActivityReportTask.where(application_form: ActivityReportApplicationForm.where(certification_case_id:).all,
-                                   status: [ :on_hold, :pending ]).exists?
-  end
-
   private
-
-  def case_not_closed
-    certification_case = CertificationCase.find_by(id: certification_case_id)
-    if certification_case.blank?
-      errors.add(:certification_case_id, "is invalid")
-    elsif certification_case.closed?
-      errors.add(:certification_case_id, "has closed")
-    elsif certification_case.verification_window_ended?
-      errors.add(:certification_case_id, "verification window has ended")
-    end
-  end
-
-  def no_pending_forms
-    errors.add(:certification_case_id, "has already been taken") if ActivityReportApplicationForm.has_pending_form(certification_case_id)
-  end
 
   def validate_reporting_periods_in_range
     invalid = reporting_periods - months_that_can_be_certified

--- a/reporting-app/app/models/concerns/form_approval_status.rb
+++ b/reporting-app/app/models/concerns/form_approval_status.rb
@@ -10,14 +10,28 @@
 module FormApprovalStatus
   extend ActiveSupport::Concern
 
+  included do
+    # The review-task class is recorded as a String and resolved lazily (see review_task_class).
+    # Resolving eagerly here would risk a Zeitwerk load cycle: a review-task class may reference
+    # its form class in its own body (e.g. ReviewExemptionClaimTask -> ExemptionApplicationForm).
+    class_attribute :review_task_class_name, instance_accessor: false
+  end
+
   class_methods do
     # Each form binds to its own review-task subclass; the association config is shared.
     def has_review_task(class_name)
+      self.review_task_class_name = class_name
       has_one :review_task,
         class_name: class_name,
         foreign_key: :application_form_id,
         inverse_of: :application_form,
         strict_loading: false
+    end
+
+    # The bound review-task class; fails loud if a form forgot has_review_task.
+    def review_task_class
+      review_task_class_name&.constantize or
+        raise NotImplementedError, "#{name} must declare has_review_task"
     end
   end
 

--- a/reporting-app/app/models/denial_response_application_form.rb
+++ b/reporting-app/app/models/denial_response_application_form.rb
@@ -3,60 +3,13 @@
 # A denial response is a lightweight way for a member to resolve a denied certification case while
 # their verification window is still open: a short written comment plus optional supporting
 # documents that a staff reviewer approves or denies.
-class DenialResponseApplicationForm < Strata::ApplicationForm
-  include FormApprovalStatus
+class DenialResponseApplicationForm < OscerApplicationForm
   has_review_task "ReviewDenialResponseTask"
+  case_approval_status :denial_response_approval_status
 
   strata_attribute :comment, :text
 
   has_many_attached :supporting_documents
 
   default_scope { with_attached_supporting_documents.includes(:determinations) }
-
-  validates :certification_case_id, presence: true
-  validate :case_not_closed, on: :create
-  validate :no_pending_forms, on: :create
-
-  # Include the case id so the submitted event routes to the case in the business process.
-  def event_payload
-    super.merge(case_id: certification_case_id)
-  end
-
-  def flow_status
-    unless @flow_status.present?
-      task_complete = ReviewDenialResponseTask.where(case_id: certification_case_id,
-                                                     application_form: self,
-                                                     status: :completed).exists?
-      @flow_status = if task_complete
-                       CertificationCase.find(certification_case_id).denial_response_approval_status
-      else
-                       status
-      end
-    end
-
-    @flow_status
-  end
-
-  def self.has_pending_form(certification_case_id)
-    DenialResponseApplicationForm.where(certification_case_id:, status: :in_progress).exists? ||
-    ReviewDenialResponseTask.where(application_form: DenialResponseApplicationForm.where(certification_case_id:).all,
-                                   status: [ :on_hold, :pending ]).exists?
-  end
-
-  private
-
-  def case_not_closed
-    certification_case = CertificationCase.find_by(id: certification_case_id)
-    if certification_case.blank?
-      errors.add(:certification_case_id, "is invalid")
-    elsif certification_case.closed?
-      errors.add(:certification_case_id, "has closed")
-    elsif certification_case.verification_window_ended?
-      errors.add(:certification_case_id, "verification window has ended")
-    end
-  end
-
-  def no_pending_forms
-    errors.add(:certification_case_id, "has already been taken") if DenialResponseApplicationForm.has_pending_form(certification_case_id)
-  end
 end

--- a/reporting-app/app/models/exemption_application_form.rb
+++ b/reporting-app/app/models/exemption_application_form.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class ExemptionApplicationForm < Strata::ApplicationForm
-  include FormApprovalStatus
+class ExemptionApplicationForm < OscerApplicationForm
   has_review_task "ReviewExemptionClaimTask"
+  case_approval_status :exemption_request_approval_status
 
   # TODO: Remove when revising the old exemption screener flow
   LEGACY_EXEMPTION_TYPES = %w[short_term_hardship incarceration].freeze
@@ -10,69 +10,21 @@ class ExemptionApplicationForm < Strata::ApplicationForm
   enum :exemption_type, Exemption.enum_hash
   validates :exemption_type, inclusion: { in: Exemption.types + LEGACY_EXEMPTION_TYPES }, allow_nil: true
 
-  validate :case_not_closed, on: :create
-  validate :no_pending_forms, on: :create
-
   has_many_attached :supporting_documents
 
   default_scope { with_attached_supporting_documents.includes(:determinations) }
 
   strata_attribute :exemption_type, :string
 
-  def self.find_by_certification_case_id(certification_case_id)
-    find_by(certification_case_id:)
-  end
-
-  def event_payload
-    super.merge(case_id: certification_case_id)
-  end
-
   def self.information_request_class
     ExemptionInformationRequest
   end
 
-  def flow_status
-    unless @flow_status.present?
-      task_complete = staff_exemption_review_complete?
-      @flow_status = if task_complete
-                       CertificationCase.find(certification_case_id).exemption_request_approval_status
-      else
-                       status
-      end
-    end
-
-    @flow_status
-  end
-
   # True when caseworker review for this form has finished (+ReviewExemptionClaimTask+ completed).
   # Case-level +exemption_request_approval_status+ applies only after this; a new submission
-  # after a prior denial stays pending until staff review the new request.
+  # after a prior denial stays pending until staff review the new request. Public delegator over
+  # the base's review-task check; has external callers (member dashboard compliance).
   def staff_exemption_review_complete?
-    ReviewExemptionClaimTask.where(case_id: certification_case_id,
-                                   application_form: self,
-                                   status: :completed).exists?
-  end
-
-  def self.has_pending_form(certification_case_id)
-    ExemptionApplicationForm.where(certification_case_id:, status: :in_progress).exists? ||
-    ReviewExemptionClaimTask.where(application_form: ExemptionApplicationForm.where(certification_case_id:).all,
-                                   status: [ :on_hold, :pending ]).exists?
-  end
-
-  private
-
-  def case_not_closed
-    certification_case = CertificationCase.find_by(id: certification_case_id)
-    if certification_case.blank?
-      errors.add(:certification_case_id, "is invalid")
-    elsif certification_case.closed?
-      errors.add(:certification_case_id, "has closed")
-    elsif certification_case.verification_window_ended?
-      errors.add(:certification_case_id, "verification window has ended")
-    end
-  end
-
-  def no_pending_forms
-    errors.add(:certification_case_id, "has already been taken") if ExemptionApplicationForm.has_pending_form(certification_case_id)
+    review_task_completed?
   end
 end

--- a/reporting-app/app/models/oscer_application_form.rb
+++ b/reporting-app/app/models/oscer_application_form.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Abstract base for OSCER's application forms, all of which are bound to a CertificationCase.
+# It holds the case-bound lifecycle those forms share — creation guards, pending-form detection,
+# flow status, and event routing — so each concrete subclass carries only its own fields plus two
+# bindings:
+#
+#   * +has_review_task "ReviewXTask"+  (from FormApprovalStatus) — the review-task class
+#   * +case_approval_status :x_approval_status+                   — the CertificationCase accessor
+#     that flow_status reads once staff review completes
+#
+# Mirrors the OscerTask -> Review*Task hierarchy in naming (Oscer + the Strata base name), but is
+# +abstract_class = true+ rather than STI: Strata::ApplicationForm is itself abstract and each form
+# has its own table (no +type+ column), so table names resolve from the concrete subclass and the
+# status enum / attributes / determinations inherit normally.
+class OscerApplicationForm < Strata::ApplicationForm
+  self.abstract_class = true
+
+  include FormApprovalStatus
+
+  # Stored as a symbol and read lazily; see case_approval_status_accessor below.
+  class_attribute :case_approval_status_accessor_name, instance_accessor: false
+
+  class << self
+    # Declares which CertificationCase approval-status accessor flow_status reads for this form
+    # once its review task is complete (e.g. :activity_report_approval_status).
+    def case_approval_status(accessor)
+      self.case_approval_status_accessor_name = accessor
+    end
+
+    # Fail loud if a subclass forgot the binding, rather than silently resolving nil.
+    def case_approval_status_accessor
+      case_approval_status_accessor_name or
+        raise NotImplementedError, "#{name} must declare case_approval_status"
+    end
+
+    # A case is blocked from a new form while one is in progress, or while a submitted form's
+    # review task has not yet been resolved (still on hold or pending).
+    def has_pending_form(certification_case_id)
+      where(certification_case_id:, status: :in_progress).exists? ||
+        review_task_class.where(
+          application_form: where(certification_case_id:).all,
+          status: [ :on_hold, :pending ]
+        ).exists?
+    end
+  end
+
+  validates :certification_case_id, presence: true
+  validate :case_not_closed, on: :create
+  validate :no_pending_forms, on: :create
+
+  # Once staff review is complete the form's status defers to the case-level approval outcome;
+  # until then it reports its own submit status. Memoization intentionally re-computes while the
+  # resolved value is blank (task complete but the case accessor not yet written) — do not
+  # simplify to +||=+, which would change that behavior.
+  def flow_status
+    unless @flow_status.present?
+      @flow_status = if review_task_completed?
+                       CertificationCase.find(certification_case_id).public_send(self.class.case_approval_status_accessor)
+      else
+                       status
+      end
+    end
+
+    @flow_status
+  end
+
+  protected
+
+  # Include the case id so the Created/Submitted events route to the case in the business process.
+  def event_payload
+    super.merge(case_id: certification_case_id)
+  end
+
+  private
+
+  # True once this form's own review task has been completed by staff.
+  def review_task_completed?
+    self.class.review_task_class.where(
+      case_id: certification_case_id,
+      application_form: self,
+      status: :completed
+    ).exists?
+  end
+
+  def case_not_closed
+    certification_case = CertificationCase.find_by(id: certification_case_id)
+    if certification_case.blank?
+      errors.add(:certification_case_id, "is invalid")
+    elsif certification_case.closed?
+      errors.add(:certification_case_id, "has closed")
+    elsif certification_case.verification_window_ended?
+      errors.add(:certification_case_id, "verification window has ended")
+    end
+  end
+
+  def no_pending_forms
+    errors.add(:certification_case_id, "has already been taken") if self.class.has_pending_form(certification_case_id)
+  end
+end

--- a/reporting-app/spec/models/oscer_application_form_spec.rb
+++ b/reporting-app/spec/models/oscer_application_form_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# OscerApplicationForm is the abstract base (no table of its own) that holds the case-bound
+# lifecycle shared by its three concrete subclasses. Its behavior is therefore exercised through
+# those subclasses. These specs assert the SHARED contract holds identically across all three —
+# the parity the consolidation guarantees — and, critically, they exercise the paths where the
+# base dereferences the per-subclass bindings: has_pending_form's review-task branch
+# (review_task_class) and flow_status (case_approval_status_accessor). The exhaustive per-model
+# behavior (full flow_status matrix, model-specific fields) stays in each subclass's own spec.
+
+# Defined as a local (not a constant) so it does not leak onto Object; the example-group blocks
+# below close over it at definition time.
+subclasses = [
+  {
+    name: "ActivityReportApplicationForm",
+    model: ActivityReportApplicationForm,
+    factory: :activity_report_application_form,
+    review_task_class: ReviewActivityReportTask,
+    review_task_factory: :review_activity_report_task,
+    case_approval_status_accessor: :activity_report_approval_status,
+    approve: ->(kase, form) { kase.accept_activity_report(nil, form) }
+  },
+  {
+    name: "ExemptionApplicationForm",
+    model: ExemptionApplicationForm,
+    factory: :exemption_application_form,
+    review_task_class: ReviewExemptionClaimTask,
+    review_task_factory: :review_exemption_claim_task,
+    case_approval_status_accessor: :exemption_request_approval_status,
+    approve: ->(kase, form) { kase.accept_exemption_request(nil, form) }
+  },
+  {
+    name: "DenialResponseApplicationForm",
+    model: DenialResponseApplicationForm,
+    factory: :denial_response_application_form,
+    review_task_class: ReviewDenialResponseTask,
+    review_task_factory: :review_denial_response_task,
+    case_approval_status_accessor: :denial_response_approval_status,
+    approve: ->(kase, form) { kase.accept_denial_response(nil, form) }
+  }
+].freeze
+
+RSpec.describe OscerApplicationForm, type: :model do
+  it "is an abstract class layered directly under Strata::ApplicationForm" do
+    expect(described_class.abstract_class?).to be(true)
+    expect(described_class.superclass).to eq(Strata::ApplicationForm)
+  end
+
+  it "includes the FormApprovalStatus concern for all subclasses" do
+    subclasses.each do |subclass|
+      expect(subclass[:model].new).to respond_to(:approval_status, :approved?, :denied?)
+    end
+  end
+
+  describe "per-subclass bindings (contract)" do
+    subclasses.each do |subclass|
+      context subclass[:name] do
+        it "descends from the abstract base" do
+          expect(subclass[:model].ancestors).to include(described_class)
+        end
+
+        it "binds its review-task class" do
+          expect(subclass[:model].review_task_class).to eq(subclass[:review_task_class])
+        end
+
+        it "binds its case approval-status accessor" do
+          expect(subclass[:model].case_approval_status_accessor).to eq(subclass[:case_approval_status_accessor])
+        end
+      end
+    end
+  end
+
+  describe "binding enforcement (fail loud)" do
+    # A subclass that omits a required binding must fail loudly the moment its lifecycle is
+    # exercised, rather than silently misbehaving. An anonymous subclass declares neither binding.
+    let(:unconfigured_subclass) { Class.new(described_class) }
+
+    it "raises a descriptive error when the review-task class is not declared" do
+      expect { unconfigured_subclass.review_task_class }
+        .to raise_error(NotImplementedError, /has_review_task/)
+    end
+
+    it "raises a descriptive error when the case approval-status accessor is not declared" do
+      expect { unconfigured_subclass.case_approval_status_accessor }
+        .to raise_error(NotImplementedError, /case_approval_status/)
+    end
+  end
+
+  describe "shared lifecycle (parity across all subclasses)" do
+    let(:certification) { create(:certification) }
+    let(:certification_case) { create(:certification_case, certification: certification) }
+
+    before { allow(Strata::EventManager).to receive(:publish) }
+
+    subclasses.each do |subclass|
+      context subclass[:name] do
+        # NOTE: exemption gains this presence validation via the base (parity addition — it had
+        # none before). Its own spec never built a nil-case form, so the regression net stays green.
+        it "requires a certification_case_id" do
+          form = build(subclass[:factory], certification_case_id: nil)
+
+          expect(form.save).to be(false)
+          expect(form.errors[:certification_case_id]).to include("can't be blank")
+        end
+
+        it "rejects a nonexistent certification case" do
+          form = build(subclass[:factory], certification_case_id: SecureRandom.uuid)
+
+          expect(form.save).to be(false)
+          expect(form.errors[:certification_case_id]).to include("is invalid")
+        end
+
+        it "rejects creation once the case is closed" do
+          certification_case.close!
+          form = build(subclass[:factory], certification_case_id: certification_case.id)
+
+          expect(form.save).to be(false)
+          expect(form.errors[:certification_case_id]).to include("has closed")
+        end
+
+        it "rejects creation once the verification window has ended" do
+          certification_case.update_attribute(:verification_window_end_date, 1.day.ago)
+          form = build(subclass[:factory], certification_case_id: certification_case.id)
+
+          expect(form.save).to be(false)
+          expect(form.errors[:certification_case_id]).to include("verification window has ended")
+        end
+
+        it "allows only one in-progress form per case" do
+          create(subclass[:factory], certification_case_id: certification_case.id)
+          second_form = build(subclass[:factory], certification_case_id: certification_case.id)
+
+          expect(second_form.save).to be(false)
+          expect(second_form.errors[:certification_case_id]).to include("has already been taken")
+        end
+
+        # The base override must preserve super's payload (application_form_id, submitted_at) — those
+        # keys route the Created/Submitted events to the business process. Asserting only case_id
+        # would pass even if a base impl dropped super, silently breaking event routing.
+        it "merges the case id into the event payload without dropping super's keys" do
+          form = create(subclass[:factory], :with_submitted_status, certification_case_id: certification_case.id)
+
+          expect(form.send(:event_payload)).to include(
+            application_form_id: form.id,
+            submitted_at: form.submitted_at,
+            case_id: certification_case.id
+          )
+        end
+
+        describe ".has_pending_form" do
+          it "is false when the case has no forms" do
+            expect(subclass[:model].has_pending_form(certification_case.id)).to be(false)
+          end
+
+          it "is true while an in-progress form exists" do
+            create(subclass[:factory], certification_case_id: certification_case.id)
+
+            expect(subclass[:model].has_pending_form(certification_case.id)).to be(true)
+          end
+
+          # Exercises the base's review-task branch (dereferences review_task_class): a submitted
+          # form is no longer in-progress, so only a pending review task keeps the case blocked.
+          it "is true while a submitted form's review task is still pending" do
+            form = create(subclass[:factory], :with_submitted_status, certification_case_id: certification_case.id)
+            create(subclass[:review_task_factory], application_form: form, case: certification_case)
+
+            expect(subclass[:model].has_pending_form(certification_case.id)).to be(true)
+          end
+        end
+
+        # Exercises the base's flow_status resolution through case_approval_status_accessor once the
+        # review task is complete and the case has recorded an outcome. The full approved/denied
+        # matrix stays in each subclass spec; one outcome here pins the accessor dereference.
+        it "resolves flow_status to the case outcome once its review task completes" do
+          form = create(subclass[:factory], :with_submitted_status, certification_case_id: certification_case.id)
+          task = create(subclass[:review_task_factory], application_form: form, case: certification_case)
+          task.completed!
+          subclass[:approve].call(certification_case, form)
+
+          expect(form.flow_status).to eq("approved")
+        end
+      end
+    end
+  end
+
+  # Exemption keeps this as a public delegator: it has external callers (member_dashboard_compliance,
+  # member_dashboard_compliance_service) and must survive the consolidation intact.
+  describe "ExemptionApplicationForm#staff_exemption_review_complete?" do
+    let(:certification_case) { create(:certification_case) }
+
+    before { allow(Strata::EventManager).to receive(:publish) }
+
+    it "is false before the review task completes and true after" do
+      form = create(:exemption_application_form, :with_submitted_status, certification_case_id: certification_case.id)
+      task = create(:review_exemption_claim_task, application_form: form, case: certification_case)
+
+      expect(form.staff_exemption_review_complete?).to be(false)
+
+      task.completed!
+      expect(form.reload.staff_exemption_review_complete?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves #736

## Changes

- Add `OscerApplicationForm` — an abstract base (`abstract_class = true`) under
  `Strata::ApplicationForm` that holds the certification-case lifecycle the three
  application forms shared: `certification_case_id` presence, the two `on: :create`
  guards (`case_not_closed`, `no_pending_forms`), `has_pending_form`, `flow_status`,
  and the `event_payload` case-id merge.
- `FormApprovalStatus`: `has_review_task` now records the review-task class name and
  exposes a lazily-resolved `review_task_class`; add a `case_approval_status` macro +
  reader on the base. Both bindings fail loud if a subclass omits them.
- Reparent `ActivityReportApplicationForm`, `ExemptionApplicationForm`, and
  `DenialResponseApplicationForm` under `OscerApplicationForm`, deleting their
  duplicated lifecycle methods (each keeps only its unique fields + the two bindings).
- Remove an unused `find_by_certification_case_id` class method.

## Context for reviewers

- **Why a layered abstract class, not a mixin or STI:** `Strata::ApplicationForm` is
  itself `abstract_class = true` and the three forms each have their own table (no
  shared table, no `type` column), so an intermediate abstract class is the safe,
  idiomatic fit. The name mirrors the sibling `OscerTask → Review*Task` hierarchy.
- **Fail-loud bindings:** an `inherited` hook can't validate the declarations (it runs
  before the subclass body), so `review_task_class` / `case_approval_status_accessor`
  raise `NotImplementedError` if unset; the review-task class is resolved lazily
  (string → `constantize`) to avoid a Zeitwerk load cycle. The new spec includes a
  contract test that each subclass binds both, and an unconfigured-subclass test.
- **Two intentional behavior changes** (this is otherwise behavior-preserving):
  1. `ExemptionApplicationForm` gains an **unconditional `certification_case_id`
     presence validation** it lacked before (parity with the other two). ✅ **Pre-merge
     check cleared:** audited dev via `rails runner` — **0 of 1,693**
     `exemption_application_forms` rows have `certification_case_id IS NULL`, so no
     existing row will newly fail on update. The unconditional validation stands as-is
     (no need to scope it to `on: :create`).
  2. `event_payload` moves to the base as `protected`, matching Strata's visibility
     (it was incidentally public on each form; no external callers).
- Reviewed via a 4-agent pass (security/quality/context + freeform); the dead-method
  removal and terminology were review findings folded in before commit.

## Testing

- Full suite green: **2456 examples, 0 failures**; coverage 96.28% line / 82.82% branch.
- New `spec/models/oscer_application_form_spec.rb` (contract + parity + fail-loud) plus
  the three existing form specs as the unchanged regression net: **117 examples, 0 failures**.
- `make lint` (RuboCop) clean.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->