### PR TITLE
OSCER-746: Configurable External Exceptions with Demo

### DIFF
--- a/reporting-app/app/forms/demo/certifications/base_create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/base_create_form.rb
@@ -25,9 +25,6 @@ module Demo
       attribute :case_number, :string
       attribute :va_icn, :string
       attribute :pregnancy_status, :boolean, default: false
-      # Selected external-exception scenario to trigger (an ExternalException id), or blank for none.
-      # to_certification maps the choice onto the matching MemberData signal.
-      attribute :external_exception, :string
       attribute :race_ethnicity, :enum, options: RACE_ETHNICITY_OPTIONS
 
       # TODO: add validation you can't set both certification_type and the other params?

--- a/reporting-app/app/forms/demo/certifications/base_create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/base_create_form.rb
@@ -25,6 +25,9 @@ module Demo
       attribute :case_number, :string
       attribute :va_icn, :string
       attribute :pregnancy_status, :boolean, default: false
+      # Selected external-exception scenario to trigger (an ExternalException id), or blank for none.
+      # to_certification maps the choice onto the matching MemberData signal.
+      attribute :external_exception, :string
       attribute :race_ethnicity, :enum, options: RACE_ETHNICITY_OPTIONS
 
       # TODO: add validation you can't set both certification_type and the other params?

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -71,6 +71,7 @@ module Demo
           md.pregnancy_status = pregnancy_status if pregnancy_status.present?
           md.race_ethnicity = race_ethnicity if race_ethnicity.present?
           md.va_icn = va_icn if va_icn.present?
+          apply_external_exception(md)
         end
 
         @certification = FactoryBot.build(
@@ -81,6 +82,23 @@ module Demo
           certification_requirements: certification_requirements,
           member_data: member_data,
         )
+      end
+
+      private
+
+      # Sets the MemberData signal that triggers the selected external exception, so the check fires
+      # downstream in ExceptionDeterminationService. A blank selection leaves member data unchanged.
+      def apply_external_exception(member_data)
+        case external_exception
+        when "inpatient_medical_care"
+          member_data.receiving_inpatient_medical_care = true
+        when "declared_emergency_county"
+          member_data.resides_in_declared_emergency_county = true
+        when "high_unemployment_county"
+          member_data.resides_in_high_unemployment_county = true
+        when "medical_travel"
+          member_data.traveling_for_medical_care = true
+        end
       end
     end
   end

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -9,6 +9,7 @@ module Demo
         "Fully met income requirement"
       ].freeze
 
+      attribute :external_exception, :string
       attribute :external_scenario, :enum, options: EXTERNAL_SCENARIO_OPTIONS
 
       def self.new_for_certification_type(certification_type)

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -75,4 +75,11 @@ class Certifications::MemberData < ValueObject
   attribute :payroll_accounts, :array, of: PayrollAccount.to_type
   attribute :activities, :array, of: Activity.to_type
   attribute :pregnancy_status, :boolean, default: false
+
+  # External-exception signals evaluated by ExceptionDeterminationService.
+  # Distinct from exclusion/exemption signals above; see ExternalException.
+  attribute :receiving_inpatient_medical_care, :boolean, default: false
+  attribute :resides_in_declared_emergency_county, :boolean, default: false
+  attribute :resides_in_high_unemployment_county, :boolean, default: false
+  attribute :traveling_for_medical_care, :boolean, default: false
 end

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -73,7 +73,13 @@ class Determination < Strata::Determination
     exemption_request_compliant: "exemption_request_compliant",
     is_veteran_with_disability: "veteran_disability_excluded",
     denial_response_convincing: "denial_response_convincing",
-    denial_response_not_convincing: "denial_response_not_convincing"
+    denial_response_not_convincing: "denial_response_not_convincing",
+    # External-exception reason codes (see ExceptionDeterminationService). "Excepted" is a
+    # distinct outcome from "excluded"/"exempt" — do not conflate the three.
+    receiving_inpatient_medical_care: "inpatient_medical_care_excepted",
+    resides_in_declared_emergency_county: "declared_emergency_county_excepted",
+    resides_in_high_unemployment_county: "high_unemployment_county_excepted",
+    traveling_for_medical_care: "medical_travel_excepted"
   }.freeze
 
   # Reasons recorded when a staff reviewer approves or denies a member's denial response.

--- a/reporting-app/app/models/external_exception.rb
+++ b/reporting-app/app/models/external_exception.rb
@@ -23,23 +23,10 @@ class ExternalException
       all.select { |t| t[:enabled] }
     end
 
-    def ids
-      all.map { |t| t[:id] }
-    end
-
-    def find(id)
-      all.find { |t| t[:id] == id.to_sym }
-    end
-
     # True when +id+ is a known external exception that is currently enabled.
     # ExceptionDeterminationService calls this before running each check.
     def enabled?(id)
       enabled.any? { |t| t[:id] == id.to_sym }
