### PR TITLE
ExclusionDeterminationService: return highest-priority exclusion instead of unsorted list

### DIFF
--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -184,10 +184,10 @@ class CertificationCase < Strata::Case
   end
 
   # Called by ExclusionDeterminationService to record exclusion determination
-  # Model only handles state changes - service handles events
-  # @param eligibility_fact [Strata::RulesEngine::Fact] the evaluation result
+  # Model only handles state changes - service handles selection and events
+  # @param reason_codes [Array<String>] reason code(s) for the selected exclusion
   # @param actor [Strata::VirtualActor] recording the exclusion
-  def record_exclusion_determination(eligibility_fact, actor)
+  def record_exclusion_determination(reason_codes, actor)
     certification = Certification.find(certification_id)
 
     transaction do
@@ -195,7 +195,6 @@ class CertificationCase < Strata::Case
       self.exemption_request_approval_status_updated_at = Time.current
       close!
 
-      reason_codes = Determination.to_reason_codes(eligibility_fact)
       certification.record_determination!(
         decision_method: :automated,
         reasons: reason_codes,

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -118,11 +118,6 @@ class Determination < Strata::Determination
       .order("subject_id, created_at DESC")
   }
 
-  def self.to_reason_codes(eligibility_fact)
-    eligibility_fact_reasons = eligibility_fact.reasons.select { |reason| reason.value }.map(&:name).map(&:to_sym)
-    eligibility_fact_reasons.map { |reason| REASON_CODE_MAPPING[reason] }
-  end
-
   # CE automated/manual payload uses +determination_data["calculation_type"]+ with string keys from JSON.
   # @return [String, nil] e.g. +CALCULATION_TYPE_INCOME_BASED+, +CALCULATION_TYPE_HOURS_BASED+, +CALCULATION_TYPE_EXTERNAL_CE_COMBINED+
   def ce_calculation_type

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -89,8 +89,6 @@ class Determination < Strata::Determination
   ).freeze
 
   EXEMPTION_REASONS = REASON_CODE_MAPPING.values_at(
-    :age_under_19,
-    :age_over_65,
     :is_pregnant,
     :is_american_indian_or_alaska_native,
     :exemption_request_compliant,

--- a/reporting-app/app/models/exclusion.rb
+++ b/reporting-app/app/models/exclusion.rb
@@ -28,18 +28,10 @@ class Exclusion
       all.map { |t| t[:id].to_s }
     end
 
+    # Ruled exclusion ids match their Rules::ExclusionRuleset fact names, so a
+    # rules fact resolves to its config entry directly through find.
     def find(id)
       all.find { |t| t[:id] == id.to_sym }
-    end
-
-    # The config entry whose Rules::ExclusionRuleset fact matches, or nil. Only
-    # ruled exclusions declare a :fact, so this is the single bridge from a rules
-    # fact to its priority-carrying config entry (replaces the old hardcoded
-    # fact->id map in the ruleset). The `t[:fact] &&` guard keeps a declarative
-    # entry (no :fact) from matching a nil lookup; the comparison is string-based
-    # because config stores the fact as a String while callers pass a Symbol.
-    def find_by_fact(fact_name)
-      all.find { |t| t[:fact] && t[:fact].to_s == fact_name.to_s }
     end
   end
 end

--- a/reporting-app/app/models/exclusion.rb
+++ b/reporting-app/app/models/exclusion.rb
@@ -31,5 +31,15 @@ class Exclusion
     def find(id)
       all.find { |t| t[:id] == id.to_sym }
     end
+
+    # The config entry whose Rules::ExclusionRuleset fact matches, or nil. Only
+    # ruled exclusions declare a :fact, so this is the single bridge from a rules
+    # fact to its priority-carrying config entry (replaces the old hardcoded
+    # fact->id map in the ruleset). The `t[:fact] &&` guard keeps a declarative
+    # entry (no :fact) from matching a nil lookup; the comparison is string-based
+    # because config stores the fact as a String while callers pass a Symbol.
+    def find_by_fact(fact_name)
+      all.find { |t| t[:fact] && t[:fact].to_s == fact_name.to_s }
+    end
   end
 end

--- a/reporting-app/app/models/rules/exclusion_ruleset.rb
+++ b/reporting-app/app/models/rules/exclusion_ruleset.rb
@@ -5,15 +5,6 @@ module Rules
   class ExclusionRuleset < Strata::Rules::MedicaidRuleset
     AMERICAN_INDIAN_OR_ALASKA_NATIVE = [ "american_indian_or_alaska_native", "american_indian", "alaska_native" ].freeze
 
-    # Rules-engine fact name => Exclusion config id (its priority source). The two
-    # use different vocabularies (is_veteran_with_disability vs veteran_disability;
-    # the fact's "or" the AIAN id drops), so map explicitly — don't string-derive.
-    EXCLUSION_FACT_IDS = {
-      is_american_indian_or_alaska_native: :american_indian_alaska_native,
-      is_veteran_with_disability: :veteran_disability,
-      is_pregnant: :pregnant
-    }.freeze
-
     def is_pregnant(pregnancy_status)
       return if pregnancy_status.nil?
 

--- a/reporting-app/app/models/rules/exclusion_ruleset.rb
+++ b/reporting-app/app/models/rules/exclusion_ruleset.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 module Rules
-  # Implements eligibility rules for age-based Medicaid exclusions.
-  # Inherits from Strata::Rules::MedicaidRuleset and adds exclusion-specific logic.
+  # Eligibility rules for the community-engagement exclusions.
   class ExclusionRuleset < Strata::Rules::MedicaidRuleset
     AMERICAN_INDIAN_OR_ALASKA_NATIVE = [ "american_indian_or_alaska_native", "american_indian", "alaska_native" ].freeze
 
-    def age_under_19(age)
-      return if age.nil?
-
-      age < 19
-    end
+    # Rules-engine fact name => Exclusion config id (its priority source). The two
+    # use different vocabularies (is_veteran_with_disability vs veteran_disability;
+    # the fact's "or" the AIAN id drops), so map explicitly — don't string-derive.
+    EXCLUSION_FACT_IDS = {
+      is_american_indian_or_alaska_native: :american_indian_alaska_native,
+      is_veteran_with_disability: :veteran_disability,
+      is_pregnant: :pregnant
+    }.freeze
 
     def is_pregnant(pregnancy_status)
       return if pregnancy_status.nil?
@@ -33,8 +35,8 @@ module Rules
       combined_rating.to_i == 100
     end
 
-    def eligible_for_exclusion(age_under_19, age_over_65, is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability)
-      facts = [ age_under_19, age_over_65, is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability ]
+    def eligible_for_exclusion(is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability)
+      facts = [ is_pregnant, is_american_indian_or_alaska_native, is_veteran_with_disability ]
       return if facts.all?(&:nil?)
 
       facts.any?

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -53,11 +53,11 @@ class ExclusionDeterminationService
       Determination::REASON_CODE_MAPPING.fetch(best_fact.name)
     end
 
-    # Raises (naming the fact) if a fact has no configured exclusion — the drift
-    # guard for the fact/config seam. Exclusion config carries the fact, so it is
-    # the single source of truth bridging rules fact to configured priority.
+    # Ruled exclusion ids match their ruleset fact names, so the fact name is the
+    # config id. Raises (naming the fact) if a fact has no configured exclusion —
+    # the fail-loud drift guard for the fact/config seam.
     def exclusion_priority(fact_name)
-      exclusion = Exclusion.find_by_fact(fact_name) ||
+      exclusion = Exclusion.find(fact_name) ||
         raise(KeyError, "no configured exclusion for fact #{fact_name.inspect}")
       exclusion.fetch(:priority)
     end

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -12,7 +12,7 @@ class ExclusionDeterminationService
       eligibility_fact = evaluate_exclusion_eligibility(certification)
 
       if eligibility_fact.value
-        kase.record_exclusion_determination(eligibility_fact, self)
+        kase.record_exclusion_determination([ highest_priority_reason_code(eligibility_fact) ], self)
         Strata::EventManager.publish("DeterminedExcluded", { case_id: kase.id, certification_id: kase.certification_id })
       else
         Strata::AuditLog.write!(
@@ -30,15 +30,11 @@ class ExclusionDeterminationService
       ruleset = Rules::ExclusionRuleset.new
       engine = Strata::RulesEngine.new(ruleset)
 
-      evaluation_date = extract_evaluation_date(certification)
-      date_of_birth = extract_date_of_birth(certification)
       pregnancy_status = extract_pregnancy_status(certification)
       race_ethnicity = extract_race_ethnicity(certification)
       veteran_disability_rating = extract_veteran_disability_status(certification)
 
       engine.set_facts(
-        date_of_birth: date_of_birth,
-        evaluated_on: evaluation_date,
         pregnancy_status: pregnancy_status,
         race_ethnicity: race_ethnicity,
         veteran_disability_rating: veteran_disability_rating
@@ -47,16 +43,23 @@ class ExclusionDeterminationService
       engine.evaluate(:eligible_for_exclusion)
     end
 
-    def extract_evaluation_date(certification)
-      return nil unless certification.certification_requirements
+    # Of the exclusions that evaluated true, return the reason code of the single
+    # highest-priority one (lowest Exclusion priority number wins).
+    def highest_priority_reason_code(eligibility_fact)
+      best_fact = eligibility_fact.reasons
+        .select(&:value)
+        .min_by { |fact| exclusion_priority(fact.name) }
 
-      certification.certification_requirements.certification_date
+      Determination::REASON_CODE_MAPPING.fetch(best_fact.name)
     end
 
-    def extract_date_of_birth(certification)
-      return nil unless certification.member_data
-
-      certification.member_data.date_of_birth
+    # Raises (naming the fact and id) if a fact is unbridged or its id has no
+    # configured priority — the drift guard for the fact/id/config seam.
+    def exclusion_priority(fact_name)
+      id = Rules::ExclusionRuleset::EXCLUSION_FACT_IDS.fetch(fact_name)
+      exclusion = Exclusion.find(id) ||
+        raise(KeyError, "no configured exclusion for id #{id.inspect} (bridged from fact #{fact_name.inspect})")
+      exclusion.fetch(:priority)
     end
 
     def extract_pregnancy_status(certification)

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -53,12 +53,12 @@ class ExclusionDeterminationService
       Determination::REASON_CODE_MAPPING.fetch(best_fact.name)
     end
 
-    # Raises (naming the fact and id) if a fact is unbridged or its id has no
-    # configured priority — the drift guard for the fact/id/config seam.
+    # Raises (naming the fact) if a fact has no configured exclusion — the drift
+    # guard for the fact/config seam. Exclusion config carries the fact, so it is
+    # the single source of truth bridging rules fact to configured priority.
     def exclusion_priority(fact_name)
-      id = Rules::ExclusionRuleset::EXCLUSION_FACT_IDS.fetch(fact_name)
-      exclusion = Exclusion.find(id) ||
-        raise(KeyError, "no configured exclusion for id #{id.inspect} (bridged from fact #{fact_name.inspect})")
+      exclusion = Exclusion.find_by_fact(fact_name) ||
+        raise(KeyError, "no configured exclusion for fact #{fact_name.inspect}")
       exclusion.fetch(:priority)
     end
 

--- a/reporting-app/app/services/exclusion_types_loader.rb
+++ b/reporting-app/app/services/exclusion_types_loader.rb
@@ -29,20 +29,24 @@ module ExclusionTypesLoader
   # Default exclusion priority order (high durability -> low), per the
   # Data Source Hierarchy spec. Only american_indian_alaska_native,
   # veteran_disability, and pregnant have rules in Rules::ExclusionRuleset
-  # today; the rest are declarative until their rules land.
+  # today; those carry a `fact` naming their Rules::ExclusionRuleset fact, which
+  # is the single source of truth bridging config id, rules fact, and reason
+  # code (see Exclusion.find_by_fact). The rest are declarative until their
+  # rules land, so they omit `fact`. `fact` is OSCER-owned; deployments only
+  # override `priority`.
   #
   # Priorities are spaced by 10 so a deployment can re-rank one exclusion by
   # dropping it into the gap between two others (e.g. priority 55 to sit
   # between 50 and 60) without renumbering the rest.
   DEFAULTS = {
-    "american_indian_alaska_native" => { "priority" => 10 },
+    "american_indian_alaska_native" => { "priority" => 10, "fact" => "is_american_indian_or_alaska_native" },
     "former_foster_care" => { "priority" => 20 },
-    "veteran_disability" => { "priority" => 30 },
+    "veteran_disability" => { "priority" => 30, "fact" => "is_veteran_with_disability" },
     "medically_frail" => { "priority" => 40 },
     "caretaker" => { "priority" => 50 },
     "tanf_snap_work" => { "priority" => 60 },
     "drug_treatment" => { "priority" => 70 },
-    "pregnant" => { "priority" => 80 },
+    "pregnant" => { "priority" => 80, "fact" => "is_pregnant" },
     "inmate" => { "priority" => 90 }
   }.freeze
 

--- a/reporting-app/app/services/exclusion_types_loader.rb
+++ b/reporting-app/app/services/exclusion_types_loader.rb
@@ -27,26 +27,24 @@ module ExclusionTypesLoader
   ConfigurationError = ConfigLoading::ConfigurationError
 
   # Default exclusion priority order (high durability -> low), per the
-  # Data Source Hierarchy spec. Only american_indian_alaska_native,
-  # veteran_disability, and pregnant have rules in Rules::ExclusionRuleset
-  # today; those carry a `fact` naming their Rules::ExclusionRuleset fact, which
-  # is the single source of truth bridging config id, rules fact, and reason
-  # code (see Exclusion.find_by_fact). The rest are declarative until their
-  # rules land, so they omit `fact`. `fact` is OSCER-owned; deployments only
-  # override `priority`.
+  # Data Source Hierarchy spec. The ruled exclusions (is_pregnant,
+  # is_american_indian_or_alaska_native, is_veteran_with_disability) use ids that
+  # match their Rules::ExclusionRuleset fact names, so the determination flow
+  # resolves an exclusion's priority directly by fact via Exclusion.find, with no
+  # separate id<->fact bridge. The rest are declarative until their rules land.
   #
   # Priorities are spaced by 10 so a deployment can re-rank one exclusion by
   # dropping it into the gap between two others (e.g. priority 55 to sit
   # between 50 and 60) without renumbering the rest.
   DEFAULTS = {
-    "american_indian_alaska_native" => { "priority" => 10, "fact" => "is_american_indian_or_alaska_native" },
+    "is_american_indian_or_alaska_native" => { "priority" => 10 },
     "former_foster_care" => { "priority" => 20 },
-    "veteran_disability" => { "priority" => 30, "fact" => "is_veteran_with_disability" },
+    "is_veteran_with_disability" => { "priority" => 30 },
     "medically_frail" => { "priority" => 40 },
     "caretaker" => { "priority" => 50 },
     "tanf_snap_work" => { "priority" => 60 },
     "drug_treatment" => { "priority" => 70 },
-    "pregnant" => { "priority" => 80, "fact" => "is_pregnant" },
+    "is_pregnant" => { "priority" => 80 },
     "inmate" => { "priority" => 90 }
   }.freeze
 

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -39,24 +39,6 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
     end
 
     context 'when applicant is eligible for exclusion' do
-      let(:age_fact) do
-        Strata::RulesEngine::Fact.new(
-          :age_under_19, true, reasons: []
-        )
-      end
-      let(:other_age_fact) do
-        Strata::RulesEngine::Fact.new(
-          :age_over_65, false, reasons: []
-        )
-      end
-      let(:eligibility_fact) do
-        Strata::RulesEngine::Fact.new(
-          :age_eligibility,
-          true,
-          reasons: [ age_fact, other_age_fact ]
-        )
-      end
-
       it 'transitions to end' do
         # Step 1: Case has been created and is on external_exclusion_check step
         expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP)
@@ -64,7 +46,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
         expect(certification_case).to be_open
 
         # Step 2: System process determines applicant is eligible for exclusion
-        certification_case.record_exclusion_determination(eligibility_fact, ExclusionDeterminationService)
+        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], ExclusionDeterminationService)
         Strata::EventManager.publish("DeterminedExcluded", { case_id: certification_case.id, certification_id: certification_case.certification_id })
         certification_case.reload
 
