### PR TITLE
OSCER-766: base pregnancy exclusion on (real or expected) parturition date

### DIFF
--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -69,7 +69,7 @@ module Demo
         member_data = ::Certifications::MemberData.new(member_data).tap do |md|
           md.name = member_name if member_name.present?
           md.date_of_birth = date_of_birth if date_of_birth.present?
-          md.pregnancy_status = pregnancy_status if pregnancy_status.present?
+          md.pregnancy_due_or_parturition_date = certification_date if pregnancy_status
           md.race_ethnicity = race_ethnicity if race_ethnicity.present?
           md.va_icn = va_icn if va_icn.present?
           apply_external_exception(md, certification_requirements.months_that_can_be_certified)

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -70,11 +70,13 @@ class Certifications::MemberData < ValueObject
   attribute :contact, ContactData.to_type
   attribute :name, ActiveModel::Type::Json.new(Strata::Name)
   attribute :date_of_birth, :date
-  attribute :race_ethnicity, :string
 
   attribute :payroll_accounts, :array, of: PayrollAccount.to_type
   attribute :activities, :array, of: Activity.to_type
-  attribute :pregnancy_status, :boolean, default: false
+
+  # Exclusion signals evaluated by ExclusionDeterminationService
+  attribute :pregnancy_due_or_parturition_date, :date
+  attribute :race_ethnicity, :string
 
   # External-exception signals evaluated by ExceptionDeterminationService.
   # Distinct from exclusion/exemption signals above; see ExternalException.

--- a/reporting-app/app/models/rules/exclusion_ruleset.rb
+++ b/reporting-app/app/models/rules/exclusion_ruleset.rb
@@ -5,10 +5,15 @@ module Rules
   class ExclusionRuleset < Strata::Rules::MedicaidRuleset
     AMERICAN_INDIAN_OR_ALASKA_NATIVE = [ "american_indian_or_alaska_native", "american_indian", "alaska_native" ].freeze
 
-    def is_pregnant(pregnancy_status)
-      return if pregnancy_status.nil?
+    # Pregnancy excludes from the due/parturition date through the following 12 months
+    POSTPARTUM_EXCLUSION_MONTHS = 12
 
-      pregnancy_status
+    def is_pregnant(pregnancy_due_or_parturition_date, certification_date)
+      return if pregnancy_due_or_parturition_date.nil?
+      return if certification_date.nil?
+
+      exclusion_end = pregnancy_due_or_parturition_date + POSTPARTUM_EXCLUSION_MONTHS.months
+      certification_date.beginning_of_month <= exclusion_end
     end
 
     def is_american_indian_or_alaska_native(race_ethnicity)

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -30,12 +30,14 @@ class ExclusionDeterminationService
       ruleset = Rules::ExclusionRuleset.new
       engine = Strata::RulesEngine.new(ruleset)
 
-      pregnancy_status = extract_pregnancy_status(certification)
+      pregnancy_due_or_parturition_date = extract_pregnancy_due_or_parturition_date(certification)
+      certification_date = certification.certification_requirements.certification_date
       race_ethnicity = extract_race_ethnicity(certification)
       veteran_disability_rating = extract_veteran_disability_status(certification)
 
       engine.set_facts(
-        pregnancy_status: pregnancy_status,
+        pregnancy_due_or_parturition_date: pregnancy_due_or_parturition_date,
+        certification_date: certification_date,
         race_ethnicity: race_ethnicity,
         veteran_disability_rating: veteran_disability_rating
       )
@@ -62,10 +64,10 @@ class ExclusionDeterminationService
       exclusion.fetch(:priority)
     end
 
-    def extract_pregnancy_status(certification)
+    def extract_pregnancy_due_or_parturition_date(certification)
       return nil unless certification.member_data
 
-      certification.member_data.pregnancy_status
+      certification.member_data.pregnancy_due_or_parturition_date
     end
 
     def extract_race_ethnicity(certification)

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -116,6 +116,8 @@ class UnifiedRecordProcessor
 
   # Build member_data hash from record fields
   def build_member_data(record)
