### PR TITLE
Check exceptions on months instead of boolean in member data

### DIFF
--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -72,7 +72,7 @@ module Demo
           md.pregnancy_status = pregnancy_status if pregnancy_status.present?
           md.race_ethnicity = race_ethnicity if race_ethnicity.present?
           md.va_icn = va_icn if va_icn.present?
-          apply_external_exception(md)
+          apply_external_exception(md, certification_requirements.months_that_can_be_certified)
         end
 
         @certification = FactoryBot.build(
@@ -89,16 +89,16 @@ module Demo
 
       # Sets the MemberData signal that triggers the selected external exception, so the check fires
       # downstream in ExceptionDeterminationService. A blank selection leaves member data unchanged.
-      def apply_external_exception(member_data)
+      def apply_external_exception(member_data, months)
         case external_exception
         when "inpatient_medical_care"
-          member_data.receiving_inpatient_medical_care = true
+          member_data.dates_receiving_inpatient_medical_care = months
         when "declared_emergency_county"
-          member_data.resides_in_declared_emergency_county = true
+          member_data.dates_in_declared_emergency_county = months
         when "high_unemployment_county"
-          member_data.resides_in_high_unemployment_county = true
+          member_data.dates_in_high_unemployment_county = months
         when "medical_travel"
-          member_data.traveling_for_medical_care = true
+          member_data.dates_traveling_for_medical_care = months
         end
       end
     end

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -78,8 +78,9 @@ class Certifications::MemberData < ValueObject
 
   # External-exception signals evaluated by ExceptionDeterminationService.
   # Distinct from exclusion/exemption signals above; see ExternalException.
-  attribute :receiving_inpatient_medical_care, :boolean, default: false
-  attribute :resides_in_declared_emergency_county, :boolean, default: false
-  attribute :resides_in_high_unemployment_county, :boolean, default: false
-  attribute :traveling_for_medical_care, :boolean, default: false
+  attribute :dates_receiving_inpatient_medical_care, :array, of: ActiveModel::Type::Date.new
+  attribute :dates_in_declared_emergency_county, :array, of: ActiveModel::Type::Date.new
+  attribute :dates_in_high_unemployment_county, :array, of: ActiveModel::Type::Date.new
+  attribute :dates_traveling_for_medical_care, :array, of: ActiveModel::Type::Date.new
+  attribute :dates_participating_in_other_program, :array, of: ActiveModel::Type::Date.new
 end

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -79,7 +79,7 @@ class Determination < Strata::Determination
     receiving_inpatient_medical_care: "inpatient_medical_care_excepted",
     resides_in_declared_emergency_county: "declared_emergency_county_excepted",
     resides_in_high_unemployment_county: "high_unemployment_county_excepted",
-    traveling_for_medical_care: "medical_travel_excepted"
+    traveling_for_medical_care: "medical_travel_excepted",
   }.freeze
 
   # Reasons recorded when a staff reviewer approves or denies a member's denial response.

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -79,7 +79,7 @@ class Determination < Strata::Determination
     receiving_inpatient_medical_care: "inpatient_medical_care_excepted",
     resides_in_declared_emergency_county: "declared_emergency_county_excepted",
     resides_in_high_unemployment_county: "high_unemployment_county_excepted",
-    traveling_for_medical_care: "medical_travel_excepted",
+    traveling_for_medical_care: "medical_travel_excepted"
   }.freeze
 
   # Reasons recorded when a staff reviewer approves or denies a member's denial response.

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -8,7 +8,7 @@
 class ExceptionDeterminationService
   include Strata::VirtualActor
 
