### PR TITLE
Add Verification data source contract + result object (OSCER-754)

### DIFF
--- a/reporting-app/app/models/verification/data_source_result.rb
+++ b/reporting-app/app/models/verification/data_source_result.rb
@@ -95,8 +95,22 @@ module Verification
         Array(outcomes).freeze
       end
 
+      # Deep-copies, then deep-freezes, so the persisted audit record is
+      # tamper-resistant all the way down. The +deep_dup+ ensures we freeze our
+      # own copy rather than mutating the caller's hash (and its nested objects)
+      # in place.
       def normalize_audit_data(audit_data)
-        (audit_data || {}).to_h.freeze
+        deep_freeze((audit_data || {}).to_h.deep_dup)
+      end
+
+      def deep_freeze(value)
+        case value
+        when Hash
+          value.each_value { |v| deep_freeze(v) }
+        when Array
+          value.each { |v| deep_freeze(v) }
+        end
+        value.freeze
       end
     end
 

--- a/reporting-app/app/models/verification/data_source_result.rb
+++ b/reporting-app/app/models/verification/data_source_result.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Verification
+  # Uniform result returned by every {Verification::DataSource}.
+  #
+  # A result carries the outcome of calling one external verification data
+  # source for a certification: a +status+, the +outcomes+ (symbols) the
+  # source emitted, and redacted +audit_data+ for later inspection. It is a
+  # value object in the style of +Determinations::*DeterminationData+.
+  #
+  # Construct only via the factories ({.skipped}, {.success}, {.error}) — they
+  # normalize inputs and enforce the contract invariants:
+  #
+  #   * +status+ is always one of {STATUSES}
+  #   * +outcomes+ is always a flat +Array<Symbol>+ (empty allowed; empty on
+  #     +:success+ means "called, no matching outcome")
+  #   * +audit_data+ is always a +Hash+ (never +nil+; may be +{}+)
+  #   * +error_code+/+error_message+ accompany +:error+
+  #
+  # +audit_data+ must be redacted by the adapter before it reaches here: no
+  # raw PHI, secrets, or tokens.
+  class DataSourceResult < ValueObject
+    STATUS_SKIPPED = :skipped
+    STATUS_SUCCESS = :success
+    STATUS_ERROR = :error
+    STATUSES = [ STATUS_SKIPPED, STATUS_SUCCESS, STATUS_ERROR ].freeze
+
+    attribute :status
+    attribute :outcomes, default: -> { [] }
+    attribute :audit_data, default: -> { {} }
+    attribute :error_code
+    attribute :error_message
+
+    validates :status, inclusion: { in: STATUSES }
+    validate :outcomes_is_symbol_array
+    validate :audit_data_is_hash
+
+    class << self
+      # A precondition was missing (e.g. no ICN), so the source was not
+      # called. Distinct from a +:success+ with empty outcomes.
+      #
+      # @param reason [Symbol, String, nil] optional machine-readable skip
+      #   reason, recorded under +audit_data[:skip_reason]+.
+      # @param audit_data [Hash] optional additional audit context.
+      # @return [DataSourceResult]
+      def skipped(reason: nil, audit_data: {})
+        audit = normalize_audit_data(audit_data)
+        audit = audit.merge(skip_reason: reason) unless reason.nil?
+
+        build(status: STATUS_SKIPPED, audit_data: audit)
+      end
+
+      # The source was called and returned successfully. +outcomes+ may be
+      # empty, which means "called, no matching outcome".
+      #
+      # @param outcomes [Array<Symbol>] emitted outcomes (may be empty).
+      # @param audit_data [Hash] redacted audit context (required — every
+      #   non-skipped call records audit data).
+      # @return [DataSourceResult]
+      def success(audit_data:, outcomes: [])
+        build(status: STATUS_SUCCESS, outcomes: outcomes, audit_data: audit_data)
+      end
+
+      # The source was called but failed for an expected integration reason
+      # (auth, 5xx, timeout, rate limit). Adapters never raise for these.
+      #
+      # @param error_code [Symbol, String] machine-readable error category.
+      # @param error_message [String] human-readable, redacted message.
+      # @param audit_data [Hash] redacted audit context (required).
+      # @param outcomes [Array<Symbol>] usually empty on error.
+      # @return [DataSourceResult]
+      def error(error_code:, error_message:, audit_data:, outcomes: [])
+        build(
+          status: STATUS_ERROR,
+          outcomes: outcomes,
+          audit_data: audit_data,
+          error_code: error_code,
+          error_message: error_message
+        )
+      end
+
+      private
+
+      def build(status:, audit_data:, outcomes: [], error_code: nil, error_message: nil)
+        new(
+          status: status,
+          outcomes: normalize_outcomes(outcomes),
+          audit_data: normalize_audit_data(audit_data),
+          error_code: error_code,
+          error_message: error_message
+        ).tap(&:validate!)
+      end
+
+      def normalize_outcomes(outcomes)
+        Array(outcomes).freeze
+      end
+
+      def normalize_audit_data(audit_data)
+        (audit_data || {}).to_h.freeze
+      end
+    end
+
+    def skipped?
+      status == STATUS_SKIPPED
+    end
+
+    def success?
+      status == STATUS_SUCCESS
+    end
+
+    def error?
+      status == STATUS_ERROR
+    end
+
+    private
+
+    def outcomes_is_symbol_array
+      unless outcomes.is_a?(Array) && outcomes.all?(Symbol)
+        errors.add(:outcomes, "must be a flat Array of Symbols")
+      end
+    end
+
+    def audit_data_is_hash
+      errors.add(:audit_data, "must be a Hash") unless audit_data.is_a?(Hash)
+    end
+  end
+end