+    parturition_date = record["certification_date"] if pregnancy_flag?(record["pregnancy_status"])
+
     {
       "name" => {
         "first" => record["first_name"],
@@ -130,7 +132,7 @@ class UnifiedRecordProcessor
       "county" => record["county"],
       "zip" => record["zip_code"],
       "date_of_birth" => record["date_of_birth"],
-      "pregnancy_status" => record["pregnancy_status"],
+      "pregnancy_due_or_parturition_date" => parturition_date,
       "race_ethnicity" => record["race_ethnicity"],
       "work_hours" => record["work_hours"],
       "other_income_sources" => record["other_income_sources"]
@@ -149,5 +151,12 @@ class UnifiedRecordProcessor
     }.compact_blank
 
     @certification_service.certification_requirements_from_input(requirement_input)
+  end
+
+  # Accepted (case-insensitive) spellings of a truthy pregnancy_status flag in an uploaded CSV.
+  PREGNANCY_TRUE_VALUES = %w[yes true].freeze
+
+  def pregnancy_flag?(value)
+    PREGNANCY_TRUE_VALUES.include?(value.to_s.strip.downcase)
   end
 end

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -78,7 +78,7 @@
                 ],
                 "date_of_birth": "1980-01-01",
                 "race_ethnicity": "Hispanic",
-                "pregnancy_status": false
+                "pregnancy_due_or_parturition_date": null
               }
             }
           },
@@ -106,7 +106,7 @@
                 },
                 "date_of_birth": "1980-01-01",
                 "race_ethnicity": "Hispanic",
-                "pregnancy_status": false
+                "pregnancy_due_or_parturition_date": null
               }
             }
           },
@@ -132,7 +132,7 @@
                 },
                 "date_of_birth": "1980-01-01",
                 "race_ethnicity": "Hispanic",
-                "pregnancy_status": false
+                "pregnancy_due_or_parturition_date": null
               }
             }
           }
@@ -284,9 +284,10 @@
             "type": ["string", "null"],
             "description": "The race or ethnicity of the member"
           },
-          "pregnancy_status": {
-            "type": ["boolean", "null"],
-            "description": "The pregnancy status of the member"
+          "pregnancy_due_or_parturition_date": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "Pregnancy due (future) or parturation (past) date"
           }
         }
       },
@@ -583,7 +584,7 @@
             ],
             "date_of_birth": "1980-01-01",
             "race_ethnicity": "Hispanic",