-  # Each symbol names a private check method taking certification and returning its reason code when
+  # Each symbol names a private check method taking member_data and lookback months and returning its reason code when
   # the exception applies (and is enabled), or nil otherwise. Add a check by adding its symbol here
   # and defining the matching method. Order is the evaluation order; the first applicable check wins.
   EXCEPTION_CHECKS = %i[

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -8,7 +8,7 @@
 class ExceptionDeterminationService
   include Strata::VirtualActor
 
-  # Each symbol names a private check method taking member_data and returning its reason code when
+  # Each symbol names a private check method taking certification and returning its reason code when
   # the exception applies (and is enabled), or nil otherwise. Add a check by adding its symbol here
   # and defining the matching method. Order is the evaluation order; the first applicable check wins.
   EXCEPTION_CHECKS = %i[
@@ -48,42 +48,57 @@ class ExceptionDeterminationService
       member_data = certification.member_data
       return [] if member_data.nil?
 
-      reason_code = EXCEPTION_CHECKS.lazy.filter_map { |check| send(check, member_data) }.first
+      certifiable_months = certification.certification_requirements.months_that_can_be_certified.map(&:beginning_of_month)
+      return [] unless certifiable_months.present?
+
+      reason_code = EXCEPTION_CHECKS.lazy.filter_map { |check| send(check, member_data, certifiable_months) }.first
       reason_code ? [ reason_code ] : []
     end
 
-    # @return [String, nil] the reason code when the member is receiving inpatient medical care and
+    # @return [String, nil] the reason code when the member was receiving inpatient medical care and
     #   the exception is enabled, otherwise nil.
-    def inpatient_medical_care(member_data)
+    def inpatient_medical_care(member_data, certifiable_months)
       return unless ExternalException.enabled?(:inpatient_medical_care)
-      return unless member_data.receiving_inpatient_medical_care
+      return unless member_data.dates_receiving_inpatient_medical_care.present?
+
+      inpatient_months = member_data.dates_receiving_inpatient_medical_care.map(&:beginning_of_month)
+      return unless (certifiable_months & inpatient_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:receiving_inpatient_medical_care)
     end
 
-    # @return [String, nil] the reason code when the member resides in a declared-emergency county
+    # @return [String, nil] the reason code when the member resided in a declared-emergency county
     #   and the exception is enabled, otherwise nil.
-    def declared_emergency_county(member_data)
+    def declared_emergency_county(member_data, certifiable_months)
       return unless ExternalException.enabled?(:declared_emergency_county)
-      return unless member_data.resides_in_declared_emergency_county
+      return unless member_data.dates_in_declared_emergency_county.present?
+
+      emergency_months = member_data.dates_in_declared_emergency_county.map(&:beginning_of_month)
+      return unless (certifiable_months & emergency_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:resides_in_declared_emergency_county)
     end
 
-    # @return [String, nil] the reason code when the member resides in a high-unemployment county and
+    # @return [String, nil] the reason code when the member resided in a high-unemployment county and
     #   the exception is enabled, otherwise nil.
-    def high_unemployment_county(member_data)
+    def high_unemployment_county(member_data, certifiable_months)
       return unless ExternalException.enabled?(:high_unemployment_county)
-      return unless member_data.resides_in_high_unemployment_county
+      return unless member_data.dates_in_high_unemployment_county.present?
+
+      high_unemployment_months = member_data.dates_in_high_unemployment_county.map(&:beginning_of_month)
+      return unless (certifiable_months & high_unemployment_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:resides_in_high_unemployment_county)
     end
 
-    # @return [String, nil] the reason code when the member is travelling for medical care (for
+    # @return [String, nil] the reason code when the member was travelling for medical care (for
     #   themselves or a dependent) and the exception is enabled, otherwise nil.
-    def medical_travel(member_data)
+    def medical_travel(member_data, certifiable_months)
       return unless ExternalException.enabled?(:medical_travel)
-      return unless member_data.traveling_for_medical_care
+      return unless member_data.dates_traveling_for_medical_care.present?
+
+      medical_travel_months = member_data.dates_traveling_for_medical_care.map(&:beginning_of_month)
+      return unless (certifiable_months & medical_travel_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:traveling_for_medical_care)
     end

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -48,7 +48,7 @@ class ExceptionDeterminationService
       member_data = certification.member_data
       return [] if member_data.nil?
 
-      certifiable_months = certification.certification_requirements.months_that_can_be_certified.map(&:beginning_of_month)
+      certifiable_months = certification.certification_requirements.months_that_can_be_certified.compact.map(&:beginning_of_month)
       return [] unless certifiable_months.present?
 
       reason_code = EXCEPTION_CHECKS.lazy.filter_map { |check| send(check, member_data, certifiable_months) }.first
@@ -61,7 +61,7 @@ class ExceptionDeterminationService
       return unless ExternalException.enabled?(:inpatient_medical_care)
       return unless member_data.dates_receiving_inpatient_medical_care.present?
 
-      inpatient_months = member_data.dates_receiving_inpatient_medical_care.map(&:beginning_of_month)
+      inpatient_months = member_data.dates_receiving_inpatient_medical_care.compact.map(&:beginning_of_month)
       return unless (certifiable_months & inpatient_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:receiving_inpatient_medical_care)
@@ -73,7 +73,7 @@ class ExceptionDeterminationService
       return unless ExternalException.enabled?(:declared_emergency_county)
       return unless member_data.dates_in_declared_emergency_county.present?
 
-      emergency_months = member_data.dates_in_declared_emergency_county.map(&:beginning_of_month)
+      emergency_months = member_data.dates_in_declared_emergency_county.compact.map(&:beginning_of_month)
       return unless (certifiable_months & emergency_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:resides_in_declared_emergency_county)
@@ -85,7 +85,7 @@ class ExceptionDeterminationService
       return unless ExternalException.enabled?(:high_unemployment_county)
       return unless member_data.dates_in_high_unemployment_county.present?
 
-      high_unemployment_months = member_data.dates_in_high_unemployment_county.map(&:beginning_of_month)
+      high_unemployment_months = member_data.dates_in_high_unemployment_county.compact.map(&:beginning_of_month)
       return unless (certifiable_months & high_unemployment_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:resides_in_high_unemployment_county)
@@ -97,7 +97,7 @@ class ExceptionDeterminationService
       return unless ExternalException.enabled?(:medical_travel)
       return unless member_data.dates_traveling_for_medical_care.present?
 
-      medical_travel_months = member_data.dates_traveling_for_medical_care.map(&:beginning_of_month)
+      medical_travel_months = member_data.dates_traveling_for_medical_care.compact.map(&:beginning_of_month)
       return unless (certifiable_months & medical_travel_months).present?
 
       Determination::REASON_CODE_MAPPING.fetch(:traveling_for_medical_care)

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -455,7 +455,7 @@
           "properties": {
             "status": {
               "type": "string",
-              "enum": ["compliant", "excluded", "exempt", "indeterminate", "not_compliant"],
+              "enum": ["compliant", "excluded", "excepted", "exempt", "indeterminate", "not_compliant"],
               "description": "Current status of community engagement requirement checks"
             },
             "reason": {

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -412,6 +412,7 @@ components:
           enum:
           - compliant
           - excluded
+          - excepted
           - exempt
           - indeterminate
           - not_compliant
@@ -545,67 +546,67 @@ components:
       required:
       - status
   responses:
-    b8f2f38bc8c2f6235cbe11844e1f22e6:
+    be516a58a4f0923b1158b40faf2725f0:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    83f294ae63467238e4f35a0cad57a3ea:
+    53c8c0f1d47139a0403896e137b4c776:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    503ff0a2127a2fff361cb1db9ebe3428:
+    7035126790e034a881ae1d857f62646f:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    a27e926ab0dbb7017819cbd94b436cb0:
+    f82923b53c6b8c5725e23daceb238185:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    14dcafc2f5493e99a23abd80ec1c0d54:
+    19cc50628e29d82ab4292a31d124e679:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    ef12758e50a588b4630a6c74ce376fd2:
+    c9151adf7b4fdb42d94ad0c73b88edab:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    71f1a8f0db1028f1e43e425cfbcdc546:
+    2fe0eed39f796f121c92aa69a7a7a5b1:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    8a9bf8f59f62d05218c6701932491f46:
+    00b32cbe3a56c325ced9bf8b9945e0b9:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    bb50fff96a9fd952e87329ae102a1d6b:
+    e885f77829cfee5fc75c7cb057044a49:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    9dc2f80603cf140b44be92b75d34f111:
+    a0007e5da733b975cf5821cd31f2f8fc:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    74d65d516ee19718a9f33d523da50238:
+    a9be643d371c2056e945c5c85b0a6887:
       description: Response
       content:
         application/json:
@@ -637,7 +638,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    bf9dfb13c9c40fce7127413e9a7d0f6e:
+    cfb70193b500d7fb2053f44ca8aa86ae:
       description: The Certification data.
       content:
         application/json:
@@ -730,11 +731,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/b8f2f38bc8c2f6235cbe11844e1f22e6"
+          "$ref": "#/components/responses/be516a58a4f0923b1158b40faf2725f0"
         '202':
-          "$ref": "#/components/responses/83f294ae63467238e4f35a0cad57a3ea"
+          "$ref": "#/components/responses/53c8c0f1d47139a0403896e137b4c776"
         '404':
-          "$ref": "#/components/responses/503ff0a2127a2fff361cb1db9ebe3428"
+          "$ref": "#/components/responses/7035126790e034a881ae1d857f62646f"
       security:
       - hmac: []
       deprecated: false
@@ -748,16 +749,16 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/bf9dfb13c9c40fce7127413e9a7d0f6e"
+        "$ref": "#/components/requestBodies/cfb70193b500d7fb2053f44ca8aa86ae"
       responses:
         '201':
-          "$ref": "#/components/responses/a27e926ab0dbb7017819cbd94b436cb0"
+          "$ref": "#/components/responses/f82923b53c6b8c5725e23daceb238185"
         '202':
-          "$ref": "#/components/responses/14dcafc2f5493e99a23abd80ec1c0d54"
+          "$ref": "#/components/responses/19cc50628e29d82ab4292a31d124e679"
         '400':
-          "$ref": "#/components/responses/ef12758e50a588b4630a6c74ce376fd2"
+          "$ref": "#/components/responses/c9151adf7b4fdb42d94ad0c73b88edab"
         '422':
-          "$ref": "#/components/responses/71f1a8f0db1028f1e43e425cfbcdc546"
+          "$ref": "#/components/responses/2fe0eed39f796f121c92aa69a7a7a5b1"
       security:
       - hmac: []
       deprecated: false
@@ -772,9 +773,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/8a9bf8f59f62d05218c6701932491f46"
+          "$ref": "#/components/responses/00b32cbe3a56c325ced9bf8b9945e0b9"
         '404':
-          "$ref": "#/components/responses/bb50fff96a9fd952e87329ae102a1d6b"
+          "$ref": "#/components/responses/e885f77829cfee5fc75c7cb057044a49"
       security:
       - hmac: []
       deprecated: false
@@ -809,9 +810,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/9dc2f80603cf140b44be92b75d34f111"
+          "$ref": "#/components/responses/a0007e5da733b975cf5821cd31f2f8fc"
         '503':
-          "$ref": "#/components/responses/74d65d516ee19718a9f33d523da50238"
+          "$ref": "#/components/responses/a9be643d371c2056e945c5c85b0a6887"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -4,15 +4,17 @@ require "rails_helper"
 
 RSpec.describe Demo::Certifications::CreateForm do
   describe "#to_certification external exception mapping" do
-    subject(:member_data) { form.to_certification.member_data }
+    subject(:member_data) { certification.member_data }
 
     let(:form) { described_class.new(certification_date: Date.current, external_exception: selected) }
+    let(:certification) { form.to_certification }
+    let(:months) { certification.certification_requirements.months_that_can_be_certified }
 
     context "when inpatient medical care is selected" do
       let(:selected) { "inpatient_medical_care" }
 
-      it "sets the matching member-data signal so the exception can be triggered" do
-        expect(member_data.receiving_inpatient_medical_care).to be true
+      it "sets the matching member-data signal so the exception can eq triggered" do
+        expect(member_data.dates_receiving_inpatient_medical_care).to eq months
       end
     end
 
@@ -20,7 +22,7 @@ RSpec.describe Demo::Certifications::CreateForm do
       let(:selected) { "declared_emergency_county" }
 
       it "sets the matching member-data signal" do
-        expect(member_data.resides_in_declared_emergency_county).to be true
+        expect(member_data.dates_in_declared_emergency_county).to eq months
       end
     end
 
@@ -28,7 +30,7 @@ RSpec.describe Demo::Certifications::CreateForm do
       let(:selected) { "high_unemployment_county" }
 
       it "sets the matching member-data signal" do
-        expect(member_data.resides_in_high_unemployment_county).to be true
+        expect(member_data.dates_in_high_unemployment_county).to eq months
       end
     end
 
@@ -36,7 +38,7 @@ RSpec.describe Demo::Certifications::CreateForm do
       let(:selected) { "medical_travel" }
 
       it "sets the matching member-data signal" do
-        expect(member_data.traveling_for_medical_care).to be true
+        expect(member_data.dates_traveling_for_medical_care).to eq months
       end
     end
 
@@ -44,10 +46,10 @@ RSpec.describe Demo::Certifications::CreateForm do
       let(:selected) { nil }
 
       it "leaves the exception signals at their defaults" do
-        expect(member_data.receiving_inpatient_medical_care).to be false
-        expect(member_data.resides_in_declared_emergency_county).to be false
-        expect(member_data.resides_in_high_unemployment_county).to be false
-        expect(member_data.traveling_for_medical_care).to be false
+        expect(member_data.dates_receiving_inpatient_medical_care).to be_blank
+        expect(member_data.dates_in_declared_emergency_county).to be_blank
+        expect(member_data.dates_in_high_unemployment_county).to be_blank
+        expect(member_data.dates_traveling_for_medical_care).to be_blank
       end
     end
   end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe "/demo/certifications", type: :request do
         }.to change(Certification, :count).by(1)
 
         cert = Certification.order(created_at: :desc).last
-        expect(cert.member_data.receiving_inpatient_medical_care).to be true
+        expect(cert.member_data.dates_receiving_inpatient_medical_care).to eq cert.certification_requirements.months_that_can_be_certified
       end
 
       it "creates a new Certification with race_ethnicity selected" do

--- a/reporting-app/spec/services/exception_determination_service_spec.rb
+++ b/reporting-app/spec/services/exception_determination_service_spec.rb
@@ -62,18 +62,23 @@ RSpec.describe ExceptionDeterminationService do
   end
 
   shared_examples 'an optional exception' do |attribute, exception_id|
-    let(:event_date) { [ cert_date - 3.months ] }
     let(:member_data) { build(:certification_member_data, cert_date:, attribute => event_date) }
 
     context 'when event in month that can be certified' do
-      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
+      let(:event_date) { [ cert_date - 2.months - 2.days ] }
 
       it_behaves_like 'an applied external exception', "#{exception_id}_excepted"
       it_behaves_like 'a disabled optional exception', exception_id
     end
 
     context 'when event not in month that can be certified' do
-      let(:months_that_can_be_certified) { (0..2).map { |i| cert_date - i.month } }
+      let(:event_date) { [ cert_date - 3.months - 2.days ] }
+
+      it_behaves_like 'a failed check'
+    end
+
+    context 'with invalid data' do
+      let(:event_date) { [ 'not a date' ] }
 
       it_behaves_like 'a failed check'
     end
@@ -82,7 +87,7 @@ RSpec.describe ExceptionDeterminationService do
   describe '#determine' do
     let(:cert_date) { Date.new(2025, 7, 1) }
     let(:member_data) { build(:certification_member_data, cert_date:) }
-    let(:months_that_can_be_certified) { [] }
+    let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
     let(:certification) do
       create(
         :certification,
@@ -92,8 +97,6 @@ RSpec.describe ExceptionDeterminationService do
     end
 
     context 'when no exception check applies (member data carries no exception signals)' do
-      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
-
       it_behaves_like 'a failed check'
 
       it 'logs a denied event in the audit log' do
@@ -135,7 +138,6 @@ RSpec.describe ExceptionDeterminationService do
       let(:dates_receiving_inpatient_medical_care) { [ cert_date - 3.months ] }
       let(:dates_traveling_for_medical_care) { [ cert_date - 3.months ] }
       let(:member_data) { build(:certification_member_data, cert_date:, dates_traveling_for_medical_care:, dates_receiving_inpatient_medical_care:) }
-      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
 
       it 'records only the first applicable reason (stops at first success)' do
         service.determine(kase)

--- a/reporting-app/spec/services/exception_determination_service_spec.rb
+++ b/reporting-app/spec/services/exception_determination_service_spec.rb
@@ -36,14 +36,7 @@ RSpec.describe ExceptionDeterminationService do
     end
   end
 
-  shared_examples 'a disabled external exception' do |exception_id|
-    before do
-      # Default to the real config, then disable only the exception under test, so the checks that
-      # run before it (up to the first success) still consult real enablement.
-      allow(ExternalException).to receive(:enabled?).and_call_original
-      allow(ExternalException).to receive(:enabled?).with(exception_id).and_return(false)
-    end
-
+  shared_examples 'a failed check' do
     it 'does not except the member (publishes DeterminedNotExcepted)' do
       service.determine(kase)
       expect(Strata::EventManager).to have_received(:publish)
@@ -57,18 +50,51 @@ RSpec.describe ExceptionDeterminationService do
     end
   end
 
-  describe '#determine' do
-    context 'when no exception check applies (member data carries no exception signals)' do
-      it 'publishes DeterminedNotExcepted' do
-        service.determine(kase)
-        expect(Strata::EventManager).to have_received(:publish)
-          .with('DeterminedNotExcepted', { case_id: kase.id, certification_id: kase.certification_id })
-      end
+  shared_examples 'a disabled optional exception' do |exception_id|
+    before do
+      # Default to the real config, then disable only the exception under test, so the checks that
+      # run before it (up to the first success) still consult real enablement.
+      allow(ExternalException).to receive(:enabled?).and_call_original
+      allow(ExternalException).to receive(:enabled?).with(exception_id).and_return(false)
+    end
 
-      it 'does not close the case' do
-        service.determine(kase)
-        expect(kase.reload.status).to eq('open')
-      end
+    it_behaves_like 'a failed check'
+  end
+
+  shared_examples 'an optional exception' do |attribute, exception_id|
+    let(:event_date) { [ cert_date - 3.months ] }
+    let(:member_data) { build(:certification_member_data, cert_date:, attribute => event_date) }
+
+    context 'when event in month that can be certified' do
+      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
+
+      it_behaves_like 'an applied external exception', "#{exception_id}_excepted"
+      it_behaves_like 'a disabled optional exception', exception_id
+    end
+
+    context 'when event not in month that can be certified' do
+      let(:months_that_can_be_certified) { (0..2).map { |i| cert_date - i.month } }
+
+      it_behaves_like 'a failed check'
+    end
+  end
+
+  describe '#determine' do
+    let(:cert_date) { Date.new(2025, 7, 1) }
+    let(:member_data) { build(:certification_member_data, cert_date:) }
+    let(:months_that_can_be_certified) { [] }
+    let(:certification) do
+      create(
+        :certification,
+        member_data:,
+        certification_requirements: build(:certification_certification_requirements, certification_date: cert_date, months_that_can_be_certified:)
+      )
+    end
+
+    context 'when no exception check applies (member data carries no exception signals)' do
+      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
+
+      it_behaves_like 'a failed check'
 
       it 'logs a denied event in the audit log' do
         expect do
@@ -89,50 +115,27 @@ RSpec.describe ExceptionDeterminationService do
       end
     end
 
-    context 'when the inpatient-medical-care check applies' do
-      let(:certification) do
-        create(:certification, member_data: build(:certification_member_data, receiving_inpatient_medical_care: true))
-      end
-
-      it_behaves_like 'an applied external exception', 'inpatient_medical_care_excepted'
-      it_behaves_like 'a disabled external exception', :inpatient_medical_care
+    describe 'checking inpatient-medical-care' do
+      it_behaves_like 'an optional exception', :dates_receiving_inpatient_medical_care, :inpatient_medical_care
     end
 
-    context 'when the declared-emergency-county check applies' do
-      let(:certification) do
-        create(:certification, member_data: build(:certification_member_data, resides_in_declared_emergency_county: true))
-      end
-
-      it_behaves_like 'an applied external exception', 'declared_emergency_county_excepted'
-      it_behaves_like 'a disabled external exception', :declared_emergency_county
+    describe 'checking declared-emergency-county' do
+      it_behaves_like 'an optional exception', :dates_in_declared_emergency_county, :declared_emergency_county
     end
 
-    context 'when the high-unemployment-county check applies' do
-      let(:certification) do
-        create(:certification, member_data: build(:certification_member_data, resides_in_high_unemployment_county: true))
-      end
-
-      it_behaves_like 'an applied external exception', 'high_unemployment_county_excepted'
-      it_behaves_like 'a disabled external exception', :high_unemployment_county
+    describe 'checking high-unemployment-county' do
+      it_behaves_like 'an optional exception', :dates_in_high_unemployment_county, :high_unemployment_county
     end
 
-    context 'when the medical-travel check applies' do
-      let(:certification) do
-        create(:certification, member_data: build(:certification_member_data, traveling_for_medical_care: true))
-      end
-
-      it_behaves_like 'an applied external exception', 'medical_travel_excepted'
-      it_behaves_like 'a disabled external exception', :medical_travel
+    describe 'checking medical-travel' do
+      it_behaves_like 'an optional exception', :dates_traveling_for_medical_care, :medical_travel
     end
 
     context 'when more than one exception check would apply' do
-      let(:certification) do
-        create(:certification, member_data: build(
-          :certification_member_data,
-          receiving_inpatient_medical_care: true,
-          resides_in_declared_emergency_county: true
-        ))
-      end
+      let(:dates_receiving_inpatient_medical_care) { [ cert_date - 3.months ] }
+      let(:dates_traveling_for_medical_care) { [ cert_date - 3.months ] }
+      let(:member_data) { build(:certification_member_data, cert_date:, dates_traveling_for_medical_care:, dates_receiving_inpatient_medical_care:) }
+      let(:months_that_can_be_certified) { (0..3).map { |i| cert_date - i.month } }
 
       it 'records only the first applicable reason (stops at first success)' do
         service.determine(kase)


### PR DESCRIPTION
## Ticket

Resolves #764 

## Changes

- Member Data takes list of dates for exceptions rather than boolean
- ExceptionDeterminationService checks months in MemberData against certification months in Requirements to determine if exception applies.
- Demo updated to set member data appropriately.

## Context for reviewers

Realized we need to validate exceptions against the dates in which the events took place instead of just generally.

## Testing
Updated specs.

Manually tested using demo:
- No exception had no affect
- Exception set member data appropriately and led to proper case determination

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->