### PR TITLE
OSCER-785: Add mandatory exceptions from exclusions

### DIFF
--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -82,6 +82,14 @@ class Determination < Strata::Determination
     denial_response_not_convincing: "denial_response_not_convincing",
     # External-exception reason codes (see ExceptionDeterminationService). "Excepted" is a
     # distinct outcome from "excluded"/"exempt" — do not conflate the three.
+    #
+    # Mandatory exceptions migrated from the exclusion ruleset carry the exclusion's reason code with
+    # "excluded" replaced by "excepted" (e.g. pregnancy_excluded -> pregnancy_excepted).
+    was_pregnant: "pregnancy_excepted",
+    former_foster_care_excepted: "former_foster_care_excepted",
+    was_caretaker: "caretaker_excepted",
+    was_in_drug_treatment: "drug_treatment_excepted",
+    was_inmate: "inmate_excepted",
     age_was_under_19: "age_under_19_excepted",
     receiving_inpatient_medical_care: "inpatient_medical_care_excepted",
     resides_in_declared_emergency_county: "declared_emergency_county_excepted",

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -86,7 +86,7 @@ class Determination < Strata::Determination
     # Mandatory exceptions migrated from the exclusion ruleset carry the exclusion's reason code with
     # "excluded" replaced by "excepted" (e.g. pregnancy_excluded -> pregnancy_excepted).
     was_pregnant: "pregnancy_excepted",
-    was_former_foster_care: "former_foster_care_excepted",
+    was_former_foster_care: "was_former_foster_care",
     was_caretaker: "caretaker_excepted",
     was_in_drug_treatment: "drug_treatment_excepted",
     was_inmate: "inmate_excepted",

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -86,7 +86,7 @@ class Determination < Strata::Determination
     # Mandatory exceptions migrated from the exclusion ruleset carry the exclusion's reason code with
     # "excluded" replaced by "excepted" (e.g. pregnancy_excluded -> pregnancy_excepted).
     was_pregnant: "pregnancy_excepted",
-    former_foster_care_excepted: "former_foster_care_excepted",
+    was_former_foster_care: "former_foster_care_excepted",
     was_caretaker: "caretaker_excepted",
     was_in_drug_treatment: "drug_treatment_excepted",
     was_inmate: "inmate_excepted",

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -88,7 +88,7 @@ class ExceptionDeterminationService
       earliest_month = certifiable_months.sort.first
       return unless earliest_month < age_cap_date
 
-      Determination::REASON_CODE_MAPPING.fetch(:former_foster_care_excepted)
+      Determination::REASON_CODE_MAPPING.fetch(:was_former_foster_care)
     end
 
     # Migrated from the caretaker exclusion: caretaking an infirm person during a certifiable month

--- a/reporting-app/app/services/exception_determination_service.rb
+++ b/reporting-app/app/services/exception_determination_service.rb
@@ -8,16 +8,26 @@
 class ExceptionDeterminationService
   include Strata::VirtualActor
 
-  # Each symbol names a private check method taking member_data and lookback months and returning its reason code when
-  # the exception applies (and is enabled), or nil otherwise. Add a check by adding its symbol here
-  # and defining the matching method. Order is the evaluation order; the first applicable check wins.
+  # Each symbol names a private (member_data, certifiable_months) check method returning its reason
+  # code, or nil. Order is evaluation order; the first applicable check wins. Mandatory checks run
+  # first and are ungated; optional checks gate on ExternalException.enabled?.
+  #
+  # The mandatory checks migrated from the exclusion ruleset (pregnancy through inmate) except a
+  # member when the corresponding exclusion would have been valid in any certifiable month
+  # (certification_date is not consulted); for those monotonic in time, the earliest certifiable
+  # month suffices (as in age_under_19).
   EXCEPTION_CHECKS = %i[
+    pregnancy
+    former_foster_care
+    caretaker
+    drug_treatment
+    inmate
     age_under_19
+    other_program
     inpatient_medical_care
     declared_emergency_county
     high_unemployment_county
     medical_travel
-    other_program
   ].freeze
 
   class << self
@@ -41,11 +51,8 @@ class ExceptionDeterminationService
 
     private
 
-    # Returns an array holding the reason code for the first exception check that applies (empty when
-    # none apply, which leaves the member not excepted). A member needs only one exception reason, so
-    # checks run lazily and stop at the first success. Each check is a plain method (no rules engine)
-    # that gates itself on ExternalException.enabled?, so a deployment can disable any optional
-    # exception via configuration.
+    # Returns the reason code of the first applicable check (empty means not excepted). Checks run
+    # lazily and stop at the first success, since a member needs only one exception reason.
     def applicable_exception_reason_codes(certification)
       member_data = certification.member_data
       return [] if member_data.nil?