-            "pregnancy_status": false
+            "pregnancy_due_or_parturition_date": null
           },
           "outcome": {
             "status": "compliant",

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -64,7 +64,7 @@ components:
                 verification_status: verified
               date_of_birth: '1980-01-01'
               race_ethnicity: Hispanic
-              pregnancy_status: false
+              pregnancy_due_or_parturition_date:
         without_explicit_months_that_can_be_certified_and_due_date:
           value:
             member_id: '123'
@@ -86,7 +86,7 @@ components:
                 suffix: Jr.
               date_of_birth: '1980-01-01'
               race_ethnicity: Hispanic
-              pregnancy_status: false
+              pregnancy_due_or_parturition_date:
         certification_type:
           value:
             member_id: '123'
@@ -106,7 +106,7 @@ components:
                 suffix: Jr.
               date_of_birth: '1980-01-01'
               race_ethnicity: Hispanic
-              pregnancy_status: false
+              pregnancy_due_or_parturition_date:
     CertificationRequirements:
       type: object
       description: Description of certification needs
@@ -244,11 +244,12 @@ components:
           - string
           - 'null'
           description: The race or ethnicity of the member
-        pregnancy_status:
+        pregnancy_due_or_parturition_date:
           type:
-          - boolean
+          - string
           - 'null'
-          description: The pregnancy status of the member
+          format: date
+          description: Pregnancy due (future) or parturation (past) date
     CertificationMemberDataPayrollAccount:
       type: object
       description: Description of a payroll
@@ -517,7 +518,7 @@ components:
             verification_status: verified
           date_of_birth: '1980-01-01'
           race_ethnicity: Hispanic
-          pregnancy_status: false
+          pregnancy_due_or_parturition_date:
         outcome:
           status: compliant
           reason: hours_reported_compliant
@@ -546,67 +547,67 @@ components:
       required:
       - status
   responses:
-    be516a58a4f0923b1158b40faf2725f0:
+    4ef56078a7d2b01212e2e8091f7b3b06:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    53c8c0f1d47139a0403896e137b4c776:
+    fbef4d639ad61ae1632d7db60f26eb83:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    7035126790e034a881ae1d857f62646f:
+    327664e974119820b630b971d17fb56e:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    f82923b53c6b8c5725e23daceb238185:
+    f206e4e12a74cebbb249a49c4760a015:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    19cc50628e29d82ab4292a31d124e679:
+    31962d7a4f428958ca92d5c9d7a0379c:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    c9151adf7b4fdb42d94ad0c73b88edab:
+    fa4af3e3ad89270b75266c8fe21626e5:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    2fe0eed39f796f121c92aa69a7a7a5b1:
+    499b0bbf334a340d13106fd5d39a9e67:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    00b32cbe3a56c325ced9bf8b9945e0b9:
+    4a49c7b0d85da1a0234943d461e5c13d:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    e885f77829cfee5fc75c7cb057044a49:
+    5d5cbed073fc7df3a7a5a2e69e613e08:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    a0007e5da733b975cf5821cd31f2f8fc:
+    '01938e0f1de15fdc46bb5e119642c879':
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    a9be643d371c2056e945c5c85b0a6887:
+    df798efcf0ba72887fbe03fe879c9644:
       description: Response
       content:
         application/json:
@@ -638,7 +639,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    cfb70193b500d7fb2053f44ca8aa86ae:
+    43911c751585704fadfdf849a5c55c70:
       description: The Certification data.
       content:
         application/json:
@@ -731,11 +732,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/be516a58a4f0923b1158b40faf2725f0"
+          "$ref": "#/components/responses/4ef56078a7d2b01212e2e8091f7b3b06"
         '202':
-          "$ref": "#/components/responses/53c8c0f1d47139a0403896e137b4c776"
+          "$ref": "#/components/responses/fbef4d639ad61ae1632d7db60f26eb83"
         '404':
-          "$ref": "#/components/responses/7035126790e034a881ae1d857f62646f"
+          "$ref": "#/components/responses/327664e974119820b630b971d17fb56e"
       security:
       - hmac: []
       deprecated: false
@@ -749,16 +750,16 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/cfb70193b500d7fb2053f44ca8aa86ae"
+        "$ref": "#/components/requestBodies/43911c751585704fadfdf849a5c55c70"
       responses:
         '201':
-          "$ref": "#/components/responses/f82923b53c6b8c5725e23daceb238185"
+          "$ref": "#/components/responses/f206e4e12a74cebbb249a49c4760a015"
         '202':
-          "$ref": "#/components/responses/19cc50628e29d82ab4292a31d124e679"
+          "$ref": "#/components/responses/31962d7a4f428958ca92d5c9d7a0379c"
         '400':
-          "$ref": "#/components/responses/c9151adf7b4fdb42d94ad0c73b88edab"
+          "$ref": "#/components/responses/fa4af3e3ad89270b75266c8fe21626e5"
         '422':
-          "$ref": "#/components/responses/2fe0eed39f796f121c92aa69a7a7a5b1"
+          "$ref": "#/components/responses/499b0bbf334a340d13106fd5d39a9e67"
       security:
       - hmac: []
       deprecated: false
@@ -773,9 +774,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/00b32cbe3a56c325ced9bf8b9945e0b9"
+          "$ref": "#/components/responses/4a49c7b0d85da1a0234943d461e5c13d"
         '404':
-          "$ref": "#/components/responses/e885f77829cfee5fc75c7cb057044a49"
+          "$ref": "#/components/responses/5d5cbed073fc7df3a7a5a2e69e613e08"
       security:
       - hmac: []
       deprecated: false
@@ -810,9 +811,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/a0007e5da733b975cf5821cd31f2f8fc"
+          "$ref": "#/components/responses/01938e0f1de15fdc46bb5e119642c879"
         '503':
-          "$ref": "#/components/responses/a9be643d371c2056e945c5c85b0a6887"
+          "$ref": "#/components/responses/df798efcf0ba72887fbe03fe879c9644"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -31,7 +31,6 @@ FactoryBot.define do
 
     trait :with_no_exemptions do
       date_of_birth { cert_date - rand(19..64).years } # random age between 19 and 64 years old (ineligible for age exemption)
-      pregnancy_status { false }
       race_ethnicity do
         (
           Demo::Certifications::BaseCreateForm::RACE_ETHNICITY_OPTIONS - [ "american_indian_or_alaska_native" ]

--- a/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
+++ b/reporting-app/spec/models/rules/exclusion_ruleset_spec.rb
@@ -6,21 +6,57 @@ RSpec.describe Rules::ExclusionRuleset do
   let(:ruleset) { described_class.new }
 
   describe '#is_pregnant' do
-    context 'when pregnancy_status is nil' do
+    let(:certification_date) { Date.new(2025, 7, 1) }
+
+    context 'when the due/parturition date is nil' do
       it 'returns nil' do
-        expect(ruleset.is_pregnant(nil)).to be_nil
+        expect(ruleset.is_pregnant(nil, certification_date)).to be_nil
       end
     end
 
-    context 'when pregnancy_status is true' do
+    context 'when the certification date is nil' do
+      it 'returns nil' do
+        expect(ruleset.is_pregnant(Date.new(2025, 6, 1), nil)).to be_nil
+      end
+    end
+
+    context 'when the due date is in the future (member is currently expecting)' do
       it 'returns true' do
-        expect(ruleset.is_pregnant(true)).to be true
+        expect(ruleset.is_pregnant(certification_date + 3.months, certification_date)).to be true
       end
     end
 
-    context 'when pregnancy_status is false' do
+    context 'when the parturition date is within the prior 12 months' do
+      it 'returns true' do
+        expect(ruleset.is_pregnant(certification_date - 6.months, certification_date)).to be true
+      end
+    end
+
+    context 'when the certification date is exactly 12 months after the parturition date (boundary)' do
+      it 'returns true' do
+        expect(ruleset.is_pregnant(certification_date - 12.months, certification_date)).to be true
+      end
+    end
+
+    context 'when the window ends the same month as the certification date but on an earlier day' do
+      it 'returns true' do
+        certification_date = Date.new(2025, 7, 20)
+        parturition_date = Date.new(2024, 7, 5)
+        expect(ruleset.is_pregnant(parturition_date, certification_date)).to be true
+      end
+    end
+
+    context 'when the window ends the month before the certification date' do
       it 'returns false' do
-        expect(ruleset.is_pregnant(false)).to be false
+        certification_date = Date.new(2025, 7, 20)
+        parturition_date = Date.new(2024, 6, 25)
+        expect(ruleset.is_pregnant(parturition_date, certification_date)).to be false
+      end
+    end
+
+    context 'when the parturition date is more than 12 months before the certification date' do
+      it 'returns false' do
+        expect(ruleset.is_pregnant(certification_date - 13.months, certification_date)).to be false
       end
     end
   end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(cert.member_data.date_of_birth).to eq(Date.new(1990, 1, 15))
       end
 
-      it "creates a new Certification with pregnancy_status checkbox selected" do
+      it "writes the certification date to pregnancy_due_or_parturition_date when the pregnancy_status checkbox is selected" do
         create_attrs = valid_request_attributes.merge({ pregnancy_status: "1", external_scenario: "No data" })
 
         expect {
@@ -316,7 +316,7 @@ RSpec.describe "/demo/certifications", type: :request do
         }.to change(Certification, :count).by(1)
 
         cert = Certification.order(created_at: :desc).last
-        expect(cert.member_data.pregnancy_status).to be true
+        expect(cert.member_data.pregnancy_due_or_parturition_date).to eq(cert.certification_requirements.certification_date)
       end
 
       it "creates a new Certification with an external exception selected" do

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -51,8 +51,17 @@ RSpec.describe ExclusionDeterminationService do
         end
       end
 
-      context 'when the member is pregnant' do
-        let(:member_data) { build(:certification_member_data, pregnancy_status: true, cert_date: cert_date) }
+      context 'when the member is pregnant with a future due date (currently expecting)' do
+        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date + 3.months, cert_date: cert_date) }
+
+        it 'records the pregnancy reason code' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "pregnancy_excluded" ])
+        end
+      end
+
+      context 'when the member is pregnant with a parturition date within the prior 12 months (postpartum)' do
+        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date - 6.months, cert_date: cert_date) }
 
         it 'records the pregnancy reason code' do
           service.determine(kase)
