### PR TITLE
Add Exclusion priority configuration (yml-configured Exclusion model)

### DIFF
--- a/reporting-app/app/models/exclusion.rb
+++ b/reporting-app/app/models/exclusion.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Utility class exposing the configured exclusions in priority order (highest
+# durability first). Backs the background exclusion-determination flow, which
+# evaluates exclusions from most to least durable. Configuration is loaded at
+# boot into Rails.application.config.exclusion_types by
+# config/initializers/exclusion_types.rb (see ExclusionTypesLoader).
+#
+# Exclusions are the mandatory federal minimum, so there is no enable/disable
+# concept: every configured exclusion is always evaluated. This is the
+# priority-ordering registry only; member-facing display is keyed by reason code
+# elsewhere (MemberStatusService), not by this config.
+class Exclusion
+  class << self
+    # All exclusions, sorted ascending by :priority (1 = highest durability).
+    def all
+      Rails.application.config.exclusion_types.sort_by { |t| t[:priority] }
+    end
+
+    # Exclusion ids in priority order (high durability -> low). This is the
+    # order the determination flow evaluates, stopping at the first match.
+    def priority_order
+      all.map { |t| t[:id] }
+    end
+
+    # All exclusion ids as strings (for enum-style validation).
+    def valid_values
+      all.map { |t| t[:id].to_s }
+    end
+
+    def find(id)
+      all.find { |t| t[:id] == id.to_sym }
+    end
+  end
+end

--- a/reporting-app/app/services/exclusion_types_loader.rb
+++ b/reporting-app/app/services/exclusion_types_loader.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "config_loading"
+
+# Loads exclusion-type configuration by deep-merging an optional deployment
+# override (config/custom/exclusion_types.yml, the deployment-owned override
+# surface) over the mandatory federal-minimum exclusions declared in DEFAULTS
+# below.
+#
+# Exclusions are the federal minimum set of conditions that remove a member from
+# the community-engagement requirement; a deployment cannot disable one, so
+# entries carry no `enabled` flag. The only configurable dimension is `priority`
+# (Integer, 1 = highest durability), which lets a deployment re-rank the order in
+# which exclusions are evaluated. The default ranking is OSCER-owned (updated by
+# Nava as CMS regulations evolve).
+#
+# Mirrors ExemptionTypesLoader; the YAML load/parse/error plumbing lives in the
+# shared ConfigLoading module (extend below). This loader keeps only its
+# deep-merge + transform logic, whose validation requires a distinct integer
+# `priority` per entry.
+module ExclusionTypesLoader
+  extend ConfigLoading
+
+  # Alias keeps ExclusionTypesLoader::ConfigurationError valid for existing
+  # rescues/specs; unqualified `raise ConfigurationError` in transform resolves
+  # to it via lexical scope, so no raise site changes.
+  ConfigurationError = ConfigLoading::ConfigurationError
+
+  # Default exclusion priority order (high durability -> low), per the
+  # Data Source Hierarchy spec. Only american_indian_alaska_native,
+  # veteran_disability, and pregnant have rules in Rules::ExclusionRuleset
+  # today; the rest are declarative until their rules land.
+  DEFAULTS = {
+    "american_indian_alaska_native" => { "priority" => 1 },
+    "former_foster_care" => { "priority" => 2 },
+    "veteran_disability" => { "priority" => 3 },
+    "medically_frail" => { "priority" => 4 },
+    "caretaker" => { "priority" => 5 },
+    "tanf_snap_work" => { "priority" => 6 },
+    "drug_treatment" => { "priority" => 7 },
+    "pregnant" => { "priority" => 8 },
+    "inmate" => { "priority" => 9 }
+  }.freeze
+
+  module_function
+
+  def merge_with_defaults(overrides)
+    DEFAULTS.deep_merge(overrides)
+  end
+
+  def transform(merged)
+    entries = merged.map do |id, attrs|
+      unless attrs.is_a?(Hash)
+        raise ConfigurationError, "exclusion_types.#{id}: expected Hash, got #{attrs.class}"
+      end
+      unless attrs.key?("priority")
+        raise ConfigurationError, "exclusion_types.#{id}: missing required 'priority' field"
+      end
+      unless attrs["priority"].is_a?(Integer)
+        raise ConfigurationError, "exclusion_types.#{id}: 'priority' must be an Integer"
+      end
+      attrs.symbolize_keys.merge(id: id.to_sym)
+    end
+
+    # Priority is a strict ordering: two exclusions sharing a priority would make
+    # evaluation order depend on an unstable sort. Reject duplicates at boot
+    # rather than silently pick a winner.
+    duplicates = entries.map { |e| e[:priority] }.tally.select { |_priority, count| count > 1 }.keys.sort
+    unless duplicates.empty?
+      raise ConfigurationError, "exclusion_types: duplicate priority values #{duplicates}; each exclusion must have a distinct priority"
+    end
+
+    entries
+  end
+end

--- a/reporting-app/app/services/exclusion_types_loader.rb
+++ b/reporting-app/app/services/exclusion_types_loader.rb
@@ -30,16 +30,20 @@ module ExclusionTypesLoader
   # Data Source Hierarchy spec. Only american_indian_alaska_native,
   # veteran_disability, and pregnant have rules in Rules::ExclusionRuleset
   # today; the rest are declarative until their rules land.
+  #
+  # Priorities are spaced by 10 so a deployment can re-rank one exclusion by
+  # dropping it into the gap between two others (e.g. priority 55 to sit
+  # between 50 and 60) without renumbering the rest.
   DEFAULTS = {
-    "american_indian_alaska_native" => { "priority" => 1 },
-    "former_foster_care" => { "priority" => 2 },
-    "veteran_disability" => { "priority" => 3 },
-    "medically_frail" => { "priority" => 4 },
-    "caretaker" => { "priority" => 5 },
-    "tanf_snap_work" => { "priority" => 6 },
-    "drug_treatment" => { "priority" => 7 },
-    "pregnant" => { "priority" => 8 },
-    "inmate" => { "priority" => 9 }
+    "american_indian_alaska_native" => { "priority" => 10 },
+    "former_foster_care" => { "priority" => 20 },
+    "veteran_disability" => { "priority" => 30 },
+    "medically_frail" => { "priority" => 40 },
+    "caretaker" => { "priority" => 50 },
+    "tanf_snap_work" => { "priority" => 60 },
+    "drug_treatment" => { "priority" => 70 },
+    "pregnant" => { "priority" => 80 },
+    "inmate" => { "priority" => 90 }
   }.freeze
 
   module_function

--- a/reporting-app/config/custom/exclusion_types.yml
+++ b/reporting-app/config/custom/exclusion_types.yml
@@ -1,0 +1,50 @@
+# Deployment-owned override surface for exclusion priority configuration.
+#
+# OSCER ships this file with no active overrides (the empty hash below); fill
+# it in to re-rank exclusions or add deployment-specific ones. Because OSCER
+# rarely edits this file, your overrides stay conflict-free when you sync
+# upstream changes.
+#
+# Exclusions are the mandatory federal minimum: a deployment cannot disable one,
+# so there is no `enabled` field. The only configurable dimension is `priority`.
+#
+# Loader: app/services/exclusion_types_loader.rb deep-merges this file over the
+# federal-minimum defaults declared in ExclusionTypesLoader::DEFAULTS. Keys
+# present here win; keys absent here inherit from the defaults. See
+# CUSTOMIZATION.md (Config) for the customization model.
+#
+# ## Shape
+#
+# The top-level hash is keyed by exclusion id, with attribute hashes as values.
+# Each entry requires a `priority` (Integer, 1 = highest durability) — the
+# loader raises a boot-time ConfigurationError otherwise. Priorities must be
+# distinct across all entries; a duplicate priority also raises at boot. Because
+# deep-merge operates per key, an override can change one exclusion's priority
+# without restating the others.
+#
+# ## Examples
+#
+# Re-rank exclusions by swapping their priorities. Because priorities must stay
+# distinct, promoting one exclusion means demoting whatever held that slot; a
+# promotion is always a swap (here, veteran disability and American Indian /
+# Alaska Native trade priorities 3 and 1):
+#
+#     veteran_disability:
+#       priority: 1
+#     american_indian_alaska_native:
+#       priority: 3
+#
+# Add a deployment-specific exclusion (use a not-yet-used priority):
+#
+#     state_specific_exclusion:
+#       priority: 10
+#
+# Federal-minimum defaults shipped by OSCER live in
+# ExclusionTypesLoader::DEFAULTS (app/services/exclusion_types_loader.rb).
+#
+# ## Empty-file note
+#
+# If you want to ship no overrides, leave the empty hash below as-is, or delete
+# the file entirely — the loader treats a missing file as no overrides.
+
+{}

--- a/reporting-app/config/custom/exclusion_types.yml
+++ b/reporting-app/config/custom/exclusion_types.yml
@@ -16,28 +16,26 @@
 # ## Shape
 #
 # The top-level hash is keyed by exclusion id, with attribute hashes as values.
-# Each entry requires a `priority` (Integer, 1 = highest durability) — the
+# Each entry requires a `priority` (Integer, lower = higher durability) — the
 # loader raises a boot-time ConfigurationError otherwise. Priorities must be
-# distinct across all entries; a duplicate priority also raises at boot. Because
-# deep-merge operates per key, an override can change one exclusion's priority
-# without restating the others.
+# distinct across all entries; a duplicate priority also raises at boot. The
+# shipped defaults are spaced by 10 (10, 20, 30, ...). Because deep-merge
+# operates per key, an override can change one exclusion's priority without
+# restating the others.
 #
 # ## Examples
 #
-# Re-rank exclusions by swapping their priorities. Because priorities must stay
-# distinct, promoting one exclusion means demoting whatever held that slot; a
-# promotion is always a swap (here, veteran disability and American Indian /
-# Alaska Native trade priorities 3 and 1):
+# Re-rank an exclusion by dropping it into the gap between its new neighbors.
+# The by-10 spacing means you move one without renumbering the rest: to move
+# former foster care just below caretaker (priority 50), set it to 55.
 #
-#     veteran_disability:
-#       priority: 1
-#     american_indian_alaska_native:
-#       priority: 3
+#     former_foster_care:
+#       priority: 55
 #
 # Add a deployment-specific exclusion (use a not-yet-used priority):
 #
 #     state_specific_exclusion:
-#       priority: 10
+#       priority: 100
 #
 # Federal-minimum defaults shipped by OSCER live in
 # ExclusionTypesLoader::DEFAULTS (app/services/exclusion_types_loader.rb).

--- a/reporting-app/config/initializers/exclusion_types.rb
+++ b/reporting-app/config/initializers/exclusion_types.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Zeitwerk autoloading is not available during initializers, so require explicitly.
+require Rails.root.join("app/services/exclusion_types_loader")
+
+override_path = Rails.root.join("config/custom/exclusion_types.yml")
+overrides     = ExclusionTypesLoader.safe_load_optional(override_path)
+merged        = ExclusionTypesLoader.merge_with_defaults(overrides)
+
+Rails.application.config.exclusion_types = ExclusionTypesLoader.transform(merged)

--- a/reporting-app/spec/models/exclusion_spec.rb
+++ b/reporting-app/spec/models/exclusion_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Exclusion, type: :model do
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
           [
-            { id: :pregnant, priority: 8 },
-            { id: :american_indian_alaska_native, priority: 1 },
-            { id: :veteran_disability, priority: 3 }
+            { id: :pregnant, priority: 80 },
+            { id: :american_indian_alaska_native, priority: 10 },
+            { id: :veteran_disability, priority: 30 }
           ]
         )
       end