--- a/reporting-app/app/services/verification/data_source.rb
+++ b/reporting-app/app/services/verification/data_source.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Verification
+  # Contract every external verification data source conforms to.
+  #
+  # A data source is called with the full {Certification}; it pulls whatever it
+  # needs (e.g. +certification.member_data&.va_icn+), calls its backing
+  # integration, and returns a {DataSourceResult} with a uniform shape so an
+  # orchestrator (built later, out of scope here) can call every source
+  # identically and audit them consistently.
+  #
+  # Subclasses implement the protected hooks — {#precondition_met?} and
+  # {#perform} — plus the class method {.declared_outcomes}. The public
+  # {#call} is a template method that enforces the contract *by design*:
+  #
+  #   * never returns +nil+ (a non-{DataSourceResult} return raises {ContractError})
+  #   * never raises for *expected* integration failures — error classes listed
+  #     in {#expected_error_classes} are caught and become +status: :error+
+  #   * returns +:skipped+ when a precondition is missing, distinct from a
+  #     +:success+ with empty outcomes
+  #
+  # Unexpected errors (bugs, undeclared exceptions) intentionally propagate so
+  # they surface loudly rather than being silently swallowed.
+  class DataSource
+    # Raised when a subclass's {#perform} violates the contract by returning
+    # something other than a {DataSourceResult}.
+    class ContractError < StandardError; end
+
+    class << self
+      # The full set of outcome symbols this source may emit. Config (ticket C)
+      # validates configured outcomes against this list.
+      #
+      # @return [Array<Symbol>]
+      def declared_outcomes
+        raise NotImplementedError, "#{name} must implement .declared_outcomes"
+      end
+    end
+
+    # Uniform entry point.
+    #
+    # @param certification [Certification]
+    # @return [DataSourceResult]
+    def call(certification:)
+      return skipped_result unless precondition_met?(certification)
+
+      ensure_result!(perform(certification: certification))
+    rescue *expected_error_classes => e
+      error_result(e)
+    end
+
+    protected
+
+    # Whether the source has what it needs to run (e.g. an ICN is present).
+    # When this is false, {#call} short-circuits to a +:skipped+ result.
+    #
+    # @param certification [Certification]
+    # @return [Boolean]
+    def precondition_met?(_certification)
+      raise NotImplementedError, "#{self.class.name} must implement #precondition_met?"
+    end
+
+    # Perform the verification and return a {DataSourceResult}. Called only
+    # when {#precondition_met?} is true. Expected integration failures should
+    # be raised as one of {#expected_error_classes} (caught by {#call}) rather
+    # than rescued here.
+    #
+    # @param certification [Certification]
+    # @return [DataSourceResult]
+    def perform(certification:)
+      raise NotImplementedError, "#{self.class.name} must implement #perform"
+    end
+
+    # Error classes representing *expected* integration failures (auth, 5xx,
+    # timeout, rate limit). {#call} catches these and returns a +:error+ result.
+    #
+    # @return [Array<Class>]
+    def expected_error_classes
+      []
+    end
+
+    # Build a +:skipped+ result. Subclasses may pass a machine-readable reason.
+    def skipped_result(reason: nil, audit_data: {})
+      DataSourceResult.skipped(reason: reason, audit_data: audit_data)
+    end
+
+    # Build a +:success+ result.
+    def success_result(audit_data:, outcomes: [])
+      DataSourceResult.success(outcomes: outcomes, audit_data: audit_data)
+    end
+
+    # Build a +:error+ result from a caught expected error. Subclasses can pass
+    # redacted +audit_data+; the error's class and message are recorded.
+    def error_result(error, audit_data: {})
+      DataSourceResult.error(
+        error_code: error_code_for(error),
+        error_message: error.message,
+        audit_data: audit_data
+      )
+    end
+
+    def error_code_for(error)
+      error.class.name.demodulize.underscore.to_sym
+    end
+
+    private
+
+    def ensure_result!(result)
+      return result if result.is_a?(DataSourceResult)
+
+      raise ContractError,
+        "#{self.class.name}#perform must return a Verification::DataSourceResult, got #{result.inspect}"
+    end
+  end
+end