-    end
-
-    # True when +id+ is a known external exception, regardless of enabled state.
-    def valid_type?(id)
-      all.any? { |t| t[:id] == id.to_sym }
     end
   end
 end

--- a/reporting-app/app/models/external_exception.rb
+++ b/reporting-app/app/models/external_exception.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Registry over the external-exception configuration loaded by
+# ExternalExceptionsLoader and assigned to Rails.application.config.external_exceptions
+# on boot.
+#
+# These are the optional short-term hardship exceptions evaluated by the
+# external exception check (ExceptionDeterminationService). The service consults
+# .enabled? to gate each check, so a deployment can disable any optional
+# exception via config/custom/external_exceptions.yml.
+#
+# Named ExternalException (not Exception) because Exception is a reserved Ruby
+# core class. This mirrors Exemption but is intentionally leaner: external
+# exceptions have no member- or staff-facing UI, so there are no I18n metadata
+# accessors.
+class ExternalException
+  class << self
+    def all
+      Rails.application.config.external_exceptions
+    end
+
+    def enabled
+      all.select { |t| t[:enabled] }
+    end
+
+    def ids
+      all.map { |t| t[:id] }
+    end
+
+    def find(id)
+      all.find { |t| t[:id] == id.to_sym }
+    end
+
+    # True when +id+ is a known external exception that is currently enabled.
+    # ExceptionDeterminationService calls this before running each check.
+    def enabled?(id)
+      enabled.any? { |t| t[:id] == id.to_sym }
+    end
+
+    # True when +id+ is a known external exception, regardless of enabled state.
+    def valid_type?(id)
+      all.any? { |t| t[:id] == id.to_sym }
+    end
+  end
+end

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -7,6 +7,17 @@
 # Business process handles: transitions and notifications.
 class ExceptionDeterminationService
   include Strata::VirtualActor
+
+  # Each symbol names a private check method taking member_data and returning its reason code when
+  # the exception applies (and is enabled), or nil otherwise. Add a check by adding its symbol here
+  # and defining the matching method. Order is the evaluation order; the first applicable check wins.
+  EXCEPTION_CHECKS = %i[
+    inpatient_medical_care
+    declared_emergency_county
+    high_unemployment_county
+    medical_travel
+  ].freeze
+
   class << self
     # @param kase [CertificationCase]
     def determine(kase)
@@ -28,11 +39,53 @@ class ExceptionDeterminationService
 
     private
 
-    # Runs the exception checks against the member's data and returns a list containing the first reason code that
-    # applies. No checks are implemented yet, so this returns [] and no member is excepted. Each check's
-    # own story adds its predicate and reason code here.
-    def applicable_exception_reason_codes(_certification)
-      []
+    # Returns an array holding the reason code for the first exception check that applies (empty when
+    # none apply, which leaves the member not excepted). A member needs only one exception reason, so
+    # checks run lazily and stop at the first success. Each check is a plain method (no rules engine)
+    # that gates itself on ExternalException.enabled?, so a deployment can disable any optional
+    # exception via configuration.
+    def applicable_exception_reason_codes(certification)
+      member_data = certification.member_data
+      return [] if member_data.nil?
+
+      reason_code = EXCEPTION_CHECKS.lazy.filter_map { |check| send(check, member_data) }.first
+      reason_code ? [ reason_code ] : []
+    end
+
+    # @return [String, nil] the reason code when the member is receiving inpatient medical care and
+    #   the exception is enabled, otherwise nil.
+    def inpatient_medical_care(member_data)
+      return unless ExternalException.enabled?(:inpatient_medical_care)
+      return unless member_data.receiving_inpatient_medical_care
+
+      Determination::REASON_CODE_MAPPING.fetch(:receiving_inpatient_medical_care)
+    end
+
+    # @return [String, nil] the reason code when the member resides in a declared-emergency county
+    #   and the exception is enabled, otherwise nil.
+    def declared_emergency_county(member_data)
+      return unless ExternalException.enabled?(:declared_emergency_county)
+      return unless member_data.resides_in_declared_emergency_county
+
+      Determination::REASON_CODE_MAPPING.fetch(:resides_in_declared_emergency_county)
+    end
+
+    # @return [String, nil] the reason code when the member resides in a high-unemployment county and
+    #   the exception is enabled, otherwise nil.
+    def high_unemployment_county(member_data)
+      return unless ExternalException.enabled?(:high_unemployment_county)
+      return unless member_data.resides_in_high_unemployment_county
+
+      Determination::REASON_CODE_MAPPING.fetch(:resides_in_high_unemployment_county)
+    end
+
+    # @return [String, nil] the reason code when the member is travelling for medical care (for
+    #   themselves or a dependent) and the exception is enabled, otherwise nil.
+    def medical_travel(member_data)
+      return unless ExternalException.enabled?(:medical_travel)
+      return unless member_data.traveling_for_medical_care
+
+      Determination::REASON_CODE_MAPPING.fetch(:traveling_for_medical_care)
     end
   end
 end