@@ -62,7 +62,7 @@ RSpec.describe Exclusion, type: :model do
     it "returns the config entry for a given id" do
       entry = described_class.find(:veteran_disability)
       expect(entry[:id]).to eq(:veteran_disability)
-      expect(entry[:priority]).to eq(3)
+      expect(entry[:priority]).to eq(30)
     end
 
     it "returns nil for an unknown id" do

--- a/reporting-app/spec/models/exclusion_spec.rb
+++ b/reporting-app/spec/models/exclusion_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Exclusion, type: :model do
+  # The spec's default priority order (high durability -> low).
+  let(:priority_ordered_ids) do
+    %i[
+      american_indian_alaska_native
+      former_foster_care
+      veteran_disability
+      medically_frail
+      caretaker
+      tanf_snap_work
+      drug_treatment
+      pregnant
+      inmate
+    ]
+  end
+
+  describe ".all" do
+    it "returns all 9 exclusion types" do
+      expect(described_class.all.size).to eq(9)
+    end
+
+    it "is sorted ascending by :priority (highest durability first)" do
+      expect(described_class.all.map { |t| t[:id] }).to eq(priority_ordered_ids)
+    end
+
+    context "when the config is declared out of priority order" do
+      before do
+        allow(Rails.application.config).to receive(:exclusion_types).and_return(
+          [
+            { id: :pregnant, priority: 8 },
+            { id: :american_indian_alaska_native, priority: 1 },
+            { id: :veteran_disability, priority: 3 }
+          ]
+        )
+      end
+
+      it "returns entries sorted ascending by :priority" do
+        expect(described_class.all.map { |t| t[:id] }).to eq(
+          %i[american_indian_alaska_native veteran_disability pregnant]
+        )
+      end
+    end
+  end
+
+  describe ".priority_order" do
+    it "returns all exclusion ids in priority order (high to low)" do
+      expect(described_class.priority_order).to eq(priority_ordered_ids)
+    end
+  end
+
+  describe ".valid_values" do
+    it "returns the 9 exclusion ids as strings" do
+      expect(described_class.valid_values).to match_array(priority_ordered_ids.map(&:to_s))
+    end
+  end
+
+  describe ".find" do
+    it "returns the config entry for a given id" do
+      entry = described_class.find(:veteran_disability)
+      expect(entry[:id]).to eq(:veteran_disability)
+      expect(entry[:priority]).to eq(3)
+    end
+
+    it "returns nil for an unknown id" do
+      expect(described_class.find(:not_a_real_exclusion)).to be_nil
+    end
+  end
+end