--- a/reporting-app/app/services/verification/data_source.rb
+++ b/reporting-app/app/services/verification/data_source.rb
@@ -43,9 +43,22 @@ module Verification
     def call(certification:)
       return skipped_result unless precondition_met?(certification)
 
-      ensure_result!(perform(certification: certification))
-    rescue *expected_error_classes => e
-      error_result(e)
+      begin
+        result = perform(certification: certification)
+      rescue ContractError
+        # A subclass may raise ContractError from #perform directly; re-raise so
+        # an over-broad expected_error_classes can never swallow a contract
+        # violation. (ensure_result! below runs outside this block, so codes it
+        # raises always propagate too.)
+        raise
+      rescue *expected_error_classes => e
+        # An empty expected_error_classes ([]) intentionally catches nothing:
+        # `rescue *[]` matches no exceptions, so unexpected errors propagate by
+        # default and only declared integration failures become :error results.
+        return error_result(e)
+      end
+
+      ensure_result!(result)
     end
 
     protected
@@ -98,8 +111,15 @@ module Verification
       )
     end
 
+    # Best-effort machine-readable code derived from the error's class name.
+    # This is *not* a stable contract: renaming the exception class changes the
+    # code. Subclasses that persist or match on +error_code+ should override
+    # this (or {#error_result}) to map known errors to stable symbols.
     def error_code_for(error)
-      error.class.name.demodulize.underscore.to_sym
+      class_name = error.class.name
+      return :unknown_error if class_name.nil?
+
+      class_name.demodulize.underscore.to_sym
     end
 
     private

--- a/reporting-app/spec/models/verification/data_source_result_spec.rb
+++ b/reporting-app/spec/models/verification/data_source_result_spec.rb
@@ -100,6 +100,22 @@ RSpec.describe Verification::DataSourceResult do
     it "freezes audit_data" do
       expect(result.audit_data).to be_frozen
     end
+
+    it "deep-freezes nested audit_data structures" do
+      nested = described_class.success(audit_data: { outer: { inner: [ 1 ] } })
+
+      expect(nested.audit_data[:outer]).to be_frozen
+      expect(nested.audit_data[:outer][:inner]).to be_frozen
+    end
+
+    it "does not freeze the caller's audit_data in place" do
+      caller_audit = { outer: { inner: [ 1 ] } }
+
+      described_class.success(audit_data: caller_audit)
+
+      expect(caller_audit).not_to be_frozen
+      expect(caller_audit[:outer]).not_to be_frozen
+    end
   end
 
   describe "status predicates" do