@@ -75,13 +57,6 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
     end
 
     context 'when applicant is not eligible for exclusion' do
-      let(:eligibility_fact) do
-        Strata::RulesEngine::Fact.new(
-          "no-op",
-          false
-        )
-      end
-
       it 'transitions to external_exception_check' do
         # Step 1: Case has been created and is on external_exclusion_check step
         expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP)

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -408,18 +408,12 @@ RSpec.describe CertificationCase, type: :model do
   end
 
   describe '#record_exclusion_determination' do
-    # Model only records state - service handles conditional logic and events
+    # Model only records the given reason codes - the service selects the single
+    # highest-priority exclusion and owns the conditional logic and events.
     before { stub_const("MockSubmitter", Class.new { include Strata::VirtualActor }) }
 
-
     it 'sets approval status and closes case' do
-      age_fact = Strata::RulesEngine::Fact.new(
-        :age_under_19, true, reasons: []
-      )
-      eligibility_fact = Strata::RulesEngine::Fact.new(
-        :age_eligibility, true, reasons: [ age_fact ]
-      )
-      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
+      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
       certification_case.reload
 
       expect(certification_case.exemption_request_approval_status).to eq("approved")
@@ -427,58 +421,27 @@ RSpec.describe CertificationCase, type: :model do
       expect(certification_case).to be_closed
     end
 
