### PR TITLE
Extract shared config-loading plumbing into a ConfigLoading module

### DIFF
--- a/reporting-app/app/services/config_loading.rb
+++ b/reporting-app/app/services/config_loading.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Shared YAML load/parse/error plumbing for the config loaders that let a
+# deployment override OSCER-shipped defaults via config/custom/*.yml
+# (ExemptionTypesLoader, FeatureFlagsLoader, and future loaders).
+#
+# Loaders consume this by `extend ConfigLoading`, which turns these PUBLIC
+# INSTANCE methods into PUBLIC singleton methods on the loader, so existing
+# `Loader.safe_load_optional(path)` call sites keep working. Do NOT convert
+# these to `module_function`: after `extend`, module_function methods land as
+# PRIVATE singleton methods and the initializers' external
+# `Loader.safe_load_optional(...)` calls would raise NoMethodError at boot.
+#
+# This module holds only the load/parse/error plumbing that is byte-identical
+# across loaders. Each loader keeps its own (intentionally divergent) merge,
+# validation, and transform logic.
+module ConfigLoading
+  class ConfigurationError < StandardError; end
+
+  # Load an optional override file, treating a missing file as "no overrides".
+  def safe_load_optional(path)
+    return {} unless File.exist?(path)
+    parse_yaml(path)
+  end
+
+  # Parse a YAML file with no Ruby object deserialization. Returns {} for an
+  # empty/comment-only file (parses to nil); raises ConfigurationError on
+  # malformed YAML, a disallowed Ruby tag, or a non-Hash top level.
+  def parse_yaml(path)
+    raw = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
+    return {} if raw.nil?
+    unless raw.is_a?(Hash)
+      raise ConfigurationError, "Expected a Hash at top level in #{path}, got #{raw.class}"
+    end
+    raw
+  rescue Psych::SyntaxError, Psych::DisallowedClass => e
+    raise ConfigurationError, "Invalid YAML in #{path}: #{e.message}"
+  end
+end

--- a/reporting-app/app/services/exemption_types_loader.rb
+++ b/reporting-app/app/services/exemption_types_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "config_loading"
+
 # Loads exemption-type configuration by deep-merging an optional deployment
 # override (config/custom/exemption_types.yml, the deployment-owned override
 # surface) over the federal-floor defaults declared in DEFAULTS below.
@@ -7,8 +9,16 @@
 # Defaults represent OSCER's federal floor and are OSCER-owned (updated by
 # Nava as CMS regulations evolve). Deployments customize via the override
 # file, not by editing this constant.
+#
+# The YAML load/parse/error plumbing lives in the shared ConfigLoading module
+# (extend below); this loader keeps only its deep-merge + transform logic.
 module ExemptionTypesLoader
-  class ConfigurationError < StandardError; end
+  extend ConfigLoading
+
+  # Alias keeps ExemptionTypesLoader::ConfigurationError valid for existing
+  # rescues/specs; unqualified `raise ConfigurationError` in transform resolves
+  # to it via lexical scope, so no raise site changes.
+  ConfigurationError = ConfigLoading::ConfigurationError
 
   DEFAULTS = {
     "caregiver_disability" => { "enabled" => true },
@@ -21,11 +31,6 @@ module ExemptionTypesLoader
   }.freeze
 
   module_function
-
-  def safe_load_optional(path)
-    return {} unless File.exist?(path)
-    parse_yaml(path)
-  end
 
   def merge_with_defaults(overrides)
     DEFAULTS.deep_merge(overrides)
@@ -41,16 +46,5 @@ module ExemptionTypesLoader
       end
       attrs.symbolize_keys.merge(id: id.to_sym)
     end
-  end
-
-  def parse_yaml(path)
-    raw = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
-    return {} if raw.nil?
-    unless raw.is_a?(Hash)
-      raise ConfigurationError, "Expected a Hash at top level in #{path}, got #{raw.class}"
-    end
-    raw
-  rescue Psych::SyntaxError, Psych::DisallowedClass => e
-    raise ConfigurationError, "Invalid YAML in #{path}: #{e.message}"
   end
 end