@@ -74,7 +83,7 @@ RSpec.describe ExclusionDeterminationService do
     context 'when multiple exclusions apply' do
       # Default priorities: is_american_indian_or_alaska_native (10) < is_veteran_with_disability (30) < is_pregnant (80).
       context 'when pregnant and a veteran with 100% disability' do
-        let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_status: true, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
         let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
         it 'records only the higher-priority veteran-disability exclusion' do
@@ -85,7 +94,7 @@ RSpec.describe ExclusionDeterminationService do
 
       context 'when pregnant and American Indian or Alaska Native' do
         let(:member_data) do
-          build(:certification_member_data, pregnancy_status: true, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+          build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
         end
 
         it 'records only the higher-priority AIAN exclusion' do
@@ -96,7 +105,7 @@ RSpec.describe ExclusionDeterminationService do
 
       context 'when all three exclusions apply' do
         let(:member_data) do
-          build(:certification_member_data, :with_icn, pregnancy_status: true, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+          build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
         end
         let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
@@ -120,7 +129,7 @@ RSpec.describe ExclusionDeterminationService do
         )
       end
 
-      let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_status: true, cert_date: cert_date) }
+      let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
       let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
       it 'records the exclusion now ranked highest (pregnancy)' do
@@ -138,7 +147,7 @@ RSpec.describe ExclusionDeterminationService do
         )
       end
 