-
     it "logs approved decision to audit log" do
-      age_fact = Strata::RulesEngine::Fact.new(
-        :age_under_19, true, reasons: []
-      )
-      eligibility_fact = Strata::RulesEngine::Fact.new(
-        :age_eligibility, true, reasons: [ age_fact ]
-      )
       certification = Certification.find(certification_case.certification_id)
       expect do
-        certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
+        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
       end.to change { Strata::AuditLine.where(subject: certification, actor_type: MockSubmitter.name, action: "case.exclusion.approved").count }.by(1)
     end
 
-    it 'creates determination with correct attributes' do
-      age_fact = Strata::RulesEngine::Fact.new(
-        :age_under_19, true, reasons: []
-      )
-      eligibility_fact = Strata::RulesEngine::Fact.new(
-        :age_eligibility, true, reasons: [ age_fact ]
-      )
-      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
+    it 'creates a determination that records the given reason code' do
+      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
 
       determination = Determination.first
 
       expect(determination.decision_method).to eq("automated")
-      expect(determination.reasons).to include("age_under_19_excluded")
+      expect(determination.reasons).to eq([ "pregnancy_excluded" ])
       expect(determination.outcome).to eq("excluded")
       expect(determination.determined_at).to be_present
       # determination_data is a jsonb column and must be stored as a Hash, never a JSON
       # String (writing reasons.to_json double-encodes it into a String — see #680). For
       # automated exclusions it records the granting reason codes.
       expect(determination.determination_data).to be_a(Hash)