--- a/reporting-app/app/services/feature_flags_loader.rb
+++ b/reporting-app/app/services/feature_flags_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "config_loading"
+
 # Builds the in-memory feature-flag registry by adding optional
 # deployment-defined flags (config/custom/feature_flags.yml, the
 # deployment-owned override surface) onto the OSCER-shipped built-ins declared
@@ -10,12 +12,12 @@
 # override file. The override is ADDITIVE ONLY: a deployment cannot redefine or
 # disable a built-in here. To toggle a built-in, set its env var.
 #
-# Mirrors ExemptionTypesLoader's load/validate discipline:
-#   - safe_load_optional treats a missing/empty file as "no overrides"
-#   - parse_yaml uses YAML.safe_load (no Ruby object deserialization)
-#   - build_registry raises a ConfigurationError naming the offending entry and
-#     field on any malformed/colliding deployment flag, so misconfiguration
-#     fails loudly at boot rather than silently at runtime.
+# Shares its YAML load/parse plumbing with ExemptionTypesLoader via the shared
+# ConfigLoading module (extend below): safe_load_optional treats a missing/empty
+# file as "no overrides"; parse_yaml uses YAML.safe_load (no Ruby object
+# deserialization). build_registry then raises a ConfigurationError naming the
+# offending entry and field on any malformed/colliding deployment flag, so
+# misconfiguration fails loudly at boot rather than silently at runtime.
 #
 # Merge semantics intentionally DIFFER from ExemptionTypesLoader: that loader
 # deep_merges deployment values over OSCER defaults (the deployment owns the
@@ -23,7 +25,12 @@
 # state, so this loader is purely ADDITIVE and raises on any collision. Do not
 # "align" the two by introducing deep_merge here.
 module FeatureFlagsLoader
-  class ConfigurationError < StandardError; end
+  extend ConfigLoading
+
+  # Alias keeps FeatureFlagsLoader::ConfigurationError valid for existing
+  # rescues/specs; unqualified `raise ConfigurationError` in build_registry /
+  # validate_entry! resolves to it via lexical scope, so no raise site changes.
+  ConfigurationError = ConfigLoading::ConfigurationError
 
   # Deployment-defined env vars must match the same FEATURE_<NAME> convention
   # the built-ins follow: "FEATURE_" + uppercase letters/digits/underscores.
@@ -43,11 +50,6 @@ module FeatureFlagsLoader
   ALLOWED_ENTRY_KEYS = %w[env_var default description].freeze
 
   module_function
-
-  def safe_load_optional(path)
-    return {} unless File.exist?(path)
-    parse_yaml(path)
-  end
 
   # Merge deployment overrides on top of the OSCER-shipped built-ins.
   #
@@ -94,17 +96,6 @@ module FeatureFlagsLoader
     end
 
     registry
-  end
-
-  def parse_yaml(path)
-    raw = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
-    return {} if raw.nil?
-    unless raw.is_a?(Hash)
-      raise ConfigurationError, "Expected a Hash at top level in #{path}, got #{raw.class}"
-    end
-    raw
-  rescue Psych::SyntaxError, Psych::DisallowedClass => e
-    raise ConfigurationError, "Invalid YAML in #{path}: #{e.message}"
   end
 
   # Validate a single deployment-defined flag entry. Each entry requires an

--- a/reporting-app/spec/rails_helper.rb
+++ b/reporting-app/spec/rails_helper.rb
@@ -45,6 +45,7 @@ require_relative 'support/policy_shared_examples'
 require_relative 'support/sso_helpers'
 require_relative 'support/feature_flag_helpers'
 require_relative 'support/env_helpers'
+require_relative 'support/yaml_config_helpers'
 require "strata/testing/api_auth_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/reporting-app/spec/services/config_loading_spec.rb