@@ -55,6 +62,76 @@ class ExceptionDeterminationService
 
       reason_code = EXCEPTION_CHECKS.lazy.filter_map { |check| send(check, member_data, certifiable_months) }.first
       reason_code ? [ reason_code ] : []
+    end
+
+    # Migrated from the pregnancy exclusion. The postpartum window (due/parturition date +
+    # POSTPARTUM_EXCLUSION_MONTHS) has no lower bound, so the earliest certifiable month decides.
+    def pregnancy(member_data, certifiable_months)
+      due_or_parturition_date = member_data.pregnancy_due_or_parturition_date
+      return unless due_or_parturition_date
+
+      postpartum_end = due_or_parturition_date + Rules::ExclusionRuleset::POSTPARTUM_EXCLUSION_MONTHS.months
+      earliest_month = certifiable_months.sort.first
+      return unless earliest_month <= postpartum_end
+
+      Determination::REASON_CODE_MAPPING.fetch(:was_pregnant)
+    end
+
+    # Migrated from the former-foster-care exclusion: in foster care and under the age cap
+    # (FORMER_FOSTER_CARE_AGE_CAP) during a certifiable month.
+    def former_foster_care(member_data, certifiable_months)
+      return unless member_data.was_in_foster_care
+      dob = member_data.date_of_birth
+      return unless dob
+
+      age_cap_date = dob + Rules::ExclusionRuleset::FORMER_FOSTER_CARE_AGE_CAP.years
+      earliest_month = certifiable_months.sort.first
+      return unless earliest_month < age_cap_date
+
+      Determination::REASON_CODE_MAPPING.fetch(:former_foster_care_excepted)
+    end
+
+    # Migrated from the caretaker exclusion: caretaking an infirm person during a certifiable month
+    # (month-specific), or caring for a dependent child under CARETAKER_CHILD_AGE_THRESHOLD.
+    def caretaker(member_data, certifiable_months)
+      infirm_months = Array(member_data.dates_caretaking_infirm).compact.map(&:beginning_of_month)
+      caretaking_infirm = (certifiable_months & infirm_months).present?
+
+      threshold = Rules::ExclusionRuleset::CARETAKER_CHILD_AGE_THRESHOLD
+      earliest_month = certifiable_months.sort.first
+      caring_for_child = Array(member_data.dependent_children_birth_dates).compact.any? do |date_of_birth|
+        earliest_month < date_of_birth + threshold.years
+      end
+
+      return unless caretaking_infirm || caring_for_child
+
+      Determination::REASON_CODE_MAPPING.fetch(:was_caretaker)
+    end
+
+    # Migrated from the drug-treatment exclusion: in a drug/alcohol treatment program during a
+    # certifiable month (month intersection).
+    def drug_treatment(member_data, certifiable_months)
+      return unless member_data.dates_in_drug_treatment.present?
+
+      treatment_months = member_data.dates_in_drug_treatment.compact.map(&:beginning_of_month)
+      return unless (certifiable_months & treatment_months).present?
+
+      Determination::REASON_CODE_MAPPING.fetch(:was_in_drug_treatment)
+    end
+
+    # Migrated from the inmate exclusion: each incarceration opens a bounded window [incarceration
+    # month, +INMATE_BUFFER_MONTHS], so every certifiable month is tested against every window.
+    def inmate(member_data, certifiable_months)
+      return unless member_data.dates_incarcerated.present?
+
+      buffer = Rules::ExclusionRuleset::INMATE_BUFFER_MONTHS
+      incarceration_starts = member_data.dates_incarcerated.compact.map(&:beginning_of_month)
+      excepted = certifiable_months.any? do |month|
+        incarceration_starts.any? { |start| start <= month && month <= start + buffer.months }
+      end
+      return unless excepted
+
+      Determination::REASON_CODE_MAPPING.fetch(:was_inmate)
     end
 
     # @return [String, nil] the reason code when the member was less than 19 in lookback period,

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe Determination, type: :model do
           veteran_disability_excluded
           denial_response_convincing
           denial_response_not_convincing
+          pregnancy_excepted
+          former_foster_care_excepted
+          caretaker_excepted
+          drug_treatment_excepted
+          inmate_excepted
           age_under_19_excepted
           inpatient_medical_care_excepted
           declared_emergency_county_excepted

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Determination, type: :model do
           denial_response_convincing
           denial_response_not_convincing
           pregnancy_excepted
-          former_foster_care_excepted
+          was_former_foster_care
           caretaker_excepted
           drug_treatment_excepted
           inmate_excepted

