### PR TITLE
Re-enable docai

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -37,8 +37,6 @@ export default defineConfig({
     screenshot: 'on',
     video: 'on-first-retry',
   },
-  // TODO: stop ignoring this test when DOC_AI Feature flag back on
-  testIgnore: '**/docAiUploadFlow.spec.ts',
   // Splits tests into chunks for distributed parallel execution
   shard: {
     // Total number of shards

--- a/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
@@ -18,8 +18,7 @@ export class BeforeYouStartPage extends BasePage {
 
   async clickStart() {
     // Skip DocAI for original document upload flow
-    // TODO: re-enable this action when DOC_AI Feature flag back on
-    // await this.skipAiCheckbox.check();
+    await this.skipAiCheckbox.check();
     await this.startButton.click();
 
     return new ChooseMonthsPage(this.page).waitForURLtoMatchPagePath();

--- a/infra/reporting-app/app-config/dev.tf
+++ b/infra/reporting-app/app-config/dev.tf
@@ -37,7 +37,7 @@ module "dev_config" {
     ENABLE_LOOKBOOK             = "true"
     FEATURE_BATCH_UPLOAD_V2     = "true"
     PERFORM_EMAIL_DELIVERY      = "false"
-    FEATURE_DOC_AI              = "false"
+    FEATURE_DOC_AI              = "true"
     FEATURE_DEMO_CERTIFICATIONS = "true"
   }
 }

--- a/infra/reporting-app/app-config/env-config/environment_variables.tf
+++ b/infra/reporting-app/app-config/env-config/environment_variables.tf
@@ -64,5 +64,9 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}-${var.environment}/service/doc-ai-api-host"
     }
+    DOC_AI_API_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}-${var.environment}/service/doc-ai-api-key"
+    }
   }
 }

--- a/infra/reporting-app/app-config/sandbox.tf
+++ b/infra/reporting-app/app-config/sandbox.tf
@@ -26,6 +26,6 @@ module "sandbox_config" {
     ENABLE_LOOKBOOK         = "true"
     SSO_ENABLED             = "true"
     FEATURE_BATCH_UPLOAD_V2 = "true"
-    FEATURE_DOC_AI          = "false"
+    FEATURE_DOC_AI          = "true"
   }
 }


### PR DESCRIPTION
## Ticket

Resolves #610

## Changes

- PR #597 reverted
- DOC AI API KEY added to secrets (manually transfered)

## Context for reviewers

We disabled DOC API in PR #597, and we are putting it back.
Parameter Store values added/updated manually.

## Testing

Successfully used Doc AI on:

https://p-788-reporting-app-dev-362437505.us-east-1.elb.amazonaws.com/

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->