--- a/reporting-app/spec/models/verification/data_source_result_spec.rb
+++ b/reporting-app/spec/models/verification/data_source_result_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Verification::DataSourceResult do
+  describe ".skipped" do
+    subject(:result) { described_class.skipped }
+
+    it_behaves_like "a skipped verification result"
+
+    it "defaults to empty audit_data" do
+      expect(result.audit_data).to eq({})
+    end
+
+    it "records a skip reason under audit_data when given" do
+      result = described_class.skipped(reason: :missing_icn)
+
+      expect(result.audit_data).to eq(skip_reason: :missing_icn)
+    end
+
+    it "merges an explicit skip reason into provided audit_data" do
+      result = described_class.skipped(reason: :missing_icn, audit_data: { checked_at: "t" })
+
+      expect(result.audit_data).to eq(checked_at: "t", skip_reason: :missing_icn)
+    end
+  end
+
+  describe ".success" do
+    context "with an empty outcome set" do
+      subject(:result) { described_class.success(audit_data: { rating: 70 }) }
+
+      it_behaves_like "a successful verification result"
+
+      it "allows empty outcomes (called, no matching outcome)" do
+        expect(result.outcomes).to eq([])
+      end
+
+      it "keeps the provided audit_data" do
+        expect(result.audit_data).to eq(rating: 70)
+      end
+    end
+
+    context "with a populated outcome set" do
+      subject(:result) do
+        described_class.success(outcomes: [ :veteran_with_disability ], audit_data: { rating: 100 })
+      end
+
+      it_behaves_like "a successful verification result"
+
+      it "exposes the emitted outcomes" do
+        expect(result.outcomes).to eq([ :veteran_with_disability ])
+      end
+    end
+
+    it "requires audit_data" do
+      expect { described_class.success(outcomes: []) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".error" do
+    subject(:result) do
+      described_class.error(
+        error_code: :unauthorized,
+        error_message: "VA API unauthorized",
+        audit_data: { attempted_at: "t" }
+      )
+    end
+
+    it_behaves_like "an errored verification result"
+
+    it "exposes the error code and message" do
+      expect(result.error_code).to eq(:unauthorized)
+      expect(result.error_message).to eq("VA API unauthorized")
+    end
+
+    it "requires audit_data" do
+      expect { described_class.error(error_code: :x, error_message: "y") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "validation" do
+    it "rejects an unknown status" do
+      expect { described_class.send(:build, status: :bogus, audit_data: {}) }
+        .to raise_error(ActiveModel::ValidationError)
+    end
+
+    it "rejects non-symbol outcomes" do
+      expect { described_class.success(outcomes: [ "not_a_symbol" ], audit_data: {}) }
+        .to raise_error(ActiveModel::ValidationError)
+    end
+  end
+
+  describe "immutability" do
+    subject(:result) { described_class.success(outcomes: [ :a ], audit_data: { k: 1 }) }
+
+    it "freezes outcomes" do
+      expect(result.outcomes).to be_frozen
+    end
+
+    it "freezes audit_data" do
+      expect(result.audit_data).to be_frozen
+    end
+  end
+
+  describe "status predicates" do
+    it "reports each status distinctly" do
+      expect(described_class.skipped).to be_skipped
+      expect(described_class.success(audit_data: {})).to be_success
+      expect(described_class.error(error_code: :x, error_message: "y", audit_data: {})).to be_error
+    end
+  end
+end

--- a/reporting-app/spec/rails_helper.rb
+++ b/reporting-app/spec/rails_helper.rb
@@ -46,6 +46,7 @@ require_relative 'support/sso_helpers'
 require_relative 'support/feature_flag_helpers'
 require_relative 'support/env_helpers'
 require_relative 'support/yaml_config_helpers'
+require_relative 'support/verification/data_source_shared_examples'
 require "strata/testing/api_auth_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/reporting-app/spec/services/verification/data_source_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe Verification::DataSource do
 
     context "when the source hits an expected integration failure" do
       let(:data_source) { TestDataSource.new(behavior: :raise_expected) }
-      let(:expected_error) { TestVerificationApiError.new }
 
       it_behaves_like "an errored verification result"
       it_behaves_like "a resilient verification data source"
@@ -102,6 +101,20 @@ RSpec.describe Verification::DataSource do
       let(:data_source) { TestDataSource.new(behavior: :return_nil) }
 
       it "raises ContractError" do
+        expect { result }.to raise_error(Verification::DataSource::ContractError, /must return/)
+      end
+    end
+
+    context "when a subclass declares an over-broad expected_error_classes" do
+      let(:data_source) do
+        Class.new(described_class) do
+          def precondition_met?(_certification) = true
+          def perform(certification:) = nil
+          def expected_error_classes = [ StandardError ]
+        end.new
+      end
+
+      it "still raises ContractError rather than swallowing it as an :error result" do
         expect { result }.to raise_error(Verification::DataSource::ContractError, /must return/)
       end
     end

--- a/reporting-app/spec/services/verification/data_source_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Verification::DataSource do
+  let(:certification) { instance_double(Certification) }
+
+  before do
+    stub_const("TestVerificationApiError", Class.new(StandardError))
+    stub_const("TestUndeclaredError", Class.new(StandardError))
+
+    stub_const("TestDataSource", Class.new(described_class) do
+      def self.declared_outcomes
+        [ :matched ]
+      end
+
+      def initialize(precondition: true, behavior: :success_empty)
+        @precondition = precondition
+        @behavior = behavior
+      end
+
+      protected
+
+      def precondition_met?(_certification)
+        @precondition
+      end
+
+      def perform(certification:)
+        case @behavior
+        when :success_empty then success_result(outcomes: [], audit_data: { called: true })
+        when :success_populated then success_result(outcomes: [ :matched ], audit_data: { called: true })
+        when :raise_expected then raise TestVerificationApiError, "integration down"
+        when :raise_undeclared then raise TestUndeclaredError, "boom"
+        when :return_nil then nil
+        end
+      end
+
+      def expected_error_classes
+        [ TestVerificationApiError ]
+      end
+    end)
+  end
+
+  describe ".declared_outcomes" do
+    it "raises NotImplementedError on the abstract base" do
+      expect { described_class.declared_outcomes }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#call" do
+    subject(:result) { data_source.call(certification: certification) }
+
+    context "when a precondition is missing" do
+      let(:data_source) { TestDataSource.new(precondition: false) }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the source succeeds with no matching outcome" do
+      let(:data_source) { TestDataSource.new(behavior: :success_empty) }
+
+      it_behaves_like "a successful verification result"
+
+      it "has empty outcomes and populated audit_data" do
+        expect(result.outcomes).to eq([])
+        expect(result.audit_data).to eq(called: true)
+      end
+    end
+
+    context "when the source succeeds with a matching outcome" do
+      let(:data_source) { TestDataSource.new(behavior: :success_populated) }
+
+      it_behaves_like "a successful verification result"
+
+      it "exposes the emitted outcome" do
+        expect(result.outcomes).to eq([ :matched ])
+      end
+    end
+
+    context "when the source hits an expected integration failure" do
+      let(:data_source) { TestDataSource.new(behavior: :raise_expected) }
+      let(:expected_error) { TestVerificationApiError.new }
+
+      it_behaves_like "an errored verification result"
+      it_behaves_like "a resilient verification data source"
+
+      it "maps the error class to an error_code" do
+        expect(result.error_code).to eq(:test_verification_api_error)
+        expect(result.error_message).to eq("integration down")
+      end
+    end
+
+    context "when the source raises an undeclared error" do
+      let(:data_source) { TestDataSource.new(behavior: :raise_undeclared) }
+
+      it "propagates the error rather than swallowing it" do
+        expect { result }.to raise_error(TestUndeclaredError, "boom")
+      end
+    end
+
+    context "when #perform violates the contract by returning nil" do
+      let(:data_source) { TestDataSource.new(behavior: :return_nil) }
+
+      it "raises ContractError" do
+        expect { result }.to raise_error(Verification::DataSource::ContractError, /must return/)
+      end
+    end
+  end
+
+  describe "abstract hooks" do
+    let(:bare_source) { Class.new(described_class).new }
+
+    it "requires subclasses to implement #precondition_met?" do
+      expect { bare_source.call(certification: certification) }
+        .to raise_error(NotImplementedError, /precondition_met\?/)
+    end
+
+    it "requires subclasses to implement #perform" do
+      klass = Class.new(described_class) do
+        def precondition_met?(_certification) = true
+      end
+
+      expect { klass.new.call(certification: certification) }
+        .to raise_error(NotImplementedError, /perform/)
+    end
+  end
+end

--- a/reporting-app/spec/support/verification/data_source_shared_examples.rb
+++ b/reporting-app/spec/support/verification/data_source_shared_examples.rb
@@ -89,8 +89,8 @@ RSpec.shared_examples "an errored verification result" do
 end
 
 # Invariants that require exercising +#call+ rather than inspecting a single
-# result. Host specs provide +let(:data_source)+, +let(:certification)+, and
-# +let(:expected_error)+ (an instance of a declared expected error class).
+# result. Host specs provide +let(:data_source)+ and +let(:certification)+,
+# where the data source is configured to hit an expected integration failure.
 RSpec.shared_examples "a resilient verification data source" do
   it "declares the outcomes it can emit" do
     expect(data_source.class.declared_outcomes).to all(be_a(Symbol))

--- a/reporting-app/spec/support/verification/data_source_shared_examples.rb
+++ b/reporting-app/spec/support/verification/data_source_shared_examples.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Shared expectations for the +Verification::DataSource+ contract.
+#
+# Every verification data source result must satisfy the base invariants
+# ("a verification data source result"): never nil, always a
+# +Verification::DataSourceResult+, a known status, a flat Array<Symbol> of
+# outcomes, and a Hash audit_data. The status-specific groups layer the
+# per-status assertions on top.
+#
+# Host specs provide the result under test via +let(:result)+ (or +subject+),
+# typically by calling the data source's +#call+ with a certification set up
+# for that scenario. Example:
+#
+#   describe SomeSource do
+#     subject(:result) { described_class.new.call(certification: certification) }
+#
+#     context "when the ICN is missing" do
+#       let(:certification) { build(:certification) }
+#       it_behaves_like "a skipped verification result"
+#     end
+#   end
+
+RSpec.shared_examples "a verification data source result" do
+  it "is never nil" do
+    expect(result).not_to be_nil
+  end
+
+  it "is a DataSourceResult" do
+    expect(result).to be_a(Verification::DataSourceResult)
+  end
+
+  it "has a known status" do
+    expect(Verification::DataSourceResult::STATUSES).to include(result.status)
+  end
+
+  it "exposes outcomes as a flat Array of Symbols" do
+    expect(result.outcomes).to be_an(Array)
+    expect(result.outcomes).to all(be_a(Symbol))
+  end
+
+  it "always exposes audit_data as a Hash (never nil)" do
+    expect(result.audit_data).to be_a(Hash)
+  end
+end
+
+RSpec.shared_examples "a skipped verification result" do
+  it_behaves_like "a verification data source result"
+
+  it "has status :skipped" do
+    expect(result.status).to eq(Verification::DataSourceResult::STATUS_SKIPPED)
+    expect(result).to be_skipped
+  end
+
+  it "emits no outcomes" do
+    expect(result.outcomes).to be_empty
+  end
+end
+
+RSpec.shared_examples "a successful verification result" do
+  it_behaves_like "a verification data source result"
+
+  it "has status :success" do
+    expect(result.status).to eq(Verification::DataSourceResult::STATUS_SUCCESS)
+    expect(result).to be_success
+  end
+
+  it "records audit_data (present on every non-skipped call)" do
+    expect(result.audit_data).to be_a(Hash)
+  end
+end
+
+RSpec.shared_examples "an errored verification result" do
+  it_behaves_like "a verification data source result"
+
+  it "has status :error" do
+    expect(result.status).to eq(Verification::DataSourceResult::STATUS_ERROR)
+    expect(result).to be_error
+  end
+
+  it "records an error_code and error_message" do
+    expect(result.error_code).to be_present
+    expect(result.error_message).to be_present
+  end
+
+  it "records audit_data (present on every non-skipped call)" do
+    expect(result.audit_data).to be_a(Hash)
+  end
+end
+
+# Invariants that require exercising +#call+ rather than inspecting a single
+# result. Host specs provide +let(:data_source)+, +let(:certification)+, and
+# +let(:expected_error)+ (an instance of a declared expected error class).
+RSpec.shared_examples "a resilient verification data source" do
+  it "declares the outcomes it can emit" do
+    expect(data_source.class.declared_outcomes).to all(be_a(Symbol))
+  end
+
+  it "does not raise for an expected integration failure" do
+    expect { data_source.call(certification: certification) }.not_to raise_error
+  end
+
+  it "returns an :error result for an expected integration failure" do
+    result = data_source.call(certification: certification)
+
+    expect(result).to be_a(Verification::DataSourceResult)
+    expect(result).to be_error
+    expect(result.audit_data).to be_a(Hash)
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [OSCER-754](https://github.com/navapbc/oscer/issues/754)

## Changes

Introduces the foundational contract every external verification data source will conform to, so a later orchestrator can call each source identically and audit them consistently.

- **`Verification::DataSource`** (`reporting-app/app/services/verification/data_source.rb`) — abstract base using the template-method pattern. Public `#call` enforces the contract: returns `:skipped` when a precondition is missing, catches only declared `expected_error_classes` and converts them to `:error` results, lets unexpected errors propagate, and raises `ContractError` when a subclass `#perform` returns a non-`DataSourceResult`. Subclasses implement `precondition_met?`, `perform`, `.declared_outcomes`, and (optionally) `expected_error_classes`.
- **`Verification::DataSourceResult`** (`reporting-app/app/models/verification/data_source_result.rb`) — `ValueObject` (ActiveModel), in the style of `Determinations::*DeterminationData`. Tri-state `status` (`:skipped` / `:success` / `:error`), symbol `outcomes`, deep-frozen `audit_data`, and `error_code` / `error_message`. Constructed only via the `.skipped` / `.success` / `.error` factories, which normalize inputs and `validate!` invariants.
- **Shared examples** (`reporting-app/spec/support/verification/data_source_shared_examples.rb`) — reusable contract expectations (`"a verification data source result"`, `"a skipped/successful/errored verification result"`, `"a resilient verification data source"`) that future sources can adopt to prove conformance. Wired in via `reporting-app/spec/rails_helper.rb`.
- **Specs** for the result value object and the base contract (status factories, validation, immutability, template-method behavior, error propagation, and `ContractError` enforcement).

Review-driven hardening (second commit):

- Deep-dup + deep-freeze `audit_data` so persisted audit records are tamper-resistant all the way down, without freezing the caller's hash in place.
- Scope `#call`'s rescue so `ContractError` always propagates even if a subclass declares an over-broad `expected_error_classes`; documented that the empty-`[]` default intentionally catches nothing.
- Fall back to `:unknown_error` when an exception's class name is `nil` (anonymous classes) instead of raising `NoMethodError`.
- Documented `error_code_for` as best-effort/overridable (derived from class name, not a stable contract).

## Context for reviewers

- **Scope:** contract + result object + tests only. No runtime wiring — the orchestrator that calls the sources, config validation of configured outcomes against `.declared_outcomes`, and real adapters are follow-up tickets.
- **Design notes:**
  - `error_code` is derived from the exception class name as a best-effort default; subclasses that persist or match on it should override `error_code_for`/`error_result` to map known errors to stable symbols.
  - The auto-rescue path currently produces `:error` results with empty `audit_data`; a hook to attach audit context on caught errors was intentionally deferred rather than adding unused API to a foundation PR (subclasses can override the `protected` `error_result`).
  - `audit_data` must be redacted by the adapter before it reaches the result (no raw PHI, secrets, or tokens).

## Testing

- Lint: `make lint` (from `reporting-app/`) — no offenses.
- Targeted specs (from `reporting-app/`):

```
make test args='spec/models/verification/data_source_result_spec.rb spec/services/verification/data_source_spec.rb'
```

  → 86 examples, 0 failures. (A subset run trips SimpleCov's whole-app coverage gate with a non-zero exit; the suite itself passes. Run full `make test` to satisfy the gate.)

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->