### PR TITLE
OSCER-790: Set document ai form data on failed update

### DIFF
--- a/reporting-app/app/controllers/activities_controller.rb
+++ b/reporting-app/app/controllers/activities_controller.rb
@@ -34,10 +34,7 @@ class ActivitiesController < ApplicationController
   # GET /activities/1/edit
   def edit
     authorize @activity_report_application_form, :edit?
-    if @doc_ai_review
-      @pending_review_ids = Array(params[:pending_review_ids])
-      @staged_document = StagedDocument.find_by(stageable: @activity)
-    end
+    set_doc_ai_review_form_data if @doc_ai_review
   end
 
   # GET /activities/1/documents
@@ -125,6 +122,7 @@ class ActivitiesController < ApplicationController
         end
         format.json { render :show, status: :ok, location: @activity.becomes(Activity) }
       else
+        set_doc_ai_review_form_data if @doc_ai_review
         format.html { render :edit, status: :unprocessable_content }
         format.json { render json: @activity.errors, status: :unprocessable_content }
       end
@@ -192,5 +190,12 @@ class ActivitiesController < ApplicationController
 
     def set_doc_ai_review
       @doc_ai_review = ActiveModel::Type::Boolean.new.cast(params[:doc_ai_review])
+    end
+
+    # Instance variables the doc-ai review page (edit view) needs. Set on GET edit
+    # and again when update fails validation and re-renders edit.
+    def set_doc_ai_review_form_data
+      @pending_review_ids = Array(params[:pending_review_ids])
+      @staged_document = StagedDocument.find_by(stageable: @activity)
     end
 end

--- a/reporting-app/app/views/activities/_form.html.erb
+++ b/reporting-app/app/views/activities/_form.html.erb
@@ -1,5 +1,5 @@
 <% doc_ai_review = local_assigns.fetch(:doc_ai_review, false) %>
-<% pending_review_ids = local_assigns.fetch(:pending_review_ids, []) %>
+<% pending_review_ids = Array(local_assigns[:pending_review_ids]) %>
 
 <% unless doc_ai_review %>
   <h1>

--- a/reporting-app/spec/requests/activities_spec.rb
+++ b/reporting-app/spec/requests/activities_spec.rb
@@ -181,6 +181,29 @@ RSpec.describe "/activities", type: :request do
         end
       end
 
+      context "without a name" do
+        let(:invalid_attributes) {
+          {
+            name: "",
+            activity_type: "income_activity",
+            income: "1500",
+            month: (Date.today - 2.months).beginning_of_month,
+            category: "employment"
+          }
+        }
+
+        it "does not persist a new Activity" do
+          expect {
+            post activity_report_application_form_activities_url(activity_report_application_form), params: { activity: invalid_attributes }
+          }.not_to change(IncomeActivity, :count)
+        end
+
+        it "renders a response with 422 status (unprocessable entity)" do
+          post activity_report_application_form_activities_url(activity_report_application_form), params: { activity: invalid_attributes }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
       context "with valid activity parameters" do
         it "creates a new IncomeActivity when activity_type is income_activity" do
           valid_attributes = {
@@ -414,6 +437,33 @@ RSpec.describe "/activities", type: :request do
 
         income_activity.reload
         expect(income_activity.evidence_source).to eq("ai_assisted_with_member_edits")
+      end
+    end
+
+    context "with a blank organization name" do
+      it "re-renders the review page with a 422 instead of raising" do
+        patch activity_report_application_form_activity_url(activity_report_application_form, income_activity),
+          params: {
+            activity: { name: "", income: "1500", month: Date.new(2025, 1, 1) },
+            doc_ai_review: "true",
+            pending_review_ids: [ second_activity.id ]
+          }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Name can&#39;t be blank")
+      end
+
+      it "does not overwrite the existing name with a blank value" do
+        income_activity.update_column(:name, "Acme Corp")
+
+        patch activity_report_application_form_activity_url(activity_report_application_form, income_activity),
+          params: {
+            activity: { name: "", income: "1500", month: Date.new(2025, 1, 1) },
+            doc_ai_review: "true"
+          }
+
+        income_activity.reload
+        expect(income_activity.name).to eq("Acme Corp")
       end
     end
 


### PR DESCRIPTION
## Ticket

Resolves #790

## Changes

- helper method in ActivitiesController to set appropriate form data for doc ai on failure to save
- Array(locals) added to _form for extra safety

## Context for reviewers

Document AI does not set the employer's name, and if a member submitted the form without entering the employer's name, the server would 500 because the form tried to iterate on a nil value.

## Testing

Added tests

Manually tested

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->