--- a/reporting-app/spec/services/exclusion_types_loader_spec.rb
+++ b/reporting-app/spec/services/exclusion_types_loader_spec.rb
@@ -5,18 +5,18 @@ require "rails_helper"
 RSpec.describe ExclusionTypesLoader, type: :service do
   # write_yaml comes from spec/support/yaml_config_helpers.rb.
 
-  # The spec's default priority order (high durability -> low), priorities 1-9.
+  # The spec's default priority order (high durability -> low), spaced by 10.
   let(:expected_defaults) do
     {
-      american_indian_alaska_native: 1,
-      former_foster_care: 2,
-      veteran_disability: 3,
-      medically_frail: 4,
-      caretaker: 5,
-      tanf_snap_work: 6,
-      drug_treatment: 7,
-      pregnant: 8,
-      inmate: 9
+      american_indian_alaska_native: 10,
+      former_foster_care: 20,
+      veteran_disability: 30,
+      medically_frail: 40,
+      caretaker: 50,
+      tanf_snap_work: 60,
+      drug_treatment: 70,
+      pregnant: 80,
+      inmate: 90
     }
   end
 
@@ -38,8 +38,8 @@ RSpec.describe ExclusionTypesLoader, type: :service do
     context "when the file contains a valid override hash" do
       let(:override_file) do
         write_yaml(<<~YAML)
