### PR TITLE
Bump websocket-driver to 0.8.2 to resolve GHSA-2x63-gw47-w4mm

### DIFF
--- a/reporting-app/Gemfile.lock
+++ b/reporting-app/Gemfile.lock
@@ -667,7 +667,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Ticket

None (security-audit CI failure; no tracking issue).

## Changes

Conservative lockfile-only bump of the transitive `websocket-driver` gem `0.8.1` → `0.8.2`. No `Gemfile` change — it comes in transitively via `actioncable`'s `websocket-driver (>= 0.6.1)` constraint.

## Context for reviewers

The `Security audit` CI job (`make audit` → `bundler-audit check --update`) started failing on open PRs after `ruby-advisory-db` published [GHSA-2x63-gw47-w4mm / CVE-2026-54465](https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm) on 2026-07-08:

> **websocket-driver** `0.8.1` — Denial of service via malformed Host header. Solution: update to `>= 0.8.2`.

Because `bundler-audit --update` pulls a live advisory DB on every run, this hit branches that were previously green without any code change of their own (e.g. [#761](https://github.com/navapbc/oscer/pull/761) flipped red overnight while [#759](https://github.com/navapbc/oscer/pull/759), which last ran before publication, still shows the stale green). Landing it as its own small merge-first PR (per the dependency-bump policy) keeps the lockfile-bump rationale on a single squash commit and **unblocks the audit gate on the other open PRs**, which can rebase once this merges.

## Testing

- `bundle update websocket-driver --conservative` → resolved to `0.8.2` (clears `>= 0.8.2`); lockfile-only diff (1 line).
- `bundle exec bundler-audit check --update` → **No vulnerabilities found.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->