-      expect(determination.determination_data).to eq({ "exclusion_reasons" => [ "age_under_19_excluded" ] })
-    end
-
-    it 'records multiple reasons (age and pregnancy)' do
-      age_fact = Strata::RulesEngine::Fact.new(
-        :age_under_19, true, reasons: []
-      )
-      pregnant_fact = Strata::RulesEngine::Fact.new(
-        :is_pregnant, true, reasons: []
-      )
-      eligibility_fact = Strata::RulesEngine::Fact.new(
-        :eligible_for_exclusion, true, reasons: [ age_fact, pregnant_fact ]
-      )
-      certification_case.record_exclusion_determination(eligibility_fact, MockSubmitter)
-
-      determination = Determination.first
-
-      expect(determination.reasons).to include("age_under_19_excluded", "pregnancy_excluded")
-      expect(determination.outcome).to eq("excluded")
+      expect(determination.determination_data).to eq({ "exclusion_reasons" => [ "pregnancy_excluded" ] })
     end
   end
 

--- a/reporting-app/spec/models/concerns/determinable_spec.rb
+++ b/reporting-app/spec/models/concerns/determinable_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Determinable, type: :model do
   end
 
   describe 'Exemption reason' do
-    %i[age_under_19 age_over_65 is_pregnant is_american_indian_or_alaska_native exemption_request_compliant is_veteran_with_disability].each do |reason_code|
+    %i[is_pregnant is_american_indian_or_alaska_native exemption_request_compliant is_veteran_with_disability].each do |reason_code|
       context reason_code do
         it_behaves_like "a submitted determination", reason_code
         it_behaves_like "an exemption", reason_code

--- a/reporting-app/spec/models/exclusion_spec.rb
+++ b/reporting-app/spec/models/exclusion_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Exclusion, type: :model do
   # The spec's default priority order (high durability -> low).
   let(:priority_ordered_ids) do
     %i[
-      american_indian_alaska_native
+      is_american_indian_or_alaska_native
       former_foster_care
-      veteran_disability
+      is_veteran_with_disability
       medically_frail
       caretaker
       tanf_snap_work
       drug_treatment
-      pregnant
+      is_pregnant
       inmate
     ]
   end
@@ -31,16 +31,16 @@ RSpec.describe Exclusion, type: :model do
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
           [
-            { id: :pregnant, priority: 80 },
-            { id: :american_indian_alaska_native, priority: 10 },
-            { id: :veteran_disability, priority: 30 }
+            { id: :is_pregnant, priority: 80 },
+            { id: :is_american_indian_or_alaska_native, priority: 10 },
+            { id: :is_veteran_with_disability, priority: 30 }
           ]
         )
       end
 
       it "returns entries sorted ascending by :priority" do
         expect(described_class.all.map { |t| t[:id] }).to eq(
-          %i[american_indian_alaska_native veteran_disability pregnant]
+          %i[is_american_indian_or_alaska_native is_veteran_with_disability is_pregnant]
         )
       end
     end
@@ -60,43 +60,18 @@ RSpec.describe Exclusion, type: :model do
 
   describe ".find" do
     it "returns the config entry for a given id" do
-      entry = described_class.find(:veteran_disability)
-      expect(entry[:id]).to eq(:veteran_disability)
+      entry = described_class.find(:is_veteran_with_disability)
+      expect(entry[:id]).to eq(:is_veteran_with_disability)
       expect(entry[:priority]).to eq(30)
     end
 
     it "returns nil for an unknown id" do
       expect(described_class.find(:not_a_real_exclusion)).to be_nil
     end
-  end
 
-  describe ".find_by_fact" do
-    it "returns the config entry for a ruled fact" do
-      entry = described_class.find_by_fact(:is_veteran_with_disability)
-      expect(entry[:id]).to eq(:veteran_disability)
-    end
-
-    it "returns nil for a fact with no configured exclusion" do
-      expect(described_class.find_by_fact(:not_a_real_fact)).to be_nil
-    end
-  end
-
-  # Guards the fact/config/reason-code seam at test time so drift is caught here
-  # rather than as a fail-loud KeyError in the determination flow. Only ruled
-  # exclusions (those with a :fact) participate; declarative entries are exempt.
-  describe "fact bridging (drift guard)" do
-    let(:ruled_facts) { described_class.all.filter_map { |t| t[:fact] } }
-
-    it "resolves every ruled fact through find_by_fact to a priority-carrying entry" do
-      ruled_facts.each do |fact|
-        expect(described_class.find_by_fact(fact)).to include(:priority)
-      end
-    end
-
-    it "bridges only facts that map to a determination reason code" do
-      ruled_facts.each do |fact|
-        expect(Determination::REASON_CODE_MAPPING).to include(fact.to_sym)
-      end
+    it "resolves a rules fact directly, since ruled ids match their fact names" do
+      entry = described_class.find(:is_pregnant)
+      expect(entry).to include(id: :is_pregnant, priority: 80)
     end
   end
 end