-      let(:member_data) { build(:certification_member_data, pregnancy_status: true, cert_date: cert_date) }
+      let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
 
       it 'raises a descriptive error naming the unbridged fact' do
         expect { service.determine(kase) }.to raise_error(KeyError, /is_pregnant/)
@@ -146,8 +155,18 @@ RSpec.describe ExclusionDeterminationService do
     end
 
     context 'when no exclusion applies' do
+      context 'when the parturition date is more than 12 months before the certification date' do
+        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", pregnancy_due_or_parturition_date: cert_date - 13.months, cert_date: cert_date) }
+
+        it 'publishes DeterminedNotExcluded and records no exclusion' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+          expect(recorded_exclusion).to be_nil
+        end
+      end
+
       context 'without any matching condition' do
-        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", cert_date: cert_date) }
 
         it 'publishes DeterminedNotExcluded and leaves the case open' do
           service.determine(kase)
@@ -188,7 +207,7 @@ RSpec.describe ExclusionDeterminationService do
 
     context 'when the member is outside the community-engagement age range' do
       context 'when under 19 with no other exclusion' do
-        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 18.years, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 18.years, race_ethnicity: "white", cert_date: cert_date) }
 
         it 'publishes DeterminedNotExcluded and leaves the case open' do
           service.determine(kase)
@@ -198,7 +217,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'when 65 or older with no other exclusion' do
-        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", pregnancy_status: false, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", cert_date: cert_date) }
 
         it 'publishes DeterminedNotExcluded' do
           service.determine(kase)

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'when the member is pregnant with a future due date (currently expecting)' do
-        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date + 3.months, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date + 3.months, cert_date:) }
 
         it 'records the pregnancy reason code' do
           service.determine(kase)