-          veteran_disability:
-            priority: 1
+          former_foster_care:
+            priority: 55
         YAML
       end
 
@@ -47,7 +47,7 @@ RSpec.describe ExclusionTypesLoader, type: :service do
 
       it "returns the parsed hash with string keys" do
         expect(described_class.safe_load_optional(override_file.path)).to eq(
-          "veteran_disability" => { "priority" => 1 }
+          "former_foster_care" => { "priority" => 55 }
         )
       end
     end
@@ -60,24 +60,22 @@ RSpec.describe ExclusionTypesLoader, type: :service do
       end
     end
 
-    context "with an override that swaps two priorities" do
-      it "deep-merges; the overridden priorities win and unrelated entries are untouched" do
-        result = described_class.merge_with_defaults(
-          "veteran_disability" => { "priority" => 1 },
-          "american_indian_alaska_native" => { "priority" => 3 }
-        )
-        expect(result["veteran_disability"]["priority"]).to eq(1)
-        expect(result["american_indian_alaska_native"]["priority"]).to eq(3)
-        expect(result["pregnant"]["priority"]).to eq(8)
+    context "with an override that re-ranks an exclusion into a gap" do
+      it "deep-merges; the overridden priority wins and unrelated entries are untouched" do
+        # Move former_foster_care (20) into the gap just below caretaker (50).
+        result = described_class.merge_with_defaults("former_foster_care" => { "priority" => 55 })
+        expect(result["former_foster_care"]["priority"]).to eq(55)
+        expect(result["caretaker"]["priority"]).to eq(50)
+        expect(result["american_indian_alaska_native"]["priority"]).to eq(10)
         expect(result.size).to eq(ExclusionTypesLoader::DEFAULTS.size)
       end
     end
 
     context "with an override that adds a new exclusion" do
       it "produces all defaults plus the new entry" do