--- a/reporting-app/spec/models/exclusion_spec.rb
+++ b/reporting-app/spec/models/exclusion_spec.rb
@@ -69,4 +69,34 @@ RSpec.describe Exclusion, type: :model do
       expect(described_class.find(:not_a_real_exclusion)).to be_nil
     end
   end
+
+  describe ".find_by_fact" do
+    it "returns the config entry for a ruled fact" do
+      entry = described_class.find_by_fact(:is_veteran_with_disability)
+      expect(entry[:id]).to eq(:veteran_disability)
+    end
+
+    it "returns nil for a fact with no configured exclusion" do
+      expect(described_class.find_by_fact(:not_a_real_fact)).to be_nil
+    end
+  end
+
+  # Guards the fact/config/reason-code seam at test time so drift is caught here
+  # rather than as a fail-loud KeyError in the determination flow. Only ruled
+  # exclusions (those with a :fact) participate; declarative entries are exempt.
+  describe "fact bridging (drift guard)" do
+    let(:ruled_facts) { described_class.all.filter_map { |t| t[:fact] } }
+
+    it "resolves every ruled fact through find_by_fact to a priority-carrying entry" do
+      ruled_facts.each do |fact|
+        expect(described_class.find_by_fact(fact)).to include(:priority)
+      end
+    end
+
+    it "bridges only facts that map to a determination reason code" do
+      ruled_facts.each do |fact|
+        expect(Determination::REASON_CODE_MAPPING).to include(fact.to_sym)
+      end
+    end
+  end
 end

--- a/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
@@ -5,27 +5,18 @@ require 'rails_helper'
 RSpec.describe Rules::ExclusionRuleset do
   let(:ruleset) { described_class.new }
 
-  describe '#age_under_19' do
-    context 'when age is nil' do
-      it 'returns nil' do
-        expect(ruleset.age_under_19(nil)).to be_nil
+  describe 'EXCLUSION_FACT_IDS' do
+    # Guards the fact/id/config/reason-code seam at test time so drift is caught
+    # here rather than as a fail-loud KeyError in the determination flow.
+    it 'bridges every fact to an exclusion configured with a priority' do
+      described_class::EXCLUSION_FACT_IDS.each_value do |id|
+        expect(Exclusion.find(id)).to include(:priority)
       end
     end
 
-    context 'when age is less than 19' do
-      it 'returns true' do
-        expect(ruleset.age_under_19(18)).to be true
-        expect(ruleset.age_under_19(0)).to be true
-        expect(ruleset.age_under_19(1)).to be true
-      end
-    end
-
-    context 'when age is 19 or greater' do
-      it 'returns false' do
-        expect(ruleset.age_under_19(19)).to be false
-        expect(ruleset.age_under_19(64)).to be false
-        expect(ruleset.age_under_19(65)).to be false
-        expect(ruleset.age_under_19(100)).to be false
+    it 'bridges only facts that map to a determination reason code' do
+      described_class::EXCLUSION_FACT_IDS.each_key do |fact_name|
+        expect(Determination::REASON_CODE_MAPPING).to include(fact_name)
       end
     end
   end
@@ -118,67 +109,49 @@ RSpec.describe Rules::ExclusionRuleset do
   describe '#eligible_for_exclusion' do
     context 'when all parameters are nil' do
       it 'returns nil' do
-        expect(ruleset.eligible_for_exclusion(nil, nil, nil, nil, nil)).to be_nil
+        expect(ruleset.eligible_for_exclusion(nil, nil, nil)).to be_nil
       end
     end
 
     context 'when only is_pregnant is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exclusion(nil, nil, true, nil, nil)).to be true
-      end
-    end
-
-    context 'when only age_under_19 is true' do
-      it 'returns true' do
-        expect(ruleset.eligible_for_exclusion(true, nil, nil, nil, nil)).to be true
-      end
-    end
-
-    context 'when only age_over_65 is true' do
-      it 'returns true' do
-        expect(ruleset.eligible_for_exclusion(nil, true, nil, nil, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(true, nil, nil)).to be true
       end
     end
 
     context 'when only is_american_indian_or_alaska_native is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exclusion(nil, nil, nil, true, nil)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, true, nil)).to be true
       end
     end
 
     context 'when only is_veteran_with_disability is true' do
       it 'returns true' do
-        expect(ruleset.eligible_for_exclusion(nil, nil, nil, nil, true)).to be true
+        expect(ruleset.eligible_for_exclusion(nil, nil, true)).to be true
       end
     end
 
-    context 'when age_under_19 and is_pregnant are both true' do
-      it 'returns true (multiple reasons)' do
-        expect(ruleset.eligible_for_exclusion(true, nil, true, nil, nil)).to be true
+    context 'when multiple parameters are true' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_exclusion(true, true, nil)).to be true
       end
     end
 
     context 'when all are true' do
-      it 'returns true (all reasons)' do
-        expect(ruleset.eligible_for_exclusion(true, true, true, true, true)).to be true
+      it 'returns true' do
+        expect(ruleset.eligible_for_exclusion(true, true, true)).to be true
       end
     end
 
     context 'when all are false' do
-      it 'returns false (no exemption)' do
-        expect(ruleset.eligible_for_exclusion(false, false, false, false, false)).to be false
+      it 'returns false' do
+        expect(ruleset.eligible_for_exclusion(false, false, false)).to be false
       end
     end
 
-    context 'when age-based exemption is false but is_american_indian_or_alaska_native is true' do
-      it 'returns true (race-based exemption)' do
-        expect(ruleset.eligible_for_exclusion(false, false, false, true, nil)).to be true
-      end
-    end
-
-    context 'when age-based exemption is false but pregnant is true' do
-      it 'returns true (pregnant exemption)' do
-        expect(ruleset.eligible_for_exclusion(false, false, true, nil, nil)).to be true
+    context 'when some are false but one is true' do
+      it 'returns true' do
+        expect(ruleset.eligible_for_exclusion(false, true, false)).to be true
       end
     end
   end

