### PR TITLE
Conform VA disability integration to the verification adapter contract (OSCER-755)

### DIFF
--- a/reporting-app/app/services/verification/adapters/va_disability_rating.rb
+++ b/reporting-app/app/services/verification/adapters/va_disability_rating.rb
@@ -12,9 +12,10 @@ module Verification
     #
     # NOTE: the 100%-rating interpretation duplicated here also still lives in
     # +Rules::ExclusionRuleset#is_veteran_with_disability+. That duplication is
-    # intentional and temporary for this slice — the ruleset copy is removed in
-    # a downstream migration once +ExclusionDeterminationService+ consumes these
-    # outcome symbols directly.
+    # intentional and temporary for this slice — resolved when the #756 data
+    # source registry registers this adapter and a later orchestrator slice
+    # wires +ExclusionDeterminationService+ to consume adapter outcomes (the
+    # ruleset copy is then removed).
     class VaDisabilityRating < Verification::DataSource
       SOURCE = "va_disability_rating"
       OUTCOME_VETERAN_WITH_DISABILITY = :is_veteran_with_disability
@@ -64,6 +65,7 @@ module Verification
         rating_data&.dig("data", "attributes", "combined_disability_rating")
       end
 
+      # +to_i+ coercion intentionally mirrors +Rules::ExclusionRuleset#is_veteran_with_disability+.
       def outcomes_for(combined_rating)
         return [] if combined_rating.nil?
 

--- a/reporting-app/app/services/verification/adapters/va_disability_rating.rb
+++ b/reporting-app/app/services/verification/adapters/va_disability_rating.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Verification
+  module Adapters
+    # VA disability-rating verification data source.
+    #
+    # Wraps the existing VA transport layer (+VeteranAffairsAdapter+ +
+    # +VaTokenManager+) in the {Verification::DataSource} contract: it owns its
+    # ICN precondition, emits a flat outcome symbol, records redacted audit
+    # data, and normalizes transport/token failures into a +:error+ result
+    # instead of returning +nil+ (the previous fail-open behavior).
+    #
+    # NOTE: the 100%-rating interpretation duplicated here also still lives in
+    # +Rules::ExclusionRuleset#is_veteran_with_disability+. That duplication is
+    # intentional and temporary for this slice — the ruleset copy is removed in
+    # a downstream migration once +ExclusionDeterminationService+ consumes these
+    # outcome symbols directly.
+    class VaDisabilityRating < Verification::DataSource
+      SOURCE = "va_disability_rating"
+      OUTCOME_VETERAN_WITH_DISABILITY = :is_veteran_with_disability
+      QUALIFYING_COMBINED_RATING = 100
+
+      def self.declared_outcomes
+        [ OUTCOME_VETERAN_WITH_DISABILITY ]
+      end
+
+      def initialize(adapter: VeteranAffairsAdapter.new, token_manager: VaTokenManager.new)
+        @adapter = adapter
+        @token_manager = token_manager
+      end
+
+      protected
+
+      def precondition_met?(certification)
+        certification.member_data&.va_icn.present?
+      end
+
+      def perform(certification:)
+        access_token = @token_manager.get_access_token(icn: certification.member_data.va_icn)
+        rating_data = @adapter.get_disability_rating(access_token: access_token)
+        combined_rating = extract_combined_rating(rating_data)
+
+        success_result(
+          outcomes: outcomes_for(combined_rating),
+          audit_data: audit_summary(rating_data, combined_rating)
+        )
+      end
+
+      # Transport (auth, 5xx, rate limit — all subclass ApiError) and token
+      # failures are caught by DataSource#call and become a :error result.
+      def expected_error_classes
+        [ VeteranAffairsAdapter::ApiError, VaTokenManager::TokenError ]
+      end
+
+      # Enrich the base error result with the source tag so :error audit_data is
+      # never empty and is attributable to this data source.
+      def error_result(error, audit_data: {})
+        super(error, audit_data: audit_data.merge(source: SOURCE))
+      end
+
+      private
+
+      def extract_combined_rating(rating_data)
+        rating_data&.dig("data", "attributes", "combined_disability_rating")
+      end
+
+      def outcomes_for(combined_rating)
+        return [] if combined_rating.nil?
+
+        combined_rating.to_i == QUALIFYING_COMBINED_RATING ? [ OUTCOME_VETERAN_WITH_DISABILITY ] : []
+      end
+
+      # Redacted summary only — never the full VA payload (which carries
+      # individual diagnostic ratings / PHI).
+      def audit_summary(rating_data, combined_rating)
+        {
+          source: SOURCE,
+          combined_disability_rating: combined_rating,
+          disability_rating_id: rating_data&.dig("data", "id")
+        }
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
   let(:access_token) { "test-token" }
   let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: icn)) }
 