@@ -61,7 +61,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'when the member is pregnant with a parturition date within the prior 12 months (postpartum)' do
-        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date - 6.months, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date - 6.months, cert_date:) }
 
         it 'records the pregnancy reason code' do
           service.determine(kase)
@@ -83,7 +83,7 @@ RSpec.describe ExclusionDeterminationService do
     context 'when multiple exclusions apply' do
       # Default priorities: is_american_indian_or_alaska_native (10) < is_veteran_with_disability (30) < is_pregnant (80).
       context 'when pregnant and a veteran with 100% disability' do
-        let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date:) }
         let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
         it 'records only the higher-priority veteran-disability exclusion' do
@@ -94,7 +94,7 @@ RSpec.describe ExclusionDeterminationService do
 
       context 'when pregnant and American Indian or Alaska Native' do
         let(:member_data) do
-          build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+          build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date:)
         end
 
         it 'records only the higher-priority AIAN exclusion' do
@@ -105,7 +105,7 @@ RSpec.describe ExclusionDeterminationService do
 
       context 'when all three exclusions apply' do
         let(:member_data) do
-          build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date: cert_date)
+          build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, race_ethnicity: "american_indian_or_alaska_native", cert_date:)
         end
         let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
@@ -129,7 +129,7 @@ RSpec.describe ExclusionDeterminationService do
         )
       end
 
-      let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
+      let(:member_data) { build(:certification_member_data, :with_icn, pregnancy_due_or_parturition_date: cert_date, cert_date:) }
       let(:rating_data) { { "data" => { "attributes" => { "combined_disability_rating" => 100 } } } }
 
       it 'records the exclusion now ranked highest (pregnancy)' do
@@ -147,7 +147,7 @@ RSpec.describe ExclusionDeterminationService do
         )
       end
 
-      let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, cert_date: cert_date) }
+      let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, cert_date:) }
 
       it 'raises a descriptive error naming the unbridged fact' do
         expect { service.determine(kase) }.to raise_error(KeyError, /is_pregnant/)
@@ -156,7 +156,7 @@ RSpec.describe ExclusionDeterminationService do
 
     context 'when no exclusion applies' do
       context 'when the parturition date is more than 12 months before the certification date' do
-        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", pregnancy_due_or_parturition_date: cert_date - 13.months, cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", pregnancy_due_or_parturition_date: cert_date - 13.months, cert_date:) }
 
         it 'publishes DeterminedNotExcluded and records no exclusion' do
           service.determine(kase)
@@ -166,7 +166,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'without any matching condition' do
-        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", cert_date:) }
 
         it 'publishes DeterminedNotExcluded and leaves the case open' do
           service.determine(kase)
@@ -207,7 +207,7 @@ RSpec.describe ExclusionDeterminationService do
 
     context 'when the member is outside the community-engagement age range' do
       context 'when under 19 with no other exclusion' do
-        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 18.years, race_ethnicity: "white", cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 18.years, race_ethnicity: "white", cert_date:) }
 
         it 'publishes DeterminedNotExcluded and leaves the case open' do
           service.determine(kase)
@@ -217,7 +217,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'when 65 or older with no other exclusion' do
-        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", cert_date: cert_date) }
+        let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", cert_date:) }
 
         it 'publishes DeterminedNotExcluded' do
           service.determine(kase)

--- a/reporting-app/spec/services/unified_record_processor_spec.rb
+++ b/reporting-app/spec/services/unified_record_processor_spec.rb
@@ -47,6 +47,29 @@ RSpec.describe UnifiedRecordProcessor do
         expect(certification.member_data.account_email).to eq("test@example.com")
       end
 
