### PR TITLE
Bump json to 2.20.0 to resolve CVE-2026-54696

### DIFF
--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -275,7 +275,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.19.8)
+    json (2.20.0)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
       aes_key_wrap


### PR DESCRIPTION
## Ticket

None (security-audit CI failure; no tracking issue).

## Changes

Conservative lockfile-only bump of the transitive `json` gem `2.19.8` → `2.20.0`. No `Gemfile` change (`json` is pinned `~> 2.3` upstream).

## Context for reviewers

The `Security audit` CI job (`make audit` → `bundler-audit check --update`) started failing on **all open PRs** after `ruby-advisory-db` published [GHSA-x2f5-4prf-w687 / CVE-2026-54696](https://nvd.nist.gov/vuln/detail/CVE-2026-54696) on 2026-07-05:

> **json** `2.19.8` — JSON generator heap buffer overflow when streaming to an IO (Criticality: Low). Solution: update to `>= 2.19.9`.

Because `bundler-audit --update` pulls a live advisory DB on every run, this hit branches that were previously green without any code change of their own. Landing it as its own small PR (per the dependency-bump policy) keeps the lockfile-bump rationale on a single squash commit and **unblocks the audit gate on the other open PRs** ([#738](https://github.com/navapbc/oscer/pull/738), [#741](https://github.com/navapbc/oscer/pull/741)), which can rebase once this merges.

## Testing

- `bundle update json --conservative` → resolved to `2.20.0` (latest satisfying `~> 2.3`, clears `>= 2.19.9`).
- `bundle exec bundler-audit check --update` → **No vulnerabilities found.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->