-  def rating_response(combined_rating)
+  let(:rating_response) do
     {
       "data" => {
         "id" => "12303",
@@ -40,11 +40,11 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
 
     before do
       allow(token_manager).to receive(:get_access_token).with(icn: icn).and_return(access_token)
-      allow(adapter).to receive(:get_disability_rating).with(access_token: access_token).and_return(rating_data)
+      allow(adapter).to receive(:get_disability_rating).with(access_token: access_token).and_return(rating_response)
     end
 
     context "when the combined rating is 100 (qualifying)" do
-      let(:rating_data) { rating_response(100) }
+      let(:combined_rating) { 100 }
 
       it_behaves_like "a successful verification result"
 
@@ -63,7 +63,7 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
     end
 
     context "when the combined rating is below 100 (no match)" do
-      let(:rating_data) { rating_response(70) }
+      let(:combined_rating) { 70 }
 
       it_behaves_like "a successful verification result"
 
@@ -77,7 +77,7 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
     end
 
     context "when the VA payload has no combined rating" do
-      let(:rating_data) { { "data" => { "id" => "12303", "attributes" => {} } } }
+      let(:rating_response) { { "data" => { "id" => "12303", "attributes" => {} } } }
 
       it_behaves_like "a successful verification result"
 
@@ -87,7 +87,7 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
     end
 
     context "when the combined rating is a string (coercion parity with ExclusionRuleset)" do
-      let(:rating_data) { rating_response("100") }
+      let(:combined_rating) { "100" }
 
       it_behaves_like "a successful verification result"
 

--- a/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
     it "declares the single VA outcome symbol" do
       expect(described_class.declared_outcomes).to eq([ :is_veteran_with_disability ])
     end
+
+    it "declares outcomes registered in Exclusion.valid_values" do
+      expect(described_class.declared_outcomes.map(&:to_s)).to all(be_in(Exclusion.valid_values))
+    end
   end
 
   describe "#call" do
@@ -81,6 +85,16 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
         expect(result.outcomes).to eq([])
       end
     end
+
+    context "when the combined rating is a string (coercion parity with ExclusionRuleset)" do
+      let(:rating_data) { rating_response("100") }
+
+      it_behaves_like "a successful verification result"
+
+      it "emits :is_veteran_with_disability via to_i coercion" do
+        expect(result.outcomes).to eq([ :is_veteran_with_disability ])
+      end
+    end
   end
 
   describe "#call when the ICN precondition is missing" do
@@ -98,6 +112,22 @@ RSpec.describe Verification::Adapters::VaDisabilityRating do
 
       expect(token_manager).not_to have_received(:get_access_token)
       expect(adapter).not_to have_received(:get_disability_rating)
+    end
+
+    context "when va_icn is a blank string" do
+      let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: "")) }
+
+      it_behaves_like "a skipped verification result"
+
+      it "does not call the token manager or transport adapter" do
+        allow(token_manager).to receive(:get_access_token)
+        allow(adapter).to receive(:get_disability_rating)
+
+        result
+
+        expect(token_manager).not_to have_received(:get_access_token)
+        expect(adapter).not_to have_received(:get_disability_rating)
+      end
     end
   end
 