--- a/reporting-app/app/services/external_exceptions_loader.rb
+++ b/reporting-app/app/services/external_exceptions_loader.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "config_loading"
+
+# Loads external-exception configuration by deep-merging an optional deployment
+# override (config/custom/external_exceptions.yml, the deployment-owned override
+# surface) over the federal-floor defaults declared in DEFAULTS below.
+#
+# These are the optional short-term hardship exceptions the external exception
+# check evaluates (see ExceptionDeterminationService). "Exception" is distinct
+# from "exclusion" and "exemption" — do not conflate the three.
+#
+# Defaults represent OSCER's federal floor and are OSCER-owned (updated by
+# Nava as CMS regulations evolve). Deployments customize via the override
+# file, not by editing this constant.
+#
+# The YAML load/parse/error plumbing lives in the shared ConfigLoading module
+# (extend below); this loader keeps only its deep-merge + transform logic. It
+# mirrors ExemptionTypesLoader intentionally.
+module ExternalExceptionsLoader
+  extend ConfigLoading
+
+  # Alias keeps ExternalExceptionsLoader::ConfigurationError valid for
+  # rescues/specs; unqualified `raise ConfigurationError` in transform resolves
+  # to it via lexical scope, so no raise site changes.
+  ConfigurationError = ConfigLoading::ConfigurationError
+
+  DEFAULTS = {
+    "inpatient_medical_care" => { "enabled" => true },
+    "declared_emergency_county" => { "enabled" => true },
+    "high_unemployment_county" => { "enabled" => true },
+    "medical_travel" => { "enabled" => true }
+  }.freeze
+
+  module_function
+
+  def merge_with_defaults(overrides)
+    DEFAULTS.deep_merge(overrides)
+  end
+
+  def transform(merged)
+    merged.map do |id, attrs|
+      unless attrs.is_a?(Hash)
+        raise ConfigurationError, "external_exceptions.#{id}: expected Hash, got #{attrs.class}"
+      end
+      unless attrs.key?("enabled")
+        raise ConfigurationError, "external_exceptions.#{id}: missing required 'enabled' field"
+      end
+      attrs.symbolize_keys.merge(id: id.to_sym)
+    end
+  end
+end

--- a/reporting-app/app/views/demo/certifications/new.html.erb
+++ b/reporting-app/app/views/demo/certifications/new.html.erb
@@ -32,6 +32,8 @@
 
   <%= f.check_box :pregnancy_status %>
 
+  <%= f.select :external_exception, ExternalException.enabled.map { |e| [ t("certifications.demo_create.external_exception_options.#{e[:id]}"), e[:id] ] }, { include_blank: true } %>
+
   <%= f.select :race_ethnicity, Demo::Certifications::CreateForm::RACE_ETHNICITY_OPTIONS.map { |re| [ t("certifications.demo_create.race_ethnicity_options.#{re}"), re ] }, { include_blank: true } %>
 
   <%= f.select :external_scenario, Demo::Certifications::CreateForm::EXTERNAL_SCENARIO_OPTIONS %>

--- a/reporting-app/config/custom/external_exceptions.yml
+++ b/reporting-app/config/custom/external_exceptions.yml
@@ -1,0 +1,42 @@
+# Deployment-owned override surface for external-exception composition.
+#
+# These are the optional short-term hardship exceptions evaluated by the
+# external exception check (see ExceptionDeterminationService). "Exception" is
+# a distinct legal term from "exclusion" and "exemption" — this file governs
+# external exceptions only.
+#
+# OSCER ships this file with no active overrides (the empty hash below); fill
+# it in to tailor which optional exceptions your program applies. Because OSCER
+# rarely edits this file, your overrides stay conflict-free when you sync
+# upstream changes.
+#
+# Loader: app/services/external_exceptions_loader.rb deep-merges this file over
+# the federal-floor defaults declared in ExternalExceptionsLoader::DEFAULTS.
+# Keys present here win; keys absent here inherit from the defaults. See
+# CUSTOMIZATION.md (Config) for the customization model.
+#
+# ## Shape
+#
+# The top-level hash is keyed by external-exception id, with attribute hashes
+# as values. The `enabled` key is required on every entry — the loader raises a
+# boot-time ConfigurationError otherwise.
+#
+# ## Examples
+#
+# Disable an optional exception so the external exception check never applies
+# it:
+#
+#     high_unemployment_county:
+#       enabled: false
+#
+# Federal-floor defaults shipped by OSCER live in
+# ExternalExceptionsLoader::DEFAULTS (app/services/external_exceptions_loader.rb):
+# inpatient_medical_care, declared_emergency_county, high_unemployment_county,
+# medical_travel — all enabled.
+#
+# ## Empty-file note
+#
+# If you want to ship no overrides, leave the empty hash below as-is, or delete
+# the file entirely — the loader treats a missing file as no overrides.
+
+{}