--- a/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
@@ -5,22 +5,6 @@ require 'rails_helper'
 RSpec.describe Rules::ExclusionRuleset do
   let(:ruleset) { described_class.new }
 
-  describe 'EXCLUSION_FACT_IDS' do
-    # Guards the fact/id/config/reason-code seam at test time so drift is caught
-    # here rather than as a fail-loud KeyError in the determination flow.
-    it 'bridges every fact to an exclusion configured with a priority' do
-      described_class::EXCLUSION_FACT_IDS.each_value do |id|
-        expect(Exclusion.find(id)).to include(:priority)
-      end
-    end
-
-    it 'bridges only facts that map to a determination reason code' do
-      described_class::EXCLUSION_FACT_IDS.each_key do |fact_name|
-        expect(Determination::REASON_CODE_MAPPING).to include(fact_name)
-      end
-    end
-  end
-
   describe '#is_pregnant' do
     context 'when pregnancy_status is nil' do
       it 'returns nil' do

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ExclusionDeterminationService do
     end
 
     context 'when multiple exclusions apply' do
-      # Default priorities: american_indian_alaska_native (10) < veteran_disability (30) < pregnant (80).
+      # Default priorities: is_american_indian_or_alaska_native (10) < is_veteran_with_disability (30) < is_pregnant (80).
       context 'when pregnant and a veteran with 100% disability' do
         let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_status: true, cert_date: cert_date) }
         let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
@@ -108,14 +108,14 @@ RSpec.describe ExclusionDeterminationService do
     end
 
     context 'when the configured priority order is overridden' do
-      # Re-rank so pregnant (10) outranks veteran_disability (20): proves selection consults
-      # Exclusion.priority_order rather than a hardcoded order.
+      # Re-rank so is_pregnant (10) outranks is_veteran_with_disability (20): proves selection
+      # consults Exclusion.priority_order rather than a hardcoded order.
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
           [
-            { id: :pregnant, priority: 10, fact: "is_pregnant" },
-            { id: :veteran_disability, priority: 20, fact: "is_veteran_with_disability" },
-            { id: :american_indian_alaska_native, priority: 30, fact: "is_american_indian_or_alaska_native" }
+            { id: :is_pregnant, priority: 10 },
+            { id: :is_veteran_with_disability, priority: 20 },
+            { id: :is_american_indian_or_alaska_native, priority: 30 }
           ]
         )
       end
@@ -134,7 +134,7 @@ RSpec.describe ExclusionDeterminationService do
       # exercises the fail-loud drift guard in exclusion_priority.
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
-          [ { id: :veteran_disability, priority: 30, fact: "is_veteran_with_disability" } ]
+          [ { id: :is_veteran_with_disability, priority: 30 } ]
         )
       end
 

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ExclusionDeterminationService do
   let(:service) { described_class }
   let(:cert_date) { Date.new(2025, 7, 1) }
-  let(:member_data) { build(:certification_member_data, date_of_birth: dob, cert_date: cert_date) }
+  let(:member_data) { build(:certification_member_data, cert_date: cert_date) }
   let(:rating_data) { nil }
   let(:veteran_disability_service) { instance_double(VeteranDisabilityService, get_disability_rating: rating_data) }
 
@@ -18,9 +18,6 @@ RSpec.describe ExclusionDeterminationService do
       create(
         :certification,
         member_data: member_data,
-        # Pin the evaluation date to the same anchor as the DOBs (cert_date). The
-        # factory default is a random future date, which flips age-boundary cases
-        # (under-19, 64) by calendar day — a non-deterministic flake.
         certification_requirements: build(:certification_certification_requirements, certification_date: cert_date)
       )
     end
@@ -31,300 +28,182 @@ RSpec.describe ExclusionDeterminationService do
       allow(NotificationService).to receive(:send_email_notification)
     end
 
-    context 'when applicant is under 19 years old' do
-      let(:dob) { cert_date - 18.years }
+    # The single Determination recorded on the excluded path (nil when not excluded).
+    def recorded_exclusion
+      Determination.where(subject: certification, outcome: "excluded").first
+    end
 
-      it 'publishes DeterminedExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
+    context 'when a single exclusion applies' do
+      context 'when the member is American Indian or Alaska Native' do
+        let(:member_data) do
+          build(:certification_member_data, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+        end
 
-      it 'closes the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("closed")
-      end
-
-      it 'sets exemption_request_approval_status to approved' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to eq("approved")
-      end
-
-      it 'sets exemption_request_approval_status_updated_at' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status_updated_at).to be_present
-      end
-
-      it 'logs approved event' do
-        expect do
+        it 'publishes DeterminedExcluded and closes the case' do
           service.determine(kase)
-        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exclusion.approved').count }.by(1)
-      end
-    end
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+          expect(kase.reload.status).to eq("closed")
+        end
 
-    context 'when applicant is 65 years old or older' do
-      let(:dob) { cert_date - 65.years }
-
-      it 'publishes DeterminedExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'closes the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("closed")
-      end
-
-      it 'sets exemption_request_approval_status to approved' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to eq("approved")
-      end
-
-      it 'sets exemption_request_approval_status_updated_at' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status_updated_at).to be_present
-      end
-    end
-
-    context 'when applicant is 19 years old' do
-      let(:dob) { cert_date - 19.years }
-
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-
-      it 'does not set exemption_request_approval_status' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to be_nil
-      end
-    end
-
-    context 'when applicant is 64 years old' do
-      let(:dob) { cert_date - 64.years }
-
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-
-      it 'does not set exemption_request_approval_status' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to be_nil
-      end
-    end
-
-    context 'when member_data has no date_of_birth' do
-      let(:dob) { nil }
-
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-
-      it 'does not set exemption_request_approval_status' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to be_nil
-      end
-
-      it 'logs denied event' do
-        expect do
+        it 'records the AIAN reason code' do
           service.determine(kase)