--- a/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/va_disability_rating_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Verification::Adapters::VaDisabilityRating do
+  let(:adapter) { instance_double(VeteranAffairsAdapter) }
+  let(:token_manager) { instance_double(VaTokenManager) }
+  let(:data_source) { described_class.new(adapter: adapter, token_manager: token_manager) }
+  let(:icn) { "1012861229V078999" }
+  let(:access_token) { "test-token" }
+  let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: icn)) }
+
+  def rating_response(combined_rating)
+    {
+      "data" => {
+        "id" => "12303",
+        "type" => "disability-rating",
+        "attributes" => {
+          "combined_disability_rating" => combined_rating,
+          "individual_ratings" => [
+            { "decision" => "Service Connected", "rating_percentage" => combined_rating }
+          ]
+        }
+      }
+    }
+  end
+
+  describe ".declared_outcomes" do
+    it "declares the single VA outcome symbol" do
+      expect(described_class.declared_outcomes).to eq([ :is_veteran_with_disability ])
+    end
+  end
+
+  describe "#call" do
+    subject(:result) { data_source.call(certification: certification) }
+
+    before do
+      allow(token_manager).to receive(:get_access_token).with(icn: icn).and_return(access_token)
+      allow(adapter).to receive(:get_disability_rating).with(access_token: access_token).and_return(rating_data)
+    end
+
+    context "when the combined rating is 100 (qualifying)" do
+      let(:rating_data) { rating_response(100) }
+
+      it_behaves_like "a successful verification result"
+
+      it "emits :is_veteran_with_disability" do
+        expect(result.outcomes).to eq([ :is_veteran_with_disability ])
+      end
+
+      it "records a redacted audit summary (no full payload)" do
+        expect(result.audit_data).to eq(
+          source: "va_disability_rating",
+          combined_disability_rating: 100,
+          disability_rating_id: "12303"
+        )
+        expect(result.audit_data).not_to have_key(:individual_ratings)
+      end
+    end
+
+    context "when the combined rating is below 100 (no match)" do
+      let(:rating_data) { rating_response(70) }
+
+      it_behaves_like "a successful verification result"
+
+      it "returns success with empty outcomes" do
+        expect(result.outcomes).to eq([])
+      end
+
+      it "still records the observed rating in audit_data" do
+        expect(result.audit_data[:combined_disability_rating]).to eq(70)
+      end
+    end
+
+    context "when the VA payload has no combined rating" do
+      let(:rating_data) { { "data" => { "id" => "12303", "attributes" => {} } } }
+
+      it_behaves_like "a successful verification result"
+
+      it "returns success with empty outcomes" do
+        expect(result.outcomes).to eq([])
+      end
+    end
+  end
+
+  describe "#call when the ICN precondition is missing" do
+    subject(:result) { data_source.call(certification: certification) }
+
+    let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: nil)) }
+
+    it_behaves_like "a skipped verification result"
+
+    it "does not call the token manager or transport adapter" do
+      allow(token_manager).to receive(:get_access_token)
+      allow(adapter).to receive(:get_disability_rating)
+
+      result
+
+      expect(token_manager).not_to have_received(:get_access_token)
+      expect(adapter).not_to have_received(:get_disability_rating)
+    end
+  end
+
+  describe "#call when the transport layer fails" do
+    subject(:result) { data_source.call(certification: certification) }
+
+    context "when the adapter raises an ApiError" do
+      before do
+        allow(token_manager).to receive(:get_access_token).with(icn: icn).and_return(access_token)
+        allow(adapter).to receive(:get_disability_rating)
+          .and_raise(VeteranAffairsAdapter::ApiError.new("VA API server error: 500"))
+      end
+
+      it_behaves_like "an errored verification result"
+      it_behaves_like "a resilient verification data source"
+
+      it "records the error and a source-tagged audit_data" do
+        expect(result.error_code).to eq(:api_error)
+        expect(result.error_message).to eq("VA API server error: 500")
+        expect(result.audit_data).to eq(source: "va_disability_rating")
+      end
+    end
+
+    context "when the token manager raises a TokenError" do
+      before do
+        allow(token_manager).to receive(:get_access_token)
+          .and_raise(VaTokenManager::TokenError.new("Auth failed"))
+        allow(adapter).to receive(:get_disability_rating)
+      end
+
+      it_behaves_like "an errored verification result"
+      it_behaves_like "a resilient verification data source"
+
+      it "does not attempt the disability-rating request" do
+        result
+
+        expect(adapter).not_to have_received(:get_disability_rating)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [OSCER-755](https://github.com/navapbc/oscer/issues/755)

## Changes

- Add `Verification::Adapters::VaDisabilityRating`, the reference implementation of the `Verification::DataSource` contract (#754) for VA disability rating.
- Wraps `VeteranAffairsAdapter` + `VaTokenManager`; implements `#call(certification:)` returning `Verification::DataSourceResult`.
- Blank `va_icn` → `:skipped` (no HTTP); `ApiError` / `TokenError` → `:error` (never `nil`, never raised).
- Emits `:is_veteran_with_disability` when combined rating is 100%; otherwise `:success` with empty outcomes.
- Records redacted `audit_data` (rating %, resource id, source) — not the full VA payload.
- Specs cover qualifying/non-qualifying/nil-rating paths, blank ICN skip, transport/token errors, registry alignment with `Exclusion.valid_values`, and shared contract examples.

## Context for reviewers

- **Adapter-only slice:** This PR does **not** wire the adapter into `ExclusionDeterminationService`. Exclusion determination still uses `VeteranDisabilityService` + `Rules::ExclusionRuleset#is_veteran_with_disability` on `main` — no behavior change to the exclusion flow.
- **Intentional duplication:** The 100%-rating interpretation exists in both this adapter and the ruleset until a later orchestrator slice consumes adapter outcomes; the ruleset copy is removed then.
- **Three config axes:** Exclusion durability ranking lives in `Exclusion` (#758 / #752). **Data source registry** (YAML config, boot validation of declared checks ⊆ `Exclusion.valid_values`) is **#756** — out of scope here; do not expect an initializer or `VerificationDataSourcesLoader` in this PR.
- **Outcome symbol:** `:is_veteran_with_disability` matches ruled exclusion ids on `main` (`ExclusionTypesLoader::DEFAULTS` / ruleset fact names).
- **No priority/stop logic in the adapter** — durability and stop-at-first selection remain in `Exclusion` / `ExclusionDeterminationService`.

## Testing

- From `reporting-app/`:

```bash
make lint
make test args='spec/services/verification/adapters/va_disability_rating_spec.rb'
```

- All examples pass; adapter uses shared `Verification::DataSource` contract examples from #754.

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->