+      context "with pregnancy_status" do
+        [ "yes", "YES", " Yes ", "true", "TRUE" ].each do |flag|
+          it "records the certification date as the parturition date when pregnancy_status is #{flag.inspect}" do
+            allow(Strata::EventManager).to receive(:publish)
+
+            certification = processor.process(record.merge("pregnancy_status" => flag))
+
+            cert_date = certification.certification_requirements.certification_date
+            expect(certification.member_data.pregnancy_due_or_parturition_date).to eq(cert_date)
+          end
+        end
+
+        [ "no", "false", "FALSE", "" ].each do |flag|
+          it "leaves the parturition date unset when pregnancy_status is #{flag.inspect}" do
+            allow(Strata::EventManager).to receive(:publish)
+
+            certification = processor.process(record.merge("pregnancy_status" => flag))
+
+            expect(certification.member_data.pregnancy_due_or_parturition_date).to be_nil
+          end
+        end
+      end
+
       it "builds certification_requirements from record fields" do
         allow(Strata::EventManager).to receive(:publish)
 


### PR DESCRIPTION
## Ticket

First pass at #766

## Changes

Converts the pregnancy signal used by `ExclusionDeterminationService` from a boolean to a date, bringing exclusion member data in line with the date-based approach already used for exception member data.

- **`Certifications::MemberData`** — replaced `pregnancy_status` (boolean) with `pregnancy_due_or_parturition_date` (date): the expected due date if the member is currently expecting, or the actual birth date if in the past.
- **`Rules::ExclusionRuleset#is_pregnant`** — now takes `(pregnancy_due_or_parturition_date, certification_date)` and applies a 12-month exclusion window (`POSTPARTUM_EXCLUSION_MONTHS`) evaluated against the certification date.
- **`ExclusionDeterminationService`** — sets the due/parturition date and the certification date (from `certification_requirements.certification_date`) as facts for the rules engine.
- **Demo create form** — the `pregnancy_status` checkbox now writes the certification date into `pregnancy_due_or_parturition_date`.
- **Batch upload (`UnifiedRecordProcessor`)** — a truthy `pregnancy_status` CSV value records the certification date as the parturition date. The check is case-insensitive and accepts `yes`/`true`. 
Only the pregnancy signal changed — AIAN and veteran-disability exclusions and the priority-ordering mechanism are untouched. The demo, API, and batch upload input fields remain `pregnancy_status`; no documentation was modified.

## Context for reviewers

A member is pregnancy-excluded when the certification date is on or before the end of the 12-month window (`pregnancy_due_or_parturition_date + 12.months`).

The window end is evaluated at **month granularity**: as long as the window reaches the first day of the certification date's month, the exclusion covers that entire month. So a certification date of June 20 is still excluded when the window ends June 5, but a window ending in May does not carry into June.

The input surfaces intentionally stay a `pregnancy_status` boolean (checkbox / CSV column) and translate to the new date field by writing the certification date — this keeps the member/staff-facing inputs unchanged while the exclusion evaluates a date.

For the batch upload, the documentation says use "yes/no", but the sample doc uses "FALSE" for pregnancy status, so I went with as inclusive a definition as possible. This also fixes a latent bug: the previous boolean cast treated `no` as truthy, since `no` is not in ActiveModel's false-values set.


## Testing

Full suite green (2588 examples, 0 failures), `make lint` reports no offenses.

- **`Rules::ExclusionRuleset`** — rewrote `#is_pregnant` coverage: nil guards, currently-expecting, postpartum, exact-12-month boundary, month-granularity (window ends earlier in the same month → excluded; window ends the prior month → not excluded), and lapsed.
- **`ExclusionDeterminationService`** — pregnancy cases updated to the date field, with future-due and postpartum excluded cases plus a lapsed (>12 months) not-excluded case.
- **`UnifiedRecordProcessor`** — new cases confirming `yes`/`YES`/` Yes `/`true`/`TRUE` record the certification date and `no`/`false`/`FALSE`/`""` leave it unset.
- Demo request spec and member-data factory updated for the renamed field.

```
make test   # 2588 examples, 0 failures
make lint   # 541 files inspected, no offenses detected
```
### Manually tested demo
- Pregnancy flag added appropriate member data, case exempt
- Updated pregancy flag for 15 months prior to certification date; had appropriate member data; was not exempt

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->