-        result = described_class.merge_with_defaults("state_specific" => { "priority" => 10 })
+        result = described_class.merge_with_defaults("state_specific" => { "priority" => 100 })
         expect(result.size).to eq(ExclusionTypesLoader::DEFAULTS.size + 1)
-        expect(result["state_specific"]).to eq("priority" => 10)
+        expect(result["state_specific"]).to eq("priority" => 100)
       end
     end
   end
@@ -86,8 +84,8 @@ RSpec.describe ExclusionTypesLoader, type: :service do
     context "with a well-formed hash-of-hashes (happy path)" do
       let(:merged) do
         {
-          "veteran_disability" => { "priority" => 3 },
-          "pregnant" => { "priority" => 8 }
+          "veteran_disability" => { "priority" => 30 },
+          "pregnant" => { "priority" => 80 }
         }
       end
 
@@ -96,7 +94,7 @@ RSpec.describe ExclusionTypesLoader, type: :service do
         expect(result).to be_an(Array)
         entry = result.find { |e| e[:id] == :veteran_disability }
         expect(entry[:id]).to be_a(Symbol)
-        expect(entry[:priority]).to eq(3)
+        expect(entry[:priority]).to eq(30)
       end
     end
 
@@ -119,7 +117,7 @@ RSpec.describe ExclusionTypesLoader, type: :service do
     context "when priority is not an Integer" do
       it "raises ConfigurationError mentioning the offending id" do
         expect {
-          described_class.transform("pregnant" => { "priority" => "8" })
+          described_class.transform("pregnant" => { "priority" => "80" })
         }.to raise_error(ExclusionTypesLoader::ConfigurationError, /pregnant/)
       end
     end