--- a/reporting-app/spec/services/exception_determination_service_spec.rb
+++ b/reporting-app/spec/services/exception_determination_service_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe ExceptionDeterminationService do
         let(:was_in_foster_care) { true }
         let(:date_of_birth) { cert_date - (25.years + 2.months) } # ~25 -> under 26
 
-        it_behaves_like 'an applied external exception', 'former_foster_care_excepted'
+        it_behaves_like 'an applied external exception', 'was_former_foster_care'
       end
 
       context 'when a former foster youth is at/over the age cap in every certifiable month' do
@@ -218,7 +218,7 @@ RSpec.describe ExceptionDeterminationService do
         # 26th birthday is the 16th of the earliest certifiable month; still under 26 at its start
         let(:date_of_birth) { cert_date - 26.years - 3.months + 15.days }
 
-        it_behaves_like 'an applied external exception', 'former_foster_care_excepted'
+        it_behaves_like 'an applied external exception', 'was_former_foster_care'
       end
 
       context 'when a former foster youth turns 26 on the first of the earliest certifiable month' do

--- a/reporting-app/spec/services/exception_determination_service_spec.rb
+++ b/reporting-app/spec/services/exception_determination_service_spec.rb
@@ -162,6 +162,179 @@ RSpec.describe ExceptionDeterminationService do
       end
     end
 