--- a/reporting-app/config/initializers/external_exceptions.rb
+++ b/reporting-app/config/initializers/external_exceptions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Zeitwerk autoloading is not available during initializers, so require explicitly.
+require Rails.root.join("app/services/external_exceptions_loader")
+
+override_path = Rails.root.join("config/custom/external_exceptions.yml")
+overrides     = ExternalExceptionsLoader.safe_load_optional(override_path)
+merged        = ExternalExceptionsLoader.merge_with_defaults(overrides)
+
+Rails.application.config.external_exceptions = ExternalExceptionsLoader.transform(merged)

--- a/reporting-app/config/locales/views/certifications/en.yml
+++ b/reporting-app/config/locales/views/certifications/en.yml
@@ -46,6 +46,12 @@ en:
         new_application: "New application"
         recertification: "Recertification"
       pregnancy_status: "Pregnancy Status"
+      external_exception: "External exception"
+      external_exception_options:
+        inpatient_medical_care: "Receiving inpatient medical care"
+        declared_emergency_county: "Residing in a county with a declared emergency"
+        high_unemployment_county: "Residing in a county with a high unemployment rate"
+        medical_travel: "Traveling for medical care (self or dependent)"
       race_ethnicity_options:
         "white": "White"
         "black_or_african_american": "Black or African American"

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Demo::Certifications::CreateForm do
+  describe "#to_certification external exception mapping" do
+    subject(:member_data) { form.to_certification.member_data }
+
+    let(:form) { described_class.new(certification_date: Date.current, external_exception: selected) }
+
+    context "when inpatient medical care is selected" do
+      let(:selected) { "inpatient_medical_care" }
+
+      it "sets the matching member-data signal so the exception can be triggered" do
+        expect(member_data.receiving_inpatient_medical_care).to be true
+      end
+    end
+
+    context "when declared-emergency county is selected" do
+      let(:selected) { "declared_emergency_county" }
+
+      it "sets the matching member-data signal" do
+        expect(member_data.resides_in_declared_emergency_county).to be true
+      end
+    end
+
+    context "when high-unemployment county is selected" do
+      let(:selected) { "high_unemployment_county" }
+
+      it "sets the matching member-data signal" do
+        expect(member_data.resides_in_high_unemployment_county).to be true
+      end
+    end
+
+    context "when medical travel is selected" do
+      let(:selected) { "medical_travel" }
+
+      it "sets the matching member-data signal" do
+        expect(member_data.traveling_for_medical_care).to be true
+      end
+    end
+
+    context "when no external exception is selected" do
+      let(:selected) { nil }
+
+      it "leaves the exception signals at their defaults" do
+        expect(member_data.receiving_inpatient_medical_care).to be false
+        expect(member_data.resides_in_declared_emergency_county).to be false
+        expect(member_data.resides_in_high_unemployment_county).to be false
+        expect(member_data.traveling_for_medical_care).to be false
+      end
+    end
+  end
+end

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#record_exception_determination' do
-    # The positive (excepted) path is wired end to end but currently unreachable: no exception
-    # checks are registered, so ExceptionDeterminationService never supplies reason codes. When a
-    # check story does, the case records an automated :excepted determination and closes. Reason
-    # codes are supplied by the caller (deferred to each check's story).
-    let(:reason_codes) { [ 'external_exception_met' ] }
+    # The excepted path records an automated :excepted determination and closes the case. Reason
+    # codes are supplied by the caller (ExceptionDeterminationService, from the matched check); use a
+    # real reason so the determination passes its reasons-inclusion validation.
+    let(:reason_codes) { [ 'inpatient_medical_care_excepted' ] }
 
     it 'records an automated determination with the excepted outcome' do
       expect {

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Determination, type: :model do
           veteran_disability_excluded
           denial_response_convincing
           denial_response_not_convincing
+          inpatient_medical_care_excepted
+          declared_emergency_county_excepted
+          high_unemployment_county_excepted
+          medical_travel_excepted
         ]
         expect(Determination::VALID_REASONS).to match_array(expected_reasons)
       end

--- a/reporting-app/spec/models/external_exception_spec.rb
+++ b/reporting-app/spec/models/external_exception_spec.rb
@@ -19,38 +19,6 @@ RSpec.describe ExternalException, type: :model do
     end
   end
 
-  describe ".ids" do
-    it "returns the list of external-exception ids as symbols" do
-      expect(described_class.ids).to match_array(
-        %i[inpatient_medical_care declared_emergency_county high_unemployment_county medical_travel]
-      )
-    end
-  end
-
-  describe ".find" do
-    it "returns the config entry for a given id" do
-      expect(described_class.find(:inpatient_medical_care)[:id]).to eq(:inpatient_medical_care)
-    end
-
-    it "accepts a string id" do
-      expect(described_class.find("medical_travel")[:id]).to eq(:medical_travel)
-    end
-
-    it "returns nil for an unknown id" do
-      expect(described_class.find(:not_a_real_exception)).to be_nil
-    end
-  end
-
-  describe ".valid_type?" do
-    it "is true for a known id (regardless of enabled state)" do
-      expect(described_class.valid_type?(:medical_travel)).to be true
-    end
-
-    it "is false for an unknown id" do
-      expect(described_class.valid_type?(:not_a_real_exception)).to be false
-    end
-  end
-
   describe ".enabled and .enabled?" do
     context "when all defaults are enabled" do
       it ".enabled returns all four" do
@@ -91,10 +59,6 @@ RSpec.describe ExternalException, type: :model do
 
       it ".enabled? remains true for the still-enabled types" do
         expect(described_class.enabled?(:inpatient_medical_care)).to be true
-      end
-
-      it ".valid_type? is still true for the disabled type (known but off)" do
-        expect(described_class.valid_type?(:high_unemployment_county)).to be true
       end
     end
   end

--- a/reporting-app/spec/models/external_exception_spec.rb
+++ b/reporting-app/spec/models/external_exception_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExternalException, type: :model do
+  describe ".all" do
+    it "returns all 4 external exceptions" do
+      expect(described_class.all.size).to eq(4)
+    end
+
+    it "contains the specific external-exception IDs" do
+      expected_ids = %i[
+        inpatient_medical_care
+        declared_emergency_county
+        high_unemployment_county
+        medical_travel
+      ]
+      expect(described_class.all.map { |t| t[:id] }).to match_array(expected_ids)
+    end
+  end
+
+  describe ".ids" do
+    it "returns the list of external-exception ids as symbols" do
+      expect(described_class.ids).to match_array(
+        %i[inpatient_medical_care declared_emergency_county high_unemployment_county medical_travel]
+      )
+    end
+  end
+
+  describe ".find" do
+    it "returns the config entry for a given id" do
+      expect(described_class.find(:inpatient_medical_care)[:id]).to eq(:inpatient_medical_care)
+    end
+
+    it "accepts a string id" do
+      expect(described_class.find("medical_travel")[:id]).to eq(:medical_travel)
+    end
+
+    it "returns nil for an unknown id" do
+      expect(described_class.find(:not_a_real_exception)).to be_nil
+    end
+  end
+
+  describe ".valid_type?" do
+    it "is true for a known id (regardless of enabled state)" do
+      expect(described_class.valid_type?(:medical_travel)).to be true
+    end
+
+    it "is false for an unknown id" do
+      expect(described_class.valid_type?(:not_a_real_exception)).to be false
+    end
+  end
+
+  describe ".enabled and .enabled?" do
+    context "when all defaults are enabled" do
+      it ".enabled returns all four" do
+        expect(described_class.enabled.map { |t| t[:id] }).to match_array(
+          %i[inpatient_medical_care declared_emergency_county high_unemployment_county medical_travel]
+        )
+      end
+
+      it ".enabled? is true for each id (string or symbol)" do
+        expect(described_class.enabled?(:medical_travel)).to be true
+        expect(described_class.enabled?("inpatient_medical_care")).to be true
+      end
+
+      it ".enabled? is false for an unknown id" do
+        expect(described_class.enabled?(:not_a_real_exception)).to be false
+      end
+    end
+
+    context "when a type is disabled via configuration" do
+      before do
+        allow(Rails.application.config).to receive(:external_exceptions).and_return(
+          [
+            { id: :inpatient_medical_care, enabled: true },
+            { id: :declared_emergency_county, enabled: true },
+            { id: :high_unemployment_county, enabled: false },
+            { id: :medical_travel, enabled: true }
+          ]
+        )
+      end
+
+      it ".enabled excludes the disabled type" do
+        expect(described_class.enabled.map { |t| t[:id] }).not_to include(:high_unemployment_county)
+      end
+
+      it ".enabled? is false for the disabled type" do
+        expect(described_class.enabled?(:high_unemployment_county)).to be false
+      end
+
+      it ".enabled? remains true for the still-enabled types" do
+        expect(described_class.enabled?(:inpatient_medical_care)).to be true
+      end
+
+      it ".valid_type? is still true for the disabled type (known but off)" do
+        expect(described_class.valid_type?(:high_unemployment_county)).to be true
+      end
+    end
+  end
+end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -319,6 +319,18 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(cert.member_data.pregnancy_status).to be true
       end
 
+      it "creates a new Certification with an external exception selected" do
+        create_attrs = valid_request_attributes.merge({ external_exception: "inpatient_medical_care", external_scenario: "No data" })
+
+        expect {
+          post demo_certifications_url,
+               params: { demo_certifications_create_form: create_attrs }
+        }.to change(Certification, :count).by(1)
+
+        cert = Certification.order(created_at: :desc).last
+        expect(cert.member_data.receiving_inpatient_medical_care).to be true
+      end
+
       it "creates a new Certification with race_ethnicity selected" do
         create_attrs = valid_request_attributes.merge({ race_ethnicity: "white", external_scenario: "No data" })
 

--- a/reporting-app/spec/services/exception_determination_service_spec.rb
+++ b/reporting-app/spec/services/exception_determination_service_spec.rb
@@ -12,8 +12,53 @@ RSpec.describe ExceptionDeterminationService do
     allow(NotificationService).to receive(:send_email_notification)
   end
 
+  # Each check's member data is set up in its own context; these shared examples assert the common
+  # excepted / not-excepted outcomes.
+  shared_examples 'an applied external exception' do |reason_code|
+    it 'records an excepted determination carrying the reason code' do
+      expect { service.determine(kase) }.to change {
+        Determination.where(subject: certification, outcome: 'excepted').count
+      }.by(1)
+
+      determination = Determination.where(subject: certification, outcome: 'excepted').first
+      expect(determination.reasons).to eq([ reason_code ])
+    end
+
+    it 'closes the case' do
+      service.determine(kase)
+      expect(kase.reload.status).to eq('closed')
+    end
+
+    it 'publishes DeterminedExcepted' do
+      service.determine(kase)
+      expect(Strata::EventManager).to have_received(:publish)
+        .with('DeterminedExcepted', { case_id: kase.id, certification_id: kase.certification_id })
+    end
+  end
+
+  shared_examples 'a disabled external exception' do |exception_id|
+    before do
+      # Default to the real config, then disable only the exception under test, so the checks that
+      # run before it (up to the first success) still consult real enablement.
+      allow(ExternalException).to receive(:enabled?).and_call_original
+      allow(ExternalException).to receive(:enabled?).with(exception_id).and_return(false)
+    end
+
+    it 'does not except the member (publishes DeterminedNotExcepted)' do
+      service.determine(kase)
+      expect(Strata::EventManager).to have_received(:publish)
+        .with('DeterminedNotExcepted', { case_id: kase.id, certification_id: kase.certification_id })
+    end
+
+    it 'does not record an exception determination' do
+      expect { service.determine(kase) }.not_to change {
+        Determination.where(subject: certification, outcome: 'excepted').count
+      }
+    end
+  end
+
   describe '#determine' do
-    context 'when no exception check applies (no checks registered — current state)' do
+    context 'when no exception check applies (member data carries no exception signals)' do
       it 'publishes DeterminedNotExcepted' do
         service.determine(kase)
         expect(Strata::EventManager).to have_received(:publish)
@@ -44,18 +89,69 @@ RSpec.describe ExceptionDeterminationService do
       end
     end
 
-    # The positive (excepted) path is wired but currently unreachable: no checks are registered, so
-    # applicable_exception_reason_codes always returns []. This documents that when a check does
-    # apply, the service records the determination and publishes DeterminedExcepted.
-    context 'when an exception check applies (positive path wiring)' do
+    context 'when the inpatient-medical-care check applies' do
+      let(:certification) do
+        create(:certification, member_data: build(:certification_member_data, receiving_inpatient_medical_care: true))
+      end
+
+      it_behaves_like 'an applied external exception', 'inpatient_medical_care_excepted'
+      it_behaves_like 'a disabled external exception', :inpatient_medical_care
+    end
+
+    context 'when the declared-emergency-county check applies' do
+      let(:certification) do
+        create(:certification, member_data: build(:certification_member_data, resides_in_declared_emergency_county: true))
+      end
+
+      it_behaves_like 'an applied external exception', 'declared_emergency_county_excepted'
+      it_behaves_like 'a disabled external exception', :declared_emergency_county
+    end
+
+    context 'when the high-unemployment-county check applies' do
+      let(:certification) do
+        create(:certification, member_data: build(:certification_member_data, resides_in_high_unemployment_county: true))
+      end
+
+      it_behaves_like 'an applied external exception', 'high_unemployment_county_excepted'
+      it_behaves_like 'a disabled external exception', :high_unemployment_county
+    end
+
+    context 'when the medical-travel check applies' do
+      let(:certification) do
+        create(:certification, member_data: build(:certification_member_data, traveling_for_medical_care: true))
+      end
+
+      it_behaves_like 'an applied external exception', 'medical_travel_excepted'
+      it_behaves_like 'a disabled external exception', :medical_travel
+    end
+
+    context 'when more than one exception check would apply' do
+      let(:certification) do
+        create(:certification, member_data: build(
+          :certification_member_data,
+          receiving_inpatient_medical_care: true,
+          resides_in_declared_emergency_county: true
+        ))
+      end
+
+      it 'records only the first applicable reason (stops at first success)' do
+        service.determine(kase)
+        determination = Determination.where(subject: certification, outcome: 'excepted').first
+        expect(determination.reasons).to eq([ 'inpatient_medical_care_excepted' ])
+      end
+    end
+
+    # Isolates the determine() plumbing from the concrete checks: whatever reason codes the checks
+    # produce, determine records them and publishes DeterminedExcepted.
+    context 'when checks are stubbed (positive-path wiring)' do
       before do
-        allow(service).to receive(:applicable_exception_reason_codes).and_return([ 'some_reason' ])
+        allow(service).to receive(:applicable_exception_reason_codes).and_return([ 'inpatient_medical_care_excepted' ])
         allow(kase).to receive(:record_exception_determination)
       end
 
       it 'records the exception determination on the case' do
         service.determine(kase)
-        expect(kase).to have_received(:record_exception_determination).with([ 'some_reason' ], service)
+        expect(kase).to have_received(:record_exception_determination).with([ 'inpatient_medical_care_excepted' ], service)
       end
 
       it 'publishes DeterminedExcepted' do

--- a/reporting-app/spec/services/external_exceptions_loader_spec.rb
+++ b/reporting-app/spec/services/external_exceptions_loader_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExternalExceptionsLoader, type: :service do
+  # write_yaml comes from spec/support/yaml_config_helpers.rb.
+
+  it "aliases ConfigurationError to the shared ConfigLoading::ConfigurationError" do
+    # The alias is load-bearing: it keeps ExternalExceptionsLoader::ConfigurationError
+    # valid for rescues/specs and makes unqualified `raise ConfigurationError`
+    # in transform resolve to the shared class. Pin the object identity explicitly.
+    expect(described_class::ConfigurationError).to equal(ConfigLoading::ConfigurationError)
+  end
+
+  describe ".safe_load_optional" do
+    context "when the file does not exist" do
+      it "returns an empty hash without raising" do
+        missing_path = "/tmp/definitely_not_a_real_override_#{SecureRandom.hex}.yml"
+        result = nil
+        expect {
+          result = described_class.safe_load_optional(missing_path)
+        }.not_to raise_error
+        expect(result).to eq({})
+      end
+    end
+
+    context "when the file is empty (parses to nil)" do
+      let(:empty_file) { write_yaml("") }
+
+      after { empty_file.unlink }
+
+      it "returns an empty hash without raising" do
+        expect(described_class.safe_load_optional(empty_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains only comments (parses to nil)" do
+      let(:comments_only_file) { write_yaml("# just a comment\n# another comment\n") }
+
+      after { comments_only_file.unlink }
+
+      it "returns an empty hash without raising" do
+        expect(described_class.safe_load_optional(comments_only_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains a literal empty hash" do
+      let(:empty_hash_file) { write_yaml("{}\n") }
+
+      after { empty_hash_file.unlink }
+
+      it "returns an empty hash" do
+        expect(described_class.safe_load_optional(empty_hash_file.path)).to eq({})
+      end
+    end
+
+    context "when the file contains a valid override hash" do
+      let(:override_file) do
+        write_yaml(<<~YAML)
+          high_unemployment_county:
+            enabled: false
+          disaster_evacuation:
+            enabled: true
+        YAML
+      end
+
+      after { override_file.unlink }
+
+      it "returns the parsed hash with string keys" do
+        result = described_class.safe_load_optional(override_file.path)
+        expect(result).to eq(
+          "high_unemployment_county" => { "enabled" => false },
+          "disaster_evacuation" => { "enabled" => true }
+        )
+      end
+    end
+
+    context "when the YAML contains a disallowed Ruby tag" do
+      let(:disallowed_file) { write_yaml("high_unemployment_county: !ruby/symbol enabled") }
+
+      after { disallowed_file.unlink }
+
+      it "raises ConfigurationError with 'Invalid YAML'" do
+        expect {
+          described_class.safe_load_optional(disallowed_file.path)
+        }.to raise_error(ExternalExceptionsLoader::ConfigurationError, /Invalid YAML/)
+      end
+    end
+
+    context "when the YAML is malformed" do
+      let(:malformed_file) { write_yaml("high_unemployment_county: :\n  bad indent: [unclosed") }
+
+      after { malformed_file.unlink }
+
+      it "raises ConfigurationError with 'Invalid YAML'" do
+        expect {
+          described_class.safe_load_optional(malformed_file.path)
+        }.to raise_error(ExternalExceptionsLoader::ConfigurationError, /Invalid YAML/)
+      end
+    end
+
+    context "when the YAML has a non-Hash top level" do
+      let(:list_file) { write_yaml("- just\n- a\n- list\n") }
+
+      after { list_file.unlink }
+
+      it "raises ConfigurationError matching 'Expected a Hash at top level'" do
+        expect {
+          described_class.safe_load_optional(list_file.path)
+        }.to raise_error(ExternalExceptionsLoader::ConfigurationError, /Expected a Hash at top level/)
+      end
+    end
+  end
+
+  describe ".merge_with_defaults" do
+    context "with an empty override hash" do
+      it "returns DEFAULTS verbatim" do
+        expect(described_class.merge_with_defaults({})).to eq(ExternalExceptionsLoader::DEFAULTS)
+      end
+    end
+
+    context "with an override that disables a default" do
+      it "deep-merges; override values win on shared keys" do
+        result = described_class.merge_with_defaults("high_unemployment_county" => { "enabled" => false })
+        expect(result["high_unemployment_county"]["enabled"]).to be false
+        expect(result["inpatient_medical_care"]["enabled"]).to be true
+      end
+
+      it "preserves all other defaults intact" do
+        result = described_class.merge_with_defaults("high_unemployment_county" => { "enabled" => false })
+        expect(result.size).to eq(ExternalExceptionsLoader::DEFAULTS.size)
+        %w[inpatient_medical_care declared_emergency_county medical_travel].each do |id|
+          expect(result[id]["enabled"]).to be true
+        end
+      end
+    end
+
+    context "with an override that adds a new entry" do
+      it "produces all defaults plus the new entry" do
+        result = described_class.merge_with_defaults("disaster_evacuation" => { "enabled" => true })
+        expect(result.size).to eq(ExternalExceptionsLoader::DEFAULTS.size + 1)
+        expect(result["disaster_evacuation"]["enabled"]).to be true
+      end
+    end
+  end
+
+  describe ".transform" do
+    context "with a well-formed hash-of-hashes (happy path)" do
+      let(:merged) do
+        {
+          "inpatient_medical_care" => { "enabled" => true, "display_order" => 1 },
+          "medical_travel" => { "enabled" => true }
+        }
+      end
+
+      it "returns an array of entries with id as Symbol and enabled as Boolean" do
+        result = described_class.transform(merged)
+        expect(result).to be_an(Array)
+        expect(result.first[:id]).to be_a(Symbol)
+        expect(result.first[:enabled]).to be(true).or be(false)
+      end
+
+      # Regression guard for the `attrs.symbolize_keys.merge(id: id.to_sym)`
+      # pass-through (vs. hardcoded `{id:, enabled:}` narrowing). If a future
+      # refactor narrows the merge to only well-known keys, this fails.
+      it "passes through extra entry attributes unchanged" do
+        result = described_class.transform(merged)
+        entry = result.find { |e| e[:id] == :inpatient_medical_care }
+        expect(entry[:display_order]).to eq(1)
+      end
+    end
+
+    context "when an entry value is not a Hash" do
+      it "raises ConfigurationError mentioning the offending id" do
+        merged = { "inpatient_medical_care" => true }
+        expect {
+          described_class.transform(merged)
+        }.to raise_error(ExternalExceptionsLoader::ConfigurationError, /inpatient_medical_care/)
+      end
+    end
+
+    context "when an entry is missing the enabled field" do
+      it "raises ConfigurationError mentioning the offending id" do
+        merged = { "inpatient_medical_care" => {} }
+        expect {
+          described_class.transform(merged)
+        }.to raise_error(ExternalExceptionsLoader::ConfigurationError, /inpatient_medical_care/)
+      end
+    end
+  end
+
+  describe "round-trip" do
+    # Locks Hash#key? semantics: enabled: false must round-trip as Boolean false
+    # rather than triggering the missing-field error path.
+    context "when enabled is explicitly set to false" do
+      let(:override_file) do
+        write_yaml(<<~YAML)
+          medical_travel:
+            enabled: false
+        YAML
+      end
+
+      after { override_file.unlink }
+
+      it "preserves enabled: false as Boolean false through load + merge + transform" do
+        overrides = described_class.safe_load_optional(override_file.path)
+        merged = described_class.merge_with_defaults(overrides)
+        result = described_class.transform(merged)
+        entry = result.find { |e| e[:id] == :medical_travel }
+        expect(entry[:enabled]).to be false
+      end
+    end
+  end
+
+  describe "integration" do
+    it "module-direct against real override path returns the 4 OSCER defaults, all enabled" do
+      override_path = Rails.root.join("config/custom/external_exceptions.yml")
+      overrides = described_class.safe_load_optional(override_path)
+      merged = described_class.merge_with_defaults(overrides)
+      result = described_class.transform(merged)
+
+      expected_ids = %i[
+        inpatient_medical_care
+        declared_emergency_county
+        high_unemployment_county
+        medical_travel
+      ]
+      expect(result.map { |e| e[:id] }).to match_array(expected_ids)
+      expect(result.map { |e| e[:enabled] }).to all(be true)
+    end
+
+    # Initializer-wired boot test: catches initializer-wiring regressions
+    # (e.g., missing explicit require, name typo on Rails.application.config)
+    # that module-direct tests can't see.
+    it "Rails.application.config.external_exceptions is wired by the initializer on boot" do
+      types = Rails.application.config.external_exceptions
+      expect(types).to be_an(Array)
+      expected_ids = %i[
+        inpatient_medical_care
+        declared_emergency_county
+        high_unemployment_county
+        medical_travel
+      ]
+      expect(types.map { |e| e[:id] }).to match_array(expected_ids)
+      expect(types.map { |e| e[:enabled] }).to all(be true)
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves #746 

## Changes

- ExternalException configuration complex
- Easy checks in ExceptionDeterminationService
- Exceptions added to Demo

## Context for reviewers

States will need to optionally enable/disable optional exceptions.

## Testing
Tests added and passed

Manually verified via demo:
- Exception determination made
- Exception determination not made when Exclusion existed
- Exception not made when not in demo
- Exception not made when configured off

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->