-        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exclusion.denied').count }.by(1)
+          expect(recorded_exclusion.reasons).to eq([ "american_indian_alaska_native_excluded" ])
+        end
+      end
+
+      context 'when the member is pregnant' do
+        let(:member_data) { build(:certification_member_data, pregnancy_status: true, cert_date: cert_date) }
+
+        it 'records the pregnancy reason code' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "pregnancy_excluded" ])
+        end
+      end
+
+      context 'when the member is a veteran with 100% disability' do
+        let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
+        let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
+
+        it 'records the veteran-disability reason code' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+        end
       end
     end
 
-    context 'when date_of_birth is invalid format' do
-      let(:dob) { "invalid-date-format" }
+    context 'when multiple exclusions apply' do
+      # Default priorities: american_indian_alaska_native (10) < veteran_disability (30) < pregnant (80).
+      context 'when pregnant and a veteran with 100% disability' do
+        let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_status: true, cert_date: cert_date) }
+        let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
-      it 'publishes DeterminedNotExcluded event' do
-        allow(Rails.logger).to receive(:warn)
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        it 'records only the higher-priority veteran-disability exclusion' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+        end
       end
 
-      it 'does not close the case' do
-        allow(Rails.logger).to receive(:warn)
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-    end
+      context 'when pregnant and American Indian or Alaska Native' do
+        let(:member_data) do
+          build(:certification_member_data, pregnancy_status: true, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+        end
 
-    context 'when member is American Indian or Alaska Native' do
-      let(:member_data) do
-        build(:certification_member_data, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+        it 'records only the higher-priority AIAN exclusion' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "american_indian_alaska_native_excluded" ])
+        end
       end
 
-      it 'publishes DeterminedExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
+      context 'when all three exclusions apply' do
+        let(:member_data) do
+          build(:certification_member_data, :with_icn, pregnancy_status: true, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+        end
+        let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
-      it 'closes the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("closed")
-      end
-
-      it 'sets exemption_request_approval_status to approved' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to eq("approved")
-      end
-
-      it 'sets exemption_request_approval_status_updated_at' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status_updated_at).to be_present
+        it 'records exactly one reason code — the highest priority (stop-at-first)' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "american_indian_alaska_native_excluded" ])
+        end
       end
     end
 
-    context 'when member is not American Indian or Alaska Native' do
-      let(:member_data) do
-        build(:certification_member_data, race_ethnicity: "white", cert_date: cert_date)
+    context 'when the configured priority order is overridden' do
+      # Re-rank so pregnant (10) outranks veteran_disability (20): proves selection consults
+      # Exclusion.priority_order rather than a hardcoded order.
+      before do
+        allow(Rails.application.config).to receive(:exclusion_types).and_return(
+          [
+            { id: :pregnant, priority: 10 },
+            { id: :veteran_disability, priority: 20 },
+            { id: :american_indian_alaska_native, priority: 30 }
+          ]
+        )
       end
 
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-
-      it 'does not set exemption_request_approval_status' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to be_nil
-      end
-    end
-
-    context 'when member is pregnant' do
-      let(:member_data) do
-        build(:certification_member_data, pregnancy_status: true, cert_date: cert_date)
-      end
-
-      it 'publishes DeterminedExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'closes the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("closed")
-      end
-
-      it 'sets exemption_request_approval_status to approved' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to eq("approved")
-      end
-
-      it 'sets exemption_request_approval_status_updated_at' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status_updated_at).to be_present
-      end
-    end
-
-    context 'when member is not pregnant and does not qualify for other exemptions' do
-      let(:member_data) do
-        build(:certification_member_data, pregnancy_status: false, cert_date: cert_date)
-      end
-
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
-      end
-
-      it 'does not set exemption_request_approval_status' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to be_nil
-      end
-    end
-
-    context 'when member is a veteran with 100% disability' do
-      let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
+      let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_status: true, cert_date: cert_date) }
       let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
-      it 'publishes DeterminedExcluded event' do
+      it 'records the exclusion now ranked highest (pregnancy)' do
         service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcluded', { case_id: kase.id, certification_id: kase.certification_id })
-      end
-
-      it 'closes the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("closed")
-      end
-
-      it 'sets exemption_request_approval_status to approved' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.exemption_request_approval_status).to eq("approved")
+        expect(recorded_exclusion.reasons).to eq([ "pregnancy_excluded" ])
       end
     end
 
-    context 'when member is a veteran but does not have 100% disability' do
-      let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
-      let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 70 } } } }
-
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+    context 'when a matched exclusion is missing from the priority config' do
+      # A fact evaluates true but its bridged id is absent from the configured
+      # exclusions — exercises the fail-loud drift guard in exclusion_priority.
+      before do
+        allow(Rails.application.config).to receive(:exclusion_types).and_return(
+          [ { id: :veteran_disability, priority: 30 } ]
+        )
       end
 
-      it 'does not close the case' do
-        service.determine(kase)
-        kase.reload
-        expect(kase.status).to eq("open")
+      let(:member_data) { build(:certification_member_data, pregnancy_status: true, cert_date: cert_date) }
+
+      it 'raises a descriptive error naming the exclusion id' do
+        expect { service.determine(kase) }.to raise_error(KeyError, /pregnant/)
       end
     end
 
-    context 'when VA service returns nil (fail-open)' do
-      let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
+    context 'when no exclusion applies' do
+      context 'without any matching condition' do
+        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
 