+    describe 'checking pregnancy' do
+      let(:member_data) { build(:certification_member_data, cert_date:, pregnancy_due_or_parturition_date:) }
+
+      context 'when the postpartum window covers a certifiable month' do
+        # postpartum window ends cert_date - 1.month, inside the certifiable window
+        let(:pregnancy_due_or_parturition_date) { cert_date - 13.months }
+
+        it_behaves_like 'an applied external exception', 'pregnancy_excepted'
+      end
+
+      context 'when within the postpartum window but it extends past the certifiable window' do
+        # gave birth cert_date - 1.month, so the postpartum window ends ~11 months after cert_date
+        # (past every certifiable month), yet the member was within it during each certifiable month.
+        # A currently-pregnant/postpartum member would normally qualify as an exemption and not reach
+        # the exception check; this covers it defensively.
+        let(:pregnancy_due_or_parturition_date) { cert_date - 1.month }
+
+        it_behaves_like 'an applied external exception', 'pregnancy_excepted'
+      end
+
+      context 'when the postpartum window ended before every certifiable month' do
+        # postpartum window ends cert_date - 4.months, before the earliest certifiable month
+        let(:pregnancy_due_or_parturition_date) { cert_date - 16.months }
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when there is no pregnancy/parturition date' do
+        let(:pregnancy_due_or_parturition_date) { nil }
+
+        it_behaves_like 'a failed check'
+      end
+    end
+
+    describe 'checking former foster care' do
+      let(:member_data) { build(:certification_member_data, cert_date:, was_in_foster_care:, date_of_birth:) }
+
+      context 'when a former foster youth is under the age cap during a certifiable month' do
+        let(:was_in_foster_care) { true }
+        let(:date_of_birth) { cert_date - (25.years + 2.months) } # ~25 -> under 26
+
+        it_behaves_like 'an applied external exception', 'former_foster_care_excepted'
+      end
+
+      context 'when a former foster youth is at/over the age cap in every certifiable month' do
+        let(:was_in_foster_care) { true }
+        let(:date_of_birth) { cert_date - 27.years } # 27 -> over 26 throughout
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when a former foster youth turns 26 mid-way through the earliest certifiable month' do
+        let(:was_in_foster_care) { true }
+        # 26th birthday is the 16th of the earliest certifiable month; still under 26 at its start
+        let(:date_of_birth) { cert_date - 26.years - 3.months + 15.days }
+
+        it_behaves_like 'an applied external exception', 'former_foster_care_excepted'
+      end
+
+      context 'when a former foster youth turns 26 on the first of the earliest certifiable month' do
+        let(:was_in_foster_care) { true }
+        # 26th birthday is the 1st of the earliest certifiable month; already 26 at its start
+        let(:date_of_birth) { cert_date - 26.years - 3.months }
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when the member was not in foster care' do
+        let(:was_in_foster_care) { false }
+        let(:date_of_birth) { cert_date - (25.years + 2.months) }
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when there is no date of birth' do
+        let(:was_in_foster_care) { true }
+        let(:date_of_birth) { nil }
+
+        it_behaves_like 'a failed check'
+      end
+    end
+
+    describe 'checking caretaker' do
+      let(:member_data) do
+        build(:certification_member_data, cert_date:, dates_caretaking_infirm:, dependent_children_birth_dates:)
+      end
+      let(:dates_caretaking_infirm) { [] }
+      let(:dependent_children_birth_dates) { [] }
+
+      context 'when caretaking an infirm person during a certifiable month' do
+        let(:dates_caretaking_infirm) { [ cert_date - 2.months ] }
+
+        it_behaves_like 'an applied external exception', 'caretaker_excepted'
+      end
+
+      context 'when caretaking an infirm person only outside the certifiable months' do
+        let(:dates_caretaking_infirm) { [ cert_date - 6.months ] }
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when caring for a dependent child under the age threshold' do
+        let(:dependent_children_birth_dates) { [ cert_date - 10.years ] } # age 10 < 14
+
+        it_behaves_like 'an applied external exception', 'caretaker_excepted'
+      end
+
+      context 'when caring for both an under-threshold and an over-threshold child' do
+        let(:dependent_children_birth_dates) { [ cert_date - 15.years, cert_date - 10.years ] } # 15yo + 10yo
+
+        it_behaves_like 'an applied external exception', 'caretaker_excepted'
+      end
+
+      context 'when the dependent child is at/over the age threshold throughout' do
+        let(:dependent_children_birth_dates) { [ cert_date - 15.years ] } # turned 14 before the window
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when there is no caretaking data' do
+        it_behaves_like 'a failed check'
+      end
+    end
+
+    describe 'checking drug treatment' do
+      let(:event_date) { [ cert_date - 2.months - 2.days ] }
+      let(:member_data) { build(:certification_member_data, cert_date:, dates_in_drug_treatment: event_date) }
+
+      it_behaves_like 'a mandatory exception', :drug_treatment
+
+      context 'with invalid data' do
+        let(:event_date) { [ 'not a date' ] }
+
+        it_behaves_like 'a failed check'
+      end
+    end
+
+    describe 'checking inmate' do
+      let(:member_data) { build(:certification_member_data, cert_date:, dates_incarcerated:) }
+
+      context 'when incarcerated during a certifiable month' do
+        let(:dates_incarcerated) { [ cert_date - 2.months ] } # window covers that month directly
+
+        it_behaves_like 'an applied external exception', 'inmate_excepted'
+      end
+
+      context 'when incarcerated before the window but the buffer reaches into a certifiable month' do
+        # incarcerated cert_date - 5.months; +3-month buffer still covers certifiable months
+        let(:dates_incarcerated) { [ cert_date - 5.months ] }
+
+        it_behaves_like 'an applied external exception', 'inmate_excepted'
+      end
+
+      context 'when one incarceration window covers a certifiable month and another does not' do
+        # cert_date - 8.months has expired (invalid); cert_date - 2.months is in-window (valid)
+        let(:dates_incarcerated) { [ cert_date - 8.months, cert_date - 2.months ] }
+
+        it_behaves_like 'an applied external exception', 'inmate_excepted'
+      end
+
+      context 'when the incarceration window (incl. buffer) ended before every certifiable month' do
+        let(:dates_incarcerated) { [ cert_date - 8.months ] } # window ends ~cert_date - 5.months
+
+        it_behaves_like 'a failed check'
+      end
+
+      context 'when there is no incarceration data' do
+        let(:dates_incarcerated) { [] }
+
+        it_behaves_like 'a failed check'
+      end
+    end
+
     describe 'checking inpatient-medical-care' do
       it_behaves_like 'an optional exception', :dates_receiving_inpatient_medical_care, :inpatient_medical_care
     end


### PR DESCRIPTION
## Ticket

Resolves #785

## Changes

- `ExceptionDeterminationService`: added 5 mandatory exception checks migrated from the exclusion ruleset (pregnancy, former foster care, caretaker, drug treatment, inmate), and reordered the checks so all mandatory checks run before the optional ones.
- `Determination`: added the 5 corresponding `*_excepted` reason codes.
- Added spec coverage for the new checks and updated the `VALID_REASONS` guard.

## Context for reviewers

A member is excepted whenever the corresponding exclusion would have been valid in any certifiable month. For checks that are monotonic in time — an age or window that only closes as months pass — it is enough to test the earliest certifiable month, as `age_under_19` already does. `inmate` is the one exception: its window is bounded on both ends, so every certifiable month is tested against every incarceration window. Each check reuses the `Rules::ExclusionRuleset` constants so the exclusion and exception sides stay in sync.

Four exclusion checks were deliberately not migrated: American Indian / Alaska Native, veteran with disability, medically frail, and TANF/SNAP work. This may change based on API changes.

## Testing

`make lint test` passes (2869 examples, 0 failures; line coverage 96.56%, branch coverage 83.84%).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->