+++ b/reporting-app/spec/services/config_loading_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Direct regression net for the plumbing extracted from ExemptionTypesLoader and
+# FeatureFlagsLoader. The module is exercised through a throwaway anonymous module that
+# `extend`s it — mirroring how the real loaders consume it (`extend ConfigLoading`) and
+# proving the methods land as PUBLIC singleton methods. `write_yaml` comes from the shared
+# spec/support/yaml_config_helpers.rb helper.
+RSpec.describe ConfigLoading, type: :service do
+  # A stand-in for a real loader: gains safe_load_optional / parse_yaml as public
+  # singleton methods, just as `extend ConfigLoading` does on ExemptionTypesLoader et al.
+  let(:loader) { Module.new { extend ConfigLoading } }
+
+  it "exposes the plumbing as public methods after extend" do
+    expect(loader.singleton_class.public_method_defined?(:safe_load_optional)).to be(true)
+    expect(loader.singleton_class.public_method_defined?(:parse_yaml)).to be(true)
+  end
+
+  it "defines ConfigurationError as a StandardError subclass" do
+    expect(described_class::ConfigurationError.ancestors).to include(StandardError)
+  end
+
+  describe "#safe_load_optional" do
+    context "when the file does not exist" do
+      it "returns an empty hash without raising" do
+        missing_path = "/tmp/definitely_not_a_real_override_#{SecureRandom.hex}.yml"
+        result = nil
+        expect {
+          result = loader.safe_load_optional(missing_path)
+        }.not_to raise_error
+        expect(result).to eq({})
+      end
+    end
+
+    context "when the file is empty (parses to nil)" do
+      let(:empty_file) { write_yaml("") }
+
+      after { empty_file.unlink }
+
+      it "returns an empty hash without raising" do
+        expect(loader.safe_load_optional(empty_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains only comments (parses to nil)" do
+      let(:comments_only_file) { write_yaml("# just a comment\n# another comment\n") }
+
+      after { comments_only_file.unlink }
+
+      it "returns an empty hash without raising" do
+        expect(loader.safe_load_optional(comments_only_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains a literal empty hash" do
+      let(:empty_hash_file) { write_yaml("{}\n") }
+
+      after { empty_hash_file.unlink }
+
+      it "returns an empty hash" do
+        expect(loader.safe_load_optional(empty_hash_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains a valid override hash" do
+      let(:override_file) do
+        write_yaml(<<~YAML)
+          medical_condition:
+            enabled: false
+          disaster_evacuation:
+            enabled: true
+        YAML
+      end
+
+      after { override_file.unlink }
+
+      it "returns the parsed hash unchanged (string keys, no transform)" do
+        result = loader.safe_load_optional(override_file.path)
+        expect(result).to eq(
+          "medical_condition" => { "enabled" => false },
+          "disaster_evacuation" => { "enabled" => true }
+        )
+      end
+    end
+
+    context "when the YAML contains a disallowed Ruby tag" do
+      let(:disallowed_file) { write_yaml("medical_condition: !ruby/symbol enabled") }
+
+      after { disallowed_file.unlink }
+
+      it "raises ConfigurationError matching 'Invalid YAML'" do
+        expect {
+          loader.safe_load_optional(disallowed_file.path)
+        }.to raise_error(ConfigLoading::ConfigurationError, /Invalid YAML/)
+      end
+    end
+
+    context "when the YAML is malformed" do
+      let(:malformed_file) { write_yaml("medical_condition: :\n  bad indent: [unclosed") }
+
+      after { malformed_file.unlink }
+
+      it "raises ConfigurationError matching 'Invalid YAML'" do
+        expect {
+          loader.safe_load_optional(malformed_file.path)
+        }.to raise_error(ConfigLoading::ConfigurationError, /Invalid YAML/)
+      end
+    end
+
+    context "when the YAML has a non-Hash top level" do
+      let(:list_file) { write_yaml("- just\n- a\n- list\n") }
+
+      after { list_file.unlink }
+
+      it "raises ConfigurationError matching 'Expected a Hash at top level'" do
+        expect {
+          loader.safe_load_optional(list_file.path)
+        }.to raise_error(ConfigLoading::ConfigurationError, /Expected a Hash at top level/)
+      end
+    end
+  end
+
+  describe "#parse_yaml" do
+    # parse_yaml is public and skips the File.exist? guard that safe_load_optional adds.
+    context "with a well-formed hash file" do
+      let(:hash_file) { write_yaml("feature_x:\n  enabled: true\n") }
+
+      after { hash_file.unlink }
+
+      it "returns the parsed hash" do
+        expect(loader.parse_yaml(hash_file.path)).to eq("feature_x" => { "enabled" => true })
+      end
+    end
+
+    context "with a non-Hash top level" do
+      let(:scalar_file) { write_yaml("just a string\n") }
+
+      after { scalar_file.unlink }
+
+      it "names the offending file's top-level class in the error" do
+        expect {
+          loader.parse_yaml(scalar_file.path)
+        }.to raise_error(ConfigLoading::ConfigurationError, /Expected a Hash at top level.*String/)
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/config_loading_spec.rb
+++ b/reporting-app/spec/services/config_loading_spec.rb
@@ -2,17 +2,21 @@
 
 require "rails_helper"
 
-# Direct regression net for the plumbing extracted from ExemptionTypesLoader and
-# FeatureFlagsLoader. The module is exercised through a throwaway anonymous module that
-# `extend`s it — mirroring how the real loaders consume it (`extend ConfigLoading`) and
-# proving the methods land as PUBLIC singleton methods. `write_yaml` comes from the shared
-# spec/support/yaml_config_helpers.rb helper.
+# Direct regression net for the load/parse/error methods extracted from
+# ExemptionTypesLoader and FeatureFlagsLoader. The module is exercised through a throwaway
+# anonymous module that `extend`s it — mirroring how the real loaders consume it
+# (`extend ConfigLoading`) and proving the methods become PUBLIC class methods on the
+# extending loader. `write_yaml` comes from the shared spec/support/yaml_config_helpers.rb
+# helper.
 RSpec.describe ConfigLoading, type: :service do
   # A stand-in for a real loader: gains safe_load_optional / parse_yaml as public
   # singleton methods, just as `extend ConfigLoading` does on ExemptionTypesLoader et al.
   let(:loader) { Module.new { extend ConfigLoading } }
 
-  it "exposes the plumbing as public methods after extend" do
+  it "makes safe_load_optional and parse_yaml public class methods on an extending loader" do
+    # `extend ConfigLoading` copies the module's instance methods onto the loader as
+    # public singleton (class) methods, which is what lets the initializers call
+    # Loader.safe_load_optional(...) at boot. module_function would make them private.
     expect(loader.singleton_class.public_method_defined?(:safe_load_optional)).to be(true)
     expect(loader.singleton_class.public_method_defined?(:parse_yaml)).to be(true)
   end

--- a/reporting-app/spec/services/exemption_types_loader_spec.rb
+++ b/reporting-app/spec/services/exemption_types_loader_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "tempfile"
 
 RSpec.describe ExemptionTypesLoader, type: :service do
-  # Helper: write content to a tempfile and return the closed Tempfile.
-  # Callers should `.unlink` in an `after` block and use `.path` for paths.
-  def write_yaml(content)
-    file = Tempfile.new([ "exemption_types_test", ".yml" ])
-    file.write(content)
-    file.close
-    file
+  # write_yaml comes from spec/support/yaml_config_helpers.rb.
+
+  it "aliases ConfigurationError to the shared ConfigLoading::ConfigurationError" do
+    # The alias is load-bearing: it keeps ExemptionTypesLoader::ConfigurationError
+    # valid for existing rescues/specs and makes unqualified `raise ConfigurationError`
+    # in transform resolve to the shared class. Pin the object identity explicitly.
+    expect(described_class::ConfigurationError).to equal(ConfigLoading::ConfigurationError)
   end
 
   describe ".safe_load_optional" do

--- a/reporting-app/spec/services/feature_flags_loader_spec.rb
+++ b/reporting-app/spec/services/feature_flags_loader_spec.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "tempfile"
 
 RSpec.describe FeatureFlagsLoader, type: :service do
-  # Helper: write content to a tempfile and return the closed Tempfile.
-  # Callers should `.unlink` in an `after` block and use `.path` for paths.
-  def write_yaml(content)
-    file = Tempfile.new([ "feature_flags_test", ".yml" ])
-    file.write(content)
-    file.close
-    file
-  end
+  # write_yaml comes from spec/support/yaml_config_helpers.rb.
 
   # The OSCER-shipped built-ins the loader merges deployment flags on top of.
   # Mirrors the real Features::FEATURE_FLAGS shape so collision/merge behavior
@@ -24,6 +16,13 @@ RSpec.describe FeatureFlagsLoader, type: :service do
         description: "Enable DocAI document analysis for income verification"
       }
     }
+  end
+
+  it "aliases ConfigurationError to the shared ConfigLoading::ConfigurationError" do
+    # The alias is load-bearing: it keeps FeatureFlagsLoader::ConfigurationError
+    # valid for existing rescues/specs and makes unqualified `raise ConfigurationError`
+    # in build_registry / validate_entry! resolve to the shared class. Pin identity.
+    expect(described_class::ConfigurationError).to equal(ConfigLoading::ConfigurationError)
   end
 
   describe ".safe_load_optional" do

--- a/reporting-app/spec/support/yaml_config_helpers.rb
+++ b/reporting-app/spec/support/yaml_config_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+# Shared helper for config-loader specs. Writes content to a tempfile and returns the closed
+# Tempfile; callers `.unlink` in an `after` block and pass `.path`. Extracted from the previously
+# duplicated `write_yaml` defs in the loader specs. The `prefix:` kwarg preserves a per-spec
+# tempfile prefix when wanted but defaults generically, so existing `write_yaml("...")` call sites
+# are unchanged (nothing asserts on filenames).
+module YamlConfigHelpers
+  def write_yaml(content, prefix: "yaml_config_test")
+    file = Tempfile.new([ prefix, ".yml" ])
+    file.write(content)
+    file.close
+    file
+  end
+end
+
+RSpec.configure do |config|
+  config.include YamlConfigHelpers
+end


### PR DESCRIPTION
## Ticket

Resolves #740

## Changes

- **New `app/services/config_loading.rb`** — a `ConfigLoading` module holding the YAML load/parse/error plumbing (`safe_load_optional`, `parse_yaml`, `ConfigurationError`) that `ExemptionTypesLoader` and `FeatureFlagsLoader` previously duplicated byte-for-byte.
- Both loaders now `extend ConfigLoading`, alias `ConfigurationError = ConfigLoading::ConfigurationError`, and drop their local copies. Each loader's own (intentionally divergent) merge / validation / transform logic is untouched, as are the two initializers.
- **Spec support:** extracted the duplicated `write_yaml` Tempfile helper into `spec/support/yaml_config_helpers.rb`, wired into `rails_helper.rb` (its support-autoload glob is commented out, so support files are required individually).
- **New `spec/services/config_loading_spec.rb`** covering the extracted module, plus a one-line alias-identity assertion in each loader spec.

## Context for reviewers

Why now: the Data Source Hierarchy work (#735 and follow-ons) will add more config loaders. Without a shared home, each would re-copy the same ~15 lines of load/parse/error plumbing. This PR extracts only the byte-identical plumbing and deliberately defers a deep-merge base class until a second deep-merge loader's per-entry schema actually exists (tracked for #735's config-surface work).

The highest-risk detail is method visibility. The module uses plain **public instance methods, not `module_function`**: `extend` installs them as public singleton methods, so the initializers' external `Loader.safe_load_optional(...)` calls keep resolving at boot. Had they been `module_function`, `extend` would install them as private and boot would raise `NoMethodError`. Because the loader specs run under a booted Rails environment (both initializers execute), a regression here fails the whole suite, not just one example.

One observable behavior delta to be aware of: the two loaders' `ConfigurationError` are now a single shared class (a class's `.name` is fixed at first constant assignment). A malformed override file therefore aborts boot as `ConfigLoading::ConfigurationError` rather than `ExemptionTypesLoader::ConfigurationError` / `FeatureFlagsLoader::ConfigurationError`. No code depends on the old class names and error messages still name the offending file, but it is visible in logs and any error-grouping keyed on class name.

Suggested review path: read `config_loading.rb` first, then each loader diff (delete-plumbing + `extend` + alias), then the specs.

## Testing

- `make test` (full suite): **2438 examples, 0 failures**; coverage 96.23% line / 82.92% branch (above the 92% / 70% gate).
- Targeted (`config_loading_spec` + both loader specs): **63 examples, 0 failures**. The passing loader specs also confirm the `extend` visibility contract at real boot.
- `make lint` (RuboCop): clean, 533 files, no offenses.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->