-      it 'publishes DeterminedNotExcluded event' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        it 'publishes DeterminedNotExcluded and leaves the case open' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+          expect(kase.reload.status).to eq("open")
+        end
+
+        it 'records no exclusion determination' do
+          service.determine(kase)
+          expect(recorded_exclusion).to be_nil
+        end
+
+        it 'logs a denied audit event' do
+          expect { service.determine(kase) }
+            .to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.exclusion.denied').count }.by(1)
+        end
+      end
+
+      context 'without a 100% veteran disability rating' do
+        let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
+        let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 70 } } } }
+
+        it 'publishes DeterminedNotExcluded' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        end
+      end
+
+      context 'when the VA service returns nil (fail-open)' do
+        let(:member_data) { build(:certification_member_data, :with_icn, cert_date: cert_date) }
+
+        it 'publishes DeterminedNotExcluded' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        end
+      end
+    end
+
+    context 'when the member is outside the community-engagement age range' do
+      context 'when under 19 with no other exclusion' do
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 18.years, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
+
+        it 'publishes DeterminedNotExcluded and leaves the case open' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+          expect(kase.reload.status).to eq("open")
+        end
+      end
+
+      context 'when 65 or older with no other exclusion' do
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
+
+        it 'publishes DeterminedNotExcluded' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        end
       end
     end
   end

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -113,9 +113,9 @@ RSpec.describe ExclusionDeterminationService do
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
           [
-            { id: :pregnant, priority: 10 },
-            { id: :veteran_disability, priority: 20 },
-            { id: :american_indian_alaska_native, priority: 30 }
+            { id: :pregnant, priority: 10, fact: "is_pregnant" },
+            { id: :veteran_disability, priority: 20, fact: "is_veteran_with_disability" },
+            { id: :american_indian_alaska_native, priority: 30, fact: "is_american_indian_or_alaska_native" }
           ]
         )
       end
@@ -130,18 +130,18 @@ RSpec.describe ExclusionDeterminationService do
     end
 
     context 'when a matched exclusion is missing from the priority config' do
-      # A fact evaluates true but its bridged id is absent from the configured
-      # exclusions — exercises the fail-loud drift guard in exclusion_priority.
+      # A fact evaluates true but no configured exclusion declares that fact —
+      # exercises the fail-loud drift guard in exclusion_priority.
       before do
         allow(Rails.application.config).to receive(:exclusion_types).and_return(
-          [ { id: :veteran_disability, priority: 30 } ]
+          [ { id: :veteran_disability, priority: 30, fact: "is_veteran_with_disability" } ]
         )
       end
 
       let(:member_data) { build(:certification_member_data, pregnancy_status: true, cert_date: cert_date) }
 
-      it 'raises a descriptive error naming the exclusion id' do
-        expect { service.determine(kase) }.to raise_error(KeyError, /pregnant/)
+      it 'raises a descriptive error naming the unbridged fact' do
+        expect { service.determine(kase) }.to raise_error(KeyError, /is_pregnant/)
       end
     end
 

--- a/reporting-app/spec/services/exclusion_types_loader_spec.rb
+++ b/reporting-app/spec/services/exclusion_types_loader_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe ExclusionTypesLoader, type: :service do
   # The spec's default priority order (high durability -> low), spaced by 10.
   let(:expected_defaults) do
     {
-      american_indian_alaska_native: 10,
+      is_american_indian_or_alaska_native: 10,
       former_foster_care: 20,
-      veteran_disability: 30,
+      is_veteran_with_disability: 30,
       medically_frail: 40,
       caretaker: 50,
       tanf_snap_work: 60,
       drug_treatment: 70,
-      pregnant: 80,
+      is_pregnant: 80,
       inmate: 90
     }
   end
@@ -66,7 +66,7 @@ RSpec.describe ExclusionTypesLoader, type: :service do
         result = described_class.merge_with_defaults("former_foster_care" => { "priority" => 55 })
         expect(result["former_foster_care"]["priority"]).to eq(55)
         expect(result["caretaker"]["priority"]).to eq(50)
-        expect(result["american_indian_alaska_native"]["priority"]).to eq(10)
+        expect(result["is_american_indian_or_alaska_native"]["priority"]).to eq(10)
         expect(result.size).to eq(ExclusionTypesLoader::DEFAULTS.size)
       end
     end


### PR DESCRIPTION
## Ticket

Resolves #752

## Changes

- Select and record the single highest-priority exclusion, ranked by the configured `Exclusion.priority_order` (from #751), instead of recording every match as an unsorted list.
- Remove age from the exclusion path: drop `age_under_19` and the two age parameters from `ExclusionRuleset#eligible_for_exclusion`, plus the date-of-birth and evaluation-date extraction that only fed the age rule.
- Add `EXCLUSION_FACT_IDS`, an explicit rules-fact-name to `Exclusion` config-id map, with a fail-loud lookup and a test invariant so the naming seam cannot drift silently.
- Change `CertificationCase#record_exclusion_determination` to take reason codes directly, mirroring the existing `record_exception_determination`; the service owns selection, the model records what it is given.
- Remove `Determination.to_reason_codes` (it produced the old unsorted list).

## Context for reviewers

The background exclusion check previously recorded every exclusion a member matched. The Data Source Hierarchy spec calls for OSCER to record the single "best" (most durable) exclusion, so this returns the one with the lowest priority number in the #751 config. Selection is a plain `min` over `Exclusion.priority_order`, so a deployment can re-rank exclusions and change the winner with no code change (a spec covers this via a config override).

Age is dropped intentionally, confirmed with Jeff: the state does not send members outside the community-engagement age range, and age is a CMS 435.553 mandatory exception rather than an exclusion. The age reason codes are deliberately left in `REASON_CODE_MAPPING` and the locales (they still serve the display and exemption paths); only the exclusion rule and its inputs are removed.

The `EXCLUSION_FACT_IDS` bridge exists because the rules-engine fact names and the `Exclusion` config ids are different vocabularies (`is_veteran_with_disability` vs `veteran_disability`, and the fact's "or" that the AIAN id drops), so they are mapped explicitly rather than string-derived; `exclusion_priority` raises naming the fact and id if the seam ever drifts.

Forward context, within the Data Source Hierarchy work this is part of: a later story adds mandatory exceptions, where a condition that applied during a lookback month but no longer applies is credited as met for that month. OSCER makes that time-based judgment, and those exception results rank below all exclusions on the same priority ladder. The single-best selection added here is the mechanism that ladder extends: the exception band and the configurable ordering of external data-source calls build on it rather than replace it.

## Testing

- Full suite: 2552 examples, 0 failures. Coverage 96.45% line / 83.46% branch. RuboCop clean.
- New service specs cover priority-ordered selection, stop-at-first (recorded `reasons` is a single-element array), a config override proving ordering is config-driven, and the fail-loud drift guard.
- Added `EXCLUSION_FACT_IDS` invariant specs asserting every bridged id is configured with a priority and every key maps to a reason code.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->