@@ -127,8 +125,8 @@ RSpec.describe ExclusionTypesLoader, type: :service do
     context "when two entries share a priority" do
       it "raises ConfigurationError naming the duplicate priority" do
         merged = {
-          "veteran_disability" => { "priority" => 1 },
-          "pregnant" => { "priority" => 1 }
+          "veteran_disability" => { "priority" => 10 },
+          "pregnant" => { "priority" => 10 }
         }
         expect {
           described_class.transform(merged)
@@ -138,13 +136,11 @@ RSpec.describe ExclusionTypesLoader, type: :service do
   end
 
   describe "full load pipeline" do
-    context "when an override swaps priorities" do
+    context "when an override re-ranks an exclusion into a gap" do
       let(:override_file) do
         write_yaml(<<~YAML)
-          veteran_disability:
-            priority: 1
-          american_indian_alaska_native:
-            priority: 3
+          former_foster_care:
+            priority: 55
         YAML
       end
 
@@ -155,16 +151,16 @@ RSpec.describe ExclusionTypesLoader, type: :service do
         merged = described_class.merge_with_defaults(overrides)
         result = described_class.transform(merged)
 
-        veteran = result.find { |e| e[:id] == :veteran_disability }
-        american_indian = result.find { |e| e[:id] == :american_indian_alaska_native }
-        expect(veteran[:priority]).to eq(1)
-        expect(american_indian[:priority]).to eq(3)
+        former_foster_care = result.find { |e| e[:id] == :former_foster_care }
+        caretaker = result.find { |e| e[:id] == :caretaker }
+        expect(former_foster_care[:priority]).to eq(55)
+        expect(caretaker[:priority]).to eq(50)
       end
     end
   end
 
   describe "integration" do
-    it "module-direct against the real override path returns the 9 defaults with priorities 1-9" do
+    it "module-direct against the real override path returns the 9 defaults spaced by 10" do
       override_path = Rails.root.join("config/custom/exclusion_types.yml")
       overrides = described_class.safe_load_optional(override_path)
       merged = described_class.merge_with_defaults(overrides)

--- a/reporting-app/spec/services/exclusion_types_loader_spec.rb
+++ b/reporting-app/spec/services/exclusion_types_loader_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExclusionTypesLoader, type: :service do
+  # write_yaml comes from spec/support/yaml_config_helpers.rb.
+
+  # The spec's default priority order (high durability -> low), priorities 1-9.
+  let(:expected_defaults) do
+    {
+      american_indian_alaska_native: 1,
+      former_foster_care: 2,
+      veteran_disability: 3,
+      medically_frail: 4,
+      caretaker: 5,
+      tanf_snap_work: 6,
+      drug_treatment: 7,
+      pregnant: 8,
+      inmate: 9
+    }
+  end
+
+  it "aliases ConfigurationError to the shared ConfigLoading::ConfigurationError" do
+    # Same load-bearing alias as ExemptionTypesLoader: keeps
+    # ExclusionTypesLoader::ConfigurationError valid for rescues/specs and lets
+    # unqualified `raise ConfigurationError` in transform resolve to the shared class.
+    expect(described_class::ConfigurationError).to equal(ConfigLoading::ConfigurationError)
+  end
+
+  describe ".safe_load_optional (via extend ConfigLoading)" do
+    # Exhaustive YAML edge-case coverage lives in the shared ConfigLoading spec
+    # and ExemptionTypesLoader spec; here we only confirm the extend is wired.
+    it "returns an empty hash for a missing override file without raising" do
+      missing_path = "/tmp/definitely_not_a_real_exclusion_override_#{SecureRandom.hex}.yml"
+      expect(described_class.safe_load_optional(missing_path)).to eq({})
+    end
+
+    context "when the file contains a valid override hash" do
+      let(:override_file) do
+        write_yaml(<<~YAML)
+          veteran_disability:
+            priority: 1
+        YAML
+      end
+
+      after { override_file.unlink }
+
+      it "returns the parsed hash with string keys" do
+        expect(described_class.safe_load_optional(override_file.path)).to eq(
+          "veteran_disability" => { "priority" => 1 }
+        )
+      end
+    end
+  end
+
+  describe ".merge_with_defaults" do
+    context "with an empty override hash" do
+      it "returns DEFAULTS verbatim" do
+        expect(described_class.merge_with_defaults({})).to eq(ExclusionTypesLoader::DEFAULTS)
+      end
+    end
+
+    context "with an override that swaps two priorities" do
+      it "deep-merges; the overridden priorities win and unrelated entries are untouched" do
+        result = described_class.merge_with_defaults(
+          "veteran_disability" => { "priority" => 1 },
+          "american_indian_alaska_native" => { "priority" => 3 }
+        )
+        expect(result["veteran_disability"]["priority"]).to eq(1)
+        expect(result["american_indian_alaska_native"]["priority"]).to eq(3)
+        expect(result["pregnant"]["priority"]).to eq(8)
+        expect(result.size).to eq(ExclusionTypesLoader::DEFAULTS.size)
+      end
+    end
+
+    context "with an override that adds a new exclusion" do
+      it "produces all defaults plus the new entry" do
+        result = described_class.merge_with_defaults("state_specific" => { "priority" => 10 })
+        expect(result.size).to eq(ExclusionTypesLoader::DEFAULTS.size + 1)
+        expect(result["state_specific"]).to eq("priority" => 10)
+      end
+    end
+  end
+
+  describe ".transform" do
+    context "with a well-formed hash-of-hashes (happy path)" do
+      let(:merged) do
+        {
+          "veteran_disability" => { "priority" => 3 },
+          "pregnant" => { "priority" => 8 }
+        }
+      end
+
+      it "returns an array of entries with id as Symbol and priority as Integer" do
+        result = described_class.transform(merged)
+        expect(result).to be_an(Array)
+        entry = result.find { |e| e[:id] == :veteran_disability }
+        expect(entry[:id]).to be_a(Symbol)
+        expect(entry[:priority]).to eq(3)
+      end
+    end
+
+    context "when an entry value is not a Hash" do
+      it "raises ConfigurationError mentioning the offending id" do
+        expect {
+          described_class.transform("pregnant" => true)
+        }.to raise_error(ExclusionTypesLoader::ConfigurationError, /pregnant/)
+      end
+    end
+
+    context "when an entry is missing the priority field" do
+      it "raises ConfigurationError mentioning the offending id" do
+        expect {
+          described_class.transform("pregnant" => {})
+        }.to raise_error(ExclusionTypesLoader::ConfigurationError, /pregnant/)
+      end
+    end
+
+    context "when priority is not an Integer" do
+      it "raises ConfigurationError mentioning the offending id" do
+        expect {
+          described_class.transform("pregnant" => { "priority" => "8" })
+        }.to raise_error(ExclusionTypesLoader::ConfigurationError, /pregnant/)
+      end
+    end
+
+    context "when two entries share a priority" do
+      it "raises ConfigurationError naming the duplicate priority" do
+        merged = {
+          "veteran_disability" => { "priority" => 1 },
+          "pregnant" => { "priority" => 1 }
+        }
+        expect {
+          described_class.transform(merged)
+        }.to raise_error(ExclusionTypesLoader::ConfigurationError, /duplicate priority/)
+      end
+    end
+  end
+
+  describe "full load pipeline" do
+    context "when an override swaps priorities" do
+      let(:override_file) do
+        write_yaml(<<~YAML)
+          veteran_disability:
+            priority: 1
+          american_indian_alaska_native:
+            priority: 3
+        YAML
+      end
+
+      after { override_file.unlink }
+
+      it "carries the override through load + merge + transform" do
+        overrides = described_class.safe_load_optional(override_file.path)
+        merged = described_class.merge_with_defaults(overrides)
+        result = described_class.transform(merged)
+
+        veteran = result.find { |e| e[:id] == :veteran_disability }
+        american_indian = result.find { |e| e[:id] == :american_indian_alaska_native }
+        expect(veteran[:priority]).to eq(1)
+        expect(american_indian[:priority]).to eq(3)
+      end
+    end
+  end
+
+  describe "integration" do
+    it "module-direct against the real override path returns the 9 defaults with priorities 1-9" do
+      override_path = Rails.root.join("config/custom/exclusion_types.yml")
+      overrides = described_class.safe_load_optional(override_path)
+      merged = described_class.merge_with_defaults(overrides)
+      result = described_class.transform(merged)
+
+      by_id = result.index_by { |e| e[:id] }
+      expect(by_id.keys).to match_array(expected_defaults.keys)
+      expected_defaults.each do |id, priority|
+        expect(by_id[id][:priority]).to eq(priority)
+      end
+    end
+
+    it "wires Rails.application.config.exclusion_types on boot via the initializer" do
+      types = Rails.application.config.exclusion_types
+      expect(types).to be_an(Array)
+      expect(types.map { |e| e[:id] }).to match_array(expected_defaults.keys)
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves #751

## Changes

- Add `Exclusion` utility class exposing `.all` (sorted ascending by `:priority`), `.priority_order` (ids high durability to low), `.valid_values`, and `.find`.
- Add `ExclusionTypesLoader`, which `extend`s the shared `ConfigLoading` module and defines: a `DEFAULTS` set of the nine specified exclusions at priorities 1-9, `merge_with_defaults` (deep-merge of the override over defaults), and `transform` (validates each entry has an integer `priority` and rejects duplicate priorities).
- Add `config/initializers/exclusion_types.rb` to load the merged, validated config into `Rails.application.config.exclusion_types` at boot.
- Add `config/custom/exclusion_types.yml`, the deployment-owned override surface (ships empty, with documented re-rank and add examples).
- Add specs for the loader (`spec/services/exclusion_types_loader_spec.rb`) and the model (`spec/models/exclusion_spec.rb`).

## Context for reviewers

The Data Source Hierarchy work needs OSCER to determine the single "best" (highest-durability) exclusion for a member. This PR is the configuration foundation for that: a yml-configured, deployment-overridable ordered list of exclusions. It deliberately mirrors the existing `Exemption` config quartet (`Exemption` + `ExemptionTypesLoader` + initializer + `config/custom` override), so if you know that pattern this will read familiar.

Two design points worth calling out:

- **Priority-only shape, no `enabled` flag.** The defaults are the CMS "specified excluded individuals" (§435.554), which are the mandatory federal minimum, so a deployment can re-rank exclusions but must not disable one. The only configurable field is an integer `priority`. Priorities must be distinct: the loader raises a boot-time `ConfigurationError` on a duplicate, because a tie would make "best exclusion" selection depend on an unstable sort.
- **The config leads the rules.** Only three of the nine defaults (`american_indian_alaska_native`, `veteran_disability`, `pregnant`) have rules in `Rules::ExclusionRuleset` today; the rest are declarative until their rules land. Note the `age_under_19` / `age_over_65` checks in `ExclusionRuleset` are intentionally absent here: per the CMS interim final rule they are mandatory exceptions (§435.553), not specified excluded individuals, so they belong to the exception work (#735/#746), not this list.

Deliberate divergences from the Exemption pattern: the integer `priority` field and priority ordering, and no `enabled` flag. It carries no i18n metadata because member-facing display of an exclusion is keyed by reason code in `MemberStatusService`, not by this config.

Out of scope: updating `ExclusionDeterminationService` to consume this ordering and return the single highest-priority exclusion is a fast-follow, #752.

## Testing

- Full suite green: 2516 examples, 0 failures; coverage 96.39% line / 82.99% branch (above the 92% / 70% gates).
- RuboCop clean on the changed files.
- The loader spec includes a boot-integration example confirming `Rails.application.config.exclusion_types` is wired by the initializer, plus validation-failure cases (non-Hash entry, missing `priority`, non-integer `priority`, duplicate `priority`) and a full load-pipeline (parse to merge to transform) example.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->