### PR TITLE
OSCER-747: Client-facing performance baseline tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ e2e-test: e2e-build
 		-e CI=$(CI) \
 		-v $(CURDIR)/e2e/playwright-report:/e2e/playwright-report \
 		-v $(CURDIR)/e2e/blob-report:/e2e/blob-report \
+		-v $(CURDIR)/e2e/perf-results:/e2e/perf-results \
 		$(E2E_IMAGE_NAME) \
 		npm test -- $(E2E_ARGS)
 	@echo "Run 'make e2e-show-report' to view the test report"

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ e2e-test: e2e-build
 		-e CURRENT_SHARD=$(CURRENT_SHARD) \
 		-e TOTAL_SHARDS=$(TOTAL_SHARDS) \
 		-e CI=$(CI) \
+		-e PERF=$(PERF) \
+		-e PERF_PROFILES=$(PERF_PROFILES) \
+		-e PERF_OUT_DIR=$(PERF_OUT_DIR) \
+		-e PERF_ENFORCE_BUDGET=$(PERF_ENFORCE_BUDGET) \
 		-v $(CURDIR)/e2e/playwright-report:/e2e/playwright-report \
 		-v $(CURDIR)/e2e/blob-report:/e2e/blob-report \
 		-v $(CURDIR)/e2e/perf-results:/e2e/perf-results \
@@ -147,7 +151,17 @@ e2e-test: e2e-build
 e2e-test-native: ## Run end-to-end tests natively
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@echo "Running e2e tests with CI=${CI}, APP_NAME=${APP_NAME}, BASE_URL=${BASE_URL}"
-	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npm test -- $(E2E_ARGS)
+	cd e2e && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=$(PERF) PERF_PROFILES="$(PERF_PROFILES)" PERF_OUT_DIR="$(PERF_OUT_DIR)" PERF_ENFORCE_BUDGET=$(PERF_ENFORCE_BUDGET) npm test -- $(E2E_ARGS)
+
+e2e-perf-baseline: ## Capture client-facing perf baselines (opt-in; writes e2e/perf-results/)
+	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
+	$(MAKE) e2e-test-native APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=1 \
+		E2E_ARGS='reporting-app/tests/performanceBaseline.spec.ts --project=chromium'
+
+e2e-perf-lighthouse: ## Run Lighthouse audits (opt-in reports; set PERF_ENFORCE_BUDGET=1 to fail on budgets)
+	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
+	$(MAKE) e2e-test-native APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=1 \
+		E2E_ARGS='reporting-app/tests/lighthouseBudget.spec.ts --project=chromium --workers=1'
 
 e2e-test-native-ui: ## Run end-to-end tests natively in UI mode
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,16 @@ e2e-perf-baseline: ## Capture client-facing perf baselines (opt-in; writes e2e/p
 	$(MAKE) e2e-test-native APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=1 \
 		E2E_ARGS='reporting-app/tests/performanceBaseline.spec.ts --project=chromium'
 
+e2e-perf-baseline-flow: ## LONG-RUNNING opt-in flow baselines (NOT for CI; tens of min–1h+)
+	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
+	@echo ""
+	@echo "WARNING: e2e-perf-baseline-flow is opt-in and NOT run in CI."
+	@echo "         Full Slow/Fast/Unthrottled sweeps can take tens of minutes to 1+ hour."
+	@echo "         Tip: PERF_PROFILES=\"Slow 3G\" for a shorter run."
+	@echo ""
+	$(MAKE) e2e-test-native APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=1 \
+		E2E_ARGS='reporting-app/tests/performanceBaselineFlow.spec.ts --project=chromium --workers=1'
+
 e2e-perf-lighthouse: ## Run Lighthouse audits (opt-in reports; set PERF_ENFORCE_BUDGET=1 to fail on budgets)
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	$(MAKE) e2e-test-native APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) PERF=1 \

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -78,6 +78,45 @@ make e2e-test-native APP_NAME=reporting-app \
   E2E_ARGS=reporting-app/tests/exemptionApplication.spec.ts
 ```
 
+### Performance baselines (frontier / low-bandwidth)
+
+Client-facing performance harnesses for [OSCER-747](https://github.com/navapbc/oscer/issues/747) live under `e2e/reporting-app/perf/` and two opt-in specs:
+
+| Spec | Purpose |
+| --- | --- |
+| `performanceBaseline.spec.ts` (Track A) | CDP throttling (DevTools Slow/Fast 3G), writes `e2e/perf-results/perf-baseline.json` + `.md` |
+| `lighthouseBudget.spec.ts` (Track B) | Lighthouse over CDP; writes reports under `e2e/perf-results/lighthouse/` |
+
+These specs are **excluded from the default e2e suite and CI** unless `PERF=1`. Run them explicitly (app must be up; same Cognito prerequisites as other member tests):
+
+```bash
+# Track A — capture baselines (chromium only)
+make e2e-perf-baseline APP_NAME=reporting-app
+
+# Optional: subset of profiles / output dir
+PERF_PROFILES="Slow 3G" make e2e-perf-baseline APP_NAME=reporting-app
+
+# Track B — Lighthouse reports (chromium, workers=1 for fixed CDP port 9222)
+make e2e-perf-lighthouse APP_NAME=reporting-app
+
+# After baselines are calibrated, enforce budget.json + score floors:
+PERF_ENFORCE_BUDGET=1 make e2e-perf-lighthouse APP_NAME=reporting-app
+```
+
+Equivalent with Docker (also mounts `e2e/perf-results/`):
+
+```bash
+make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 PERF=1 \
+  E2E_ARGS='reporting-app/tests/performanceBaseline.spec.ts --project=chromium'
+```
+
+**Notes**
+
+- Track A uses CDP `Network.emulateNetworkConditions` with Chrome DevTools Slow/Fast 3G constants.
+- Track B uses Lighthouse `throttlingMethod: 'simulate'` with settings *derived from* Slow 3G. Simulated timings are **not** 1:1 comparable to Track A / DevTools.
+- Default Track B is capture-first (reports only). `PERF_ENFORCE_BUDGET=1` turns on `lighthouse/budget.json` and category thresholds.
+- Env vars: `PERF`, `PERF_PROFILES`, `PERF_OUT_DIR`, `PERF_ENFORCE_BUDGET`.
+
 ### Run tests in UI mode (native)
 
 ```bash

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -80,21 +80,28 @@ make e2e-test-native APP_NAME=reporting-app \
 
 ### Performance baselines (frontier / low-bandwidth)
 
-Client-facing performance harnesses for [OSCER-747](https://github.com/navapbc/oscer/issues/747) live under `e2e/reporting-app/perf/` and two opt-in specs:
+Client-facing performance harnesses for [OSCER-747](https://github.com/navapbc/oscer/issues/747) live under `e2e/reporting-app/perf/` and these opt-in specs:
 
 | Spec | Purpose |
 | --- | --- |
 | `performanceBaseline.spec.ts` (Track A) | CDP throttling (DevTools Slow/Fast 3G), writes `e2e/perf-results/perf-baseline.json` + `.md` |
+| `performanceBaselineFlow.spec.ts` | Multi-step flows under the same profiles: (1) all-No screener → 2 hours + income with supporting docs; (2) medical exemption Yes + upload. Writes `perf-baseline-flow-*.json/.md`. **Very slow** (tens of minutes–1h+ for all profiles). |
 | `lighthouseBudget.spec.ts` (Track B) | Lighthouse over CDP; writes reports under `e2e/perf-results/lighthouse/` |
 
-These specs are **excluded from the default e2e suite and CI** unless `PERF=1`. Run them explicitly (app must be up; same Cognito prerequisites as other member tests):
+These specs are **excluded from the default e2e suite and CI** unless `PERF=1`. The GitHub Actions e2e workflow does **not** set `PERF`, so they never run in CI. Run them **locally only** (app must be up; same Cognito prerequisites as other member tests):
 
 ```bash
-# Track A — capture baselines (chromium only)
+# Track A — capture page baselines (chromium only; minutes, not hours)
 make e2e-perf-baseline APP_NAME=reporting-app
 
 # Optional: subset of profiles / output dir
 PERF_PROFILES="Slow 3G" make e2e-perf-baseline APP_NAME=reporting-app
+
+# Multi-step flows — LONG-RUNNING; prefer one profile first
+# WARNING: all three profiles can take tens of minutes to 1+ hour. Not for CI.
+# Make forces --workers=1; each profile clears cookies before creating a new member.
+PERF_PROFILES="Slow 3G" make e2e-perf-baseline-flow APP_NAME=reporting-app
+make e2e-perf-baseline-flow APP_NAME=reporting-app
 
 # Track B — Lighthouse reports (chromium, workers=1 for fixed CDP port 9222)
 make e2e-perf-lighthouse APP_NAME=reporting-app
@@ -113,9 +120,12 @@ make e2e-test APP_NAME=reporting-app BASE_URL=http://host.docker.internal:3000 P
 **Notes**
 
 - Track A uses CDP `Network.emulateNetworkConditions` with Chrome DevTools Slow/Fast 3G constants.
+- Flow baselines sum per-step wall-clock (`stepDurationMs`) for multi-step member walks; prefer `PERF_PROFILES="Slow 3G"` first. Results are gitignored under `e2e/perf-results/`—copy elsewhere to retain.
 - Track B uses Lighthouse `throttlingMethod: 'simulate'` with settings *derived from* Slow 3G. Simulated timings are **not** 1:1 comparable to Track A / DevTools.
 - Default Track B is capture-first (reports only). `PERF_ENFORCE_BUDGET=1` turns on `lighthouse/budget.json` and category thresholds.
 - Env vars: `PERF`, `PERF_PROFILES`, `PERF_OUT_DIR`, `PERF_ENFORCE_BUDGET`.
+
+**Example local capture (illustrative; re-run for current numbers):** On Slow 3G, Track A cold FCP was ~7.5–10s on ~400 KB pages; the activities flow summed to ~7.7 minutes of measured steps and the medical exemption flow ~2.5 minutes (small fixture uploads ~20–23s).
 
 ### Run tests in UI mode (native)
 

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 /test-results/
 /playwright-report/
 /blob-report/
+/perf-results/
 /playwright/.cache/
 *.png*
 .prettier-cache

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -11,6 +11,8 @@
         "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@types/node": "^26.1.1",
+        "lighthouse": "^12.8.2",
+        "playwright-lighthouse": "^4.0.0",
         "prettier": "^3.9.6",
         "typescript": "^7.0.2"
       }
@@ -26,6 +28,646 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.59.tgz",
+      "integrity": "sha512-439NUzQGmH+9Y017/xCchBP9571J4bzhpcNhrxorf7r37wcyJZkgUfrUsRL3xl+JDcZ6ORhoFCzCw98c6S3YHw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
       }
     },
     "node_modules/@playwright/test": {
@@ -44,6 +686,169 @@
         "node": ">=18"
       }
     },
+    "node_modules/@prisma/instrumentation": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
+      "integrity": "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@prisma/instrumentation": "6.11.1",
+        "@sentry/core": "9.47.1",
+        "@sentry/node-core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1",
+        "@sentry/opentelemetry": "9.47.1",
+        "import-in-the-middle": "^1.14.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "9.47.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.47.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -52,6 +857,56 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -394,6 +1249,99 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
@@ -403,6 +1351,519 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+      "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1507524",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
+      "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -417,6 +1878,510 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.4.tgz",
+      "integrity": "sha512-xT3GPW6/ZbGuw4UvwHqErSCEjNUlwbQJuZn9/q5U4WEKfp2kENVCAlousG1zLxHeaQ/ffOHUNpWamvkbBW0eNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.8.2.tgz",
+      "integrity": "sha512-+5SKYzVaTFj22MgoYDPNrP9tlD2/Ay7j3SxPSFD9FpPyVxGr4UtOQGKyrdZ7wCmcnBaFk0mCkPfARU3CsE0nvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.59",
+        "@sentry/node": "^9.28.1",
+        "axe-core": "^4.10.3",
+        "chrome-launcher": "^1.2.0",
+        "configstore": "^7.0.0",
+        "csp_evaluator": "1.1.5",
+        "devtools-protocol": "0.0.1507524",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.2",
+        "lighthouse-stack-packs": "1.12.2",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "metaviewport-parser": "0.3.0",
+        "open": "^8.4.0",
+        "parse-cache-control": "1.0.1",
+        "puppeteer-core": "^24.17.1",
+        "robots-parser": "^3.0.1",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.27.0",
+        "tldts-icann": "^7.0.12",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=18.16"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.2.tgz",
+      "integrity": "sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/metaviewport-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/playwright": {
@@ -451,6 +2416,72 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright-lighthouse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/playwright-lighthouse/-/playwright-lighthouse-4.0.0.tgz",
+      "integrity": "sha512-8sLhKLYD9k08UjKMSPzYBCZZ6Ct+wZPUe+K58hZEHIdyyXHg+jniWgd+C2W57B+MDstHiYSbyBiN9S8mzUH82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "ua-parser-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=16.x"
+      },
+      "peerDependencies": {
+        "lighthouse": ">= 10.0.0",
+        "playwright-core": "^1.19.2"
+      },
+      "peerDependenciesMeta": {
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.9.6",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -466,6 +2497,428 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/third-party-web": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
+      "integrity": "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.9.tgz",
+      "integrity": "sha512-q6gyxCkcFPu5OZd2hi2quysxCG3ejIi53EACesbCEZHhH7FO3HnliqwO5zUs0TV6dA54SxhCrTGAc4ugl7rTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -502,12 +2955,183 @@
         "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,8 @@
     "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@types/node": "^26.1.1",
+    "lighthouse": "^12.8.2",
+    "playwright-lighthouse": "^4.0.0",
     "prettier": "^3.9.6",
     "typescript": "^7.0.2"
   }

--- a/e2e/reporting-app/lighthouse/budget.json
+++ b/e2e/reporting-app/lighthouse/budget.json
@@ -1,0 +1,23 @@
+[
+  {
+    "path": "/*",
+    "resourceSizes": [
+      { "resourceType": "total", "budget": 600 },
+      { "resourceType": "script", "budget": 200 },
+      { "resourceType": "stylesheet", "budget": 120 },
+      { "resourceType": "image", "budget": 150 },
+      { "resourceType": "font", "budget": 120 },
+      { "resourceType": "document", "budget": 60 }
+    ],
+    "resourceCounts": [
+      { "resourceType": "total", "budget": 45 },
+      { "resourceType": "third-party", "budget": 5 }
+    ],
+    "timings": [
+      { "metric": "first-contentful-paint", "budget": 3000 },
+      { "metric": "largest-contentful-paint", "budget": 4000 },
+      { "metric": "interactive", "budget": 5000 },
+      { "metric": "total-blocking-time", "budget": 600 }
+    ]
+  }
+]

--- a/e2e/reporting-app/pages/members/activity-reports/ActivityDetailsPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/ActivityDetailsPage.ts
@@ -10,6 +10,7 @@ export class ActivityDetailsPage extends BasePage {
 
   readonly employerNameField: Locator;
   readonly hoursField: Locator;
+  readonly incomeField: Locator;
   readonly monthField: Locator;
   readonly submitButton: Locator;
 
@@ -17,6 +18,7 @@ export class ActivityDetailsPage extends BasePage {
     super(page);
     this.employerNameField = page.getByLabel('Organization name');
     this.hoursField = page.getByLabel('Hours');
+    this.incomeField = page.getByLabel('Income (in dollars)');
     this.monthField = page.getByLabel('Month');
     this.submitButton = page.getByRole('button', { name: /save and continue/i });
   }
@@ -25,6 +27,14 @@ export class ActivityDetailsPage extends BasePage {
     await this.employerNameField.fill(employerName);
     await this.monthField.selectOption({ index: 1 });
     await this.hoursField.fill(hours);
+    await this.submitButton.click();
+    return new SupportingDocumentsPage(this.page).waitForURLtoMatchPagePath();
+  }
+
+  async fillIncomeActivityDetails(employerName: string, incomeDollars: string) {
+    await this.employerNameField.fill(employerName);
+    await this.monthField.selectOption({ index: 1 });
+    await this.incomeField.fill(incomeDollars);
     await this.submitButton.click();
     return new SupportingDocumentsPage(this.page).waitForURLtoMatchPagePath();
   }

--- a/e2e/reporting-app/pages/members/activity-reports/ActivityTypePage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/ActivityTypePage.ts
@@ -26,9 +26,20 @@ export class ActivityTypePage extends BasePage {
   }
 
   async fillActivityType() {
+    return this.fillHoursEducationActivityType();
+  }
+
+  async fillHoursEducationActivityType() {
     // Have to use dispatchEvent here due to radio button being hidden by CSS custom styling
     await this.educationRadioButton.dispatchEvent('click');
     await this.hoursRadioButton.dispatchEvent('click');
+    await this.submitButton.click();
+    return new ActivityDetailsPage(this.page).waitForURLtoMatchPagePath();
+  }
+
+  async fillIncomeEmploymentActivityType() {
+    await this.employmentRadioButton.dispatchEvent('click');
+    await this.incomeRadioButton.dispatchEvent('click');
     await this.submitButton.click();
     return new ActivityDetailsPage(this.page).waitForURLtoMatchPagePath();
   }

--- a/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
@@ -17,8 +17,12 @@ export class BeforeYouStartPage extends BasePage {
   }
 
   async clickStart() {
-    // Skip DocAI for original document upload flow
-    await this.skipAiCheckbox.check();
+    // Skip DocAI when the checkbox is present (FEATURE_DOC_AI); otherwise Start goes
+    // straight to the classic months / supporting-documents path.
+    const skipInput = this.page.locator('.usa-checkbox__input');
+    if ((await skipInput.count()) > 0) {
+      await skipInput.check();
+    }
     await this.startButton.click();
 
     return new ChooseMonthsPage(this.page).waitForURLtoMatchPagePath();

--- a/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/BeforeYouStartPage.ts
@@ -19,9 +19,10 @@ export class BeforeYouStartPage extends BasePage {
   async clickStart() {
     // Skip DocAI when the checkbox is present (FEATURE_DOC_AI); otherwise Start goes
     // straight to the classic months / supporting-documents path.
-    const skipInput = this.page.locator('.usa-checkbox__input');
-    if ((await skipInput.count()) > 0) {
-      await skipInput.check();
+    // Click the visible label — the USWDS tile input is off-viewport and
+    // `.check()` on `.usa-checkbox__input` times out in CI.
+    if ((await this.skipAiCheckbox.count()) > 0) {
+      await this.skipAiCheckbox.check();
     }
     await this.startButton.click();
 

--- a/e2e/reporting-app/pages/members/activity-reports/SupportingDocumentsPage.ts
+++ b/e2e/reporting-app/pages/members/activity-reports/SupportingDocumentsPage.ts
@@ -7,11 +7,23 @@ export class SupportingDocumentsPage extends BasePage {
     return 'activity_report_application_forms/*/activities/*/documents';
   }
 
+  readonly fileInput: Locator;
+  readonly uploadButton: Locator;
   readonly continueButton: Locator;
 
   constructor(page: Page) {
     super(page);
+    this.fileInput = page.locator('input[type="file"]');
+    this.uploadButton = page.getByRole('button', { name: /upload document/i });
     this.continueButton = page.getByRole('link', { name: /continue/i });
+  }
+
+  /** Upload a supporting document (POST upload_documents → redirect back here). */
+  async uploadDocument(filePath: string) {
+    await this.fileInput.setInputFiles(filePath);
+    await this.uploadButton.click();
+    await this.waitForURLtoMatchPagePath();
+    return this;
   }
 
   async clickContinue() {

--- a/e2e/reporting-app/perf/NetworkProfiles.ts
+++ b/e2e/reporting-app/perf/NetworkProfiles.ts
@@ -1,0 +1,57 @@
+/**
+ * Network throttling profiles for performance baselining.
+ *
+ * Values mirror the Chrome DevTools "Slow 3G" / "Fast 3G" presets exactly
+ * (see Chromium `NetworkManager` throttling constants), so numbers collected
+ * here match what a developer sees via DevTools → Network → throttling, which
+ * is the manual workflow referenced in the ticket.
+ *
+ * Throughput is expressed in bytes/second (CDP `Network.emulateNetworkConditions`
+ * expects bytes/s); latency is round-trip time in milliseconds.
+ */
+export interface NetworkProfile {
+  readonly name: string;
+  /** Round-trip latency in milliseconds. */
+  readonly latencyMs: number;
+  /** Download throughput in bytes/second (-1 = unthrottled). */
+  readonly downloadBps: number;
+  /** Upload throughput in bytes/second (-1 = unthrottled). */
+  readonly uploadBps: number;
+}
+
+// Chrome DevTools "Slow 3G": 500 kbit/s * 0.8, RTT 400ms * 5.
+export const SLOW_3G: NetworkProfile = {
+  name: 'Slow 3G',
+  latencyMs: 400 * 5,
+  downloadBps: ((500 * 1000) / 8) * 0.8,
+  uploadBps: ((500 * 1000) / 8) * 0.8,
+};
+
+// Chrome DevTools "Fast 3G": 1.6 Mbit/s down * 0.9 / 750 kbit/s up * 0.9, RTT 150ms * 3.75.
+export const FAST_3G: NetworkProfile = {
+  name: 'Fast 3G',
+  latencyMs: 150 * 3.75,
+  downloadBps: ((1.6 * 1000 * 1000) / 8) * 0.9,
+  uploadBps: ((750 * 1000) / 8) * 0.9,
+};
+
+// Control run with no throttling, for comparison against the 3G numbers.
+export const UNTHROTTLED: NetworkProfile = {
+  name: 'Unthrottled',
+  latencyMs: 0,
+  downloadBps: -1,
+  uploadBps: -1,
+};
+
+/**
+ * Profiles measured by the baseline spec. Override via the PERF_PROFILES env
+ * var (comma-separated names) to run a subset, e.g. PERF_PROFILES="Slow 3G".
+ */
+export function selectedProfiles(): NetworkProfile[] {
+  const all = [SLOW_3G, FAST_3G, UNTHROTTLED];
+  const requested = process.env.PERF_PROFILES?.split(',').map((s) => s.trim().toLowerCase());
+  if (!requested || requested.length === 0) {
+    return all;
+  }
+  return all.filter((p) => requested.includes(p.name.toLowerCase()));
+}

--- a/e2e/reporting-app/perf/NetworkProfiles.ts
+++ b/e2e/reporting-app/perf/NetworkProfiles.ts
@@ -3,8 +3,8 @@
  *
  * Values mirror the Chrome DevTools "Slow 3G" / "Fast 3G" presets exactly
  * (see Chromium `NetworkManager` throttling constants), so numbers collected
- * here match what a developer sees via DevTools → Network → throttling, which
- * is the manual workflow referenced in the ticket.
+ * via CDP (Track A) match what a developer sees via DevTools → Network →
+ * throttling, which is the manual workflow referenced in the ticket.
  *
  * Throughput is expressed in bytes/second (CDP `Network.emulateNetworkConditions`
  * expects bytes/s); latency is round-trip time in milliseconds.
@@ -43,15 +43,60 @@ export const UNTHROTTLED: NetworkProfile = {
   uploadBps: -1,
 };
 
+export const ALL_PROFILES: readonly NetworkProfile[] = [SLOW_3G, FAST_3G, UNTHROTTLED];
+
+/**
+ * Lighthouse `settings.throttling` approximating Slow 3G bandwidth/latency for
+ * `throttlingMethod: 'simulate'`.
+ *
+ * Lighthouse simulation is **not** the same as CDP `Network.emulateNetworkConditions`
+ * (Track A). Timings are not 1:1 comparable across tracks; use Track A for
+ * DevTools-parity baselines and Track B for Lighthouse scores/budgets.
+ */
+export function lighthouseSlow3gSimulatedThrottling() {
+  const downloadThroughputKbps = (SLOW_3G.downloadBps * 8) / 1000;
+  const uploadThroughputKbps = (SLOW_3G.uploadBps * 8) / 1000;
+  return {
+    rttMs: SLOW_3G.latencyMs,
+    throughputKbps: downloadThroughputKbps,
+    // Lighthouse simulate applies an extra latency multiplier on requests.
+    requestLatencyMs: SLOW_3G.latencyMs * 3.75,
+    downloadThroughputKbps: downloadThroughputKbps * 0.9,
+    uploadThroughputKbps: uploadThroughputKbps * 0.9,
+    cpuSlowdownMultiplier: 4,
+  };
+}
+
 /**
  * Profiles measured by the baseline spec. Override via the PERF_PROFILES env
  * var (comma-separated names) to run a subset, e.g. PERF_PROFILES="Slow 3G".
+ *
+ * Throws if PERF_PROFILES is set but empty after parsing, or if any name is unknown.
  */
 export function selectedProfiles(): NetworkProfile[] {
-  const all = [SLOW_3G, FAST_3G, UNTHROTTLED];
-  const requested = process.env.PERF_PROFILES?.split(',').map((s) => s.trim().toLowerCase());
-  if (!requested || requested.length === 0) {
-    return all;
+  const raw = process.env.PERF_PROFILES;
+  if (raw === undefined || raw.trim() === '') {
+    return [...ALL_PROFILES];
   }
-  return all.filter((p) => requested.includes(p.name.toLowerCase()));
+
+  const requested = raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+
+  if (requested.length === 0) {
+    throw new Error(
+      'PERF_PROFILES is set but empty after parsing. Unset it to use all profiles, or pass names like "Slow 3G,Fast 3G".'
+    );
+  }
+
+  const unknown = requested.filter(
+    (name) => !ALL_PROFILES.some((p) => p.name.toLowerCase() === name)
+  );
+  if (unknown.length > 0) {
+    const valid = ALL_PROFILES.map((p) => p.name).join(', ');
+    throw new Error(`Unknown PERF_PROFILES value(s): ${unknown.join(', ')}. Valid: ${valid}`);
+  }
+
+  return ALL_PROFILES.filter((p) => requested.includes(p.name.toLowerCase()));
 }

--- a/e2e/reporting-app/perf/PerfCollector.ts
+++ b/e2e/reporting-app/perf/PerfCollector.ts
@@ -23,7 +23,7 @@ export interface PageMeasurement {
   transferBytes: number;
   requestCount: number;
   resourceBytes: ResourceBreakdown;
-  /** Time to first byte (ms), from Navigation Timing. */
+  /** Time to first byte (ms), from Navigation Timing (0 if unavailable). */
   ttfbMs: number;
   /** First Contentful Paint (ms). */
   fcpMs: number;
@@ -33,6 +33,11 @@ export interface PageMeasurement {
   domContentLoadedMs: number;
   /** load event end (ms). */
   loadMs: number;
+  /**
+   * Wall-clock duration of a measured action (ms). Set by `measureAction` for
+   * multi-step flows; useful when Navigation Timing does not reflect POST/upload.
+   */
+  stepDurationMs?: number;
 }
 
 const CDP_TYPE_TO_BUCKET: Record<string, keyof ResourceBreakdown> = {
@@ -122,6 +127,36 @@ export class PerfCollector {
     // Let late resources (fonts, lazy assets, LCP candidates) settle.
     await this.page.waitForLoadState('networkidle').catch(() => undefined);
 
+    return this.buildMeasurement(pageName, profile, targetUrl);
+  }
+
+  /**
+   * Run `action` under the active profile and measure transfer + wall-clock time.
+   * Use for multi-step wizard navigations and document uploads (POST/redirect).
+   */
+  async measureAction(
+    stepName: string,
+    profile: NetworkProfile,
+    action: () => Promise<void>
+  ): Promise<PageMeasurement> {
+    this.resetCounters();
+    const startedAt = Date.now();
+    await action();
+    await this.page.waitForLoadState('networkidle').catch(() => undefined);
+    const stepDurationMs = Date.now() - startedAt;
+    const measurement = await this.buildMeasurement(stepName, profile, this.page.url());
+    measurement.stepDurationMs = stepDurationMs;
+    if (!measurement.loadMs) {
+      measurement.loadMs = stepDurationMs;
+    }
+    return measurement;
+  }
+
+  private async buildMeasurement(
+    pageName: string,
+    profile: NetworkProfile,
+    url: string
+  ): Promise<PageMeasurement> {
     const timing = await this.page.evaluate(() => {
       const nav = performance.getEntriesByType('navigation')[0] as
         PerformanceNavigationTiming | undefined;
@@ -139,7 +174,7 @@ export class PerfCollector {
 
     return {
       page: pageName,
-      url: targetUrl,
+      url,
       profile: profile.name,
       transferBytes: sumBreakdown(this.resourceBytes),
       requestCount: this.requestCount,

--- a/e2e/reporting-app/perf/PerfCollector.ts
+++ b/e2e/reporting-app/perf/PerfCollector.ts
@@ -64,18 +64,18 @@ const LCP_OBSERVER_SCRIPT = `
  * Usage:
  *   const collector = new PerfCollector(page);
  *   await collector.start(SLOW_3G);
- *   const measurement = await collector.measure('dashboard');
+ *   const measurement = await collector.measure('dashboard', SLOW_3G, url);
  *   await collector.stop();
  *
- * `measure()` reloads the current page under throttling with cache disabled
- * (cold-cache, first-visit worst case), so drive navigation to the target page
- * *before* calling it.
+ * `measure()` navigates once to `url` (or the current page URL) under throttling
+ * with cache disabled (cold-cache, first-visit worst case).
  */
 export class PerfCollector {
   private client?: CDPSession;
   private requestTypes = new Map<string, keyof ResourceBreakdown>();
   private resourceBytes: ResourceBreakdown = emptyBreakdown();
   private requestCount = 0;
+  private lcpScriptInstalled = false;
 
   constructor(private readonly page: Page) {}
 
@@ -103,18 +103,22 @@ export class PerfCollector {
     await this.client.send('Network.setCacheDisabled', { cacheDisabled: true });
 
     await this.installByteCounters(this.client);
-    await this.page.addInitScript(LCP_OBSERVER_SCRIPT);
+
+    if (!this.lcpScriptInstalled) {
+      await this.page.addInitScript(LCP_OBSERVER_SCRIPT);
+      this.lcpScriptInstalled = true;
+    }
   }
 
   /**
-   * Reload the current page under throttling and return its measurement.
-   * Navigate to the target page before calling this.
+   * Load `url` once under the active throttling profile and return its measurement.
+   * When `url` is omitted, navigates to the current page URL.
    */
-  async measure(pageName: string): Promise<PageMeasurement> {
+  async measure(pageName: string, profile: NetworkProfile, url?: string): Promise<PageMeasurement> {
     this.resetCounters();
-    const url = this.page.url();
+    const targetUrl = url ?? this.page.url();
 
-    await this.page.reload({ waitUntil: 'load' });
+    await this.page.goto(targetUrl, { waitUntil: 'load' });
     // Let late resources (fonts, lazy assets, LCP candidates) settle.
     await this.page.waitForLoadState('networkidle').catch(() => undefined);
 
@@ -135,8 +139,8 @@ export class PerfCollector {
 
     return {
       page: pageName,
-      url,
-      profile: '', // set by the caller (spec) which knows the active profile
+      url: targetUrl,
+      profile: profile.name,
       transferBytes: sumBreakdown(this.resourceBytes),
       requestCount: this.requestCount,
       resourceBytes: { ...this.resourceBytes },

--- a/e2e/reporting-app/perf/PerfCollector.ts
+++ b/e2e/reporting-app/perf/PerfCollector.ts
@@ -1,0 +1,177 @@
+import { CDPSession, Page } from '@playwright/test';
+
+import { NetworkProfile } from './NetworkProfiles';
+
+/**
+ * Per-resource-type transfer sizes (bytes over the wire) and request counts for
+ * a single measured page load.
+ */
+export interface ResourceBreakdown {
+  document: number;
+  stylesheet: number;
+  script: number;
+  image: number;
+  font: number;
+  other: number;
+}
+
+export interface PageMeasurement {
+  page: string;
+  url: string;
+  profile: string;
+  /** Total bytes transferred over the wire (sum of encodedDataLength). */
+  transferBytes: number;
+  requestCount: number;
+  resourceBytes: ResourceBreakdown;
+  /** Time to first byte (ms), from Navigation Timing. */
+  ttfbMs: number;
+  /** First Contentful Paint (ms). */
+  fcpMs: number;
+  /** Largest Contentful Paint (ms); 0 if not observed. */
+  lcpMs: number;
+  /** DOMContentLoaded (ms). */
+  domContentLoadedMs: number;
+  /** load event end (ms). */
+  loadMs: number;
+}
+
+const CDP_TYPE_TO_BUCKET: Record<string, keyof ResourceBreakdown> = {
+  Document: 'document',
+  Stylesheet: 'stylesheet',
+  Script: 'script',
+  Image: 'image',
+  Font: 'font',
+};
+
+// Installed before navigation so LCP is captured with buffered entries.
+const LCP_OBSERVER_SCRIPT = `
+  window.__perfLcp = 0;
+  try {
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      const last = entries[entries.length - 1];
+      if (last) window.__perfLcp = last.renderTime || last.loadTime || last.startTime || 0;
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch (e) {
+    // largest-contentful-paint unsupported; leave __perfLcp at 0.
+  }
+`;
+
+/**
+ * Measures transfer size and paint/timing metrics for individual page loads
+ * under a throttled network profile, using the Chrome DevTools Protocol.
+ *
+ * Usage:
+ *   const collector = new PerfCollector(page);
+ *   await collector.start(SLOW_3G);
+ *   const measurement = await collector.measure('dashboard');
+ *   await collector.stop();
+ *
+ * `measure()` reloads the current page under throttling with cache disabled
+ * (cold-cache, first-visit worst case), so drive navigation to the target page
+ * *before* calling it.
+ */
+export class PerfCollector {
+  private client?: CDPSession;
+  private requestTypes = new Map<string, keyof ResourceBreakdown>();
+  private resourceBytes: ResourceBreakdown = emptyBreakdown();
+  private requestCount = 0;
+
+  constructor(private readonly page: Page) {}
+
+  async start(profile: NetworkProfile): Promise<void> {
+    this.client = await this.page.context().newCDPSession(this.page);
+    await this.client.send('Network.enable');
+
+    if (profile.downloadBps < 0) {
+      await this.client.send('Network.emulateNetworkConditions', {
+        offline: false,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput: -1,
+      });
+    } else {
+      await this.client.send('Network.emulateNetworkConditions', {
+        offline: false,
+        latency: profile.latencyMs,
+        downloadThroughput: profile.downloadBps,
+        uploadThroughput: profile.uploadBps,
+      });
+    }
+
+    // Cold cache: the baseline should reflect a first-time visitor on a slow link.
+    await this.client.send('Network.setCacheDisabled', { cacheDisabled: true });
+
+    await this.installByteCounters(this.client);
+    await this.page.addInitScript(LCP_OBSERVER_SCRIPT);
+  }
+
+  /**
+   * Reload the current page under throttling and return its measurement.
+   * Navigate to the target page before calling this.
+   */
+  async measure(pageName: string): Promise<PageMeasurement> {
+    this.resetCounters();
+    const url = this.page.url();
+
+    await this.page.reload({ waitUntil: 'load' });
+    // Let late resources (fonts, lazy assets, LCP candidates) settle.
+    await this.page.waitForLoadState('networkidle').catch(() => undefined);
+
+    const timing = await this.page.evaluate(() => {
+      const nav = performance.getEntriesByType('navigation')[0] as
+        PerformanceNavigationTiming | undefined;
+      const fcp = performance
+        .getEntriesByType('paint')
+        .find((e) => e.name === 'first-contentful-paint');
+      return {
+        ttfbMs: nav ? Math.round(nav.responseStart) : 0,
+        fcpMs: fcp ? Math.round(fcp.startTime) : 0,
+        lcpMs: Math.round((window as unknown as { __perfLcp: number }).__perfLcp || 0),
+        domContentLoadedMs: nav ? Math.round(nav.domContentLoadedEventEnd) : 0,
+        loadMs: nav ? Math.round(nav.loadEventEnd) : 0,
+      };
+    });
+
+    return {
+      page: pageName,
+      url,
+      profile: '', // set by the caller (spec) which knows the active profile
+      transferBytes: sumBreakdown(this.resourceBytes),
+      requestCount: this.requestCount,
+      resourceBytes: { ...this.resourceBytes },
+      ...timing,
+    };
+  }
+
+  async stop(): Promise<void> {
+    await this.client?.detach().catch(() => undefined);
+    this.client = undefined;
+  }
+
+  private async installByteCounters(client: CDPSession): Promise<void> {
+    client.on('Network.responseReceived', (event) => {
+      const bucket = CDP_TYPE_TO_BUCKET[event.type] ?? 'other';
+      this.requestTypes.set(event.requestId, bucket);
+    });
+    client.on('Network.loadingFinished', (event) => {
+      const bucket = this.requestTypes.get(event.requestId) ?? 'other';
+      this.resourceBytes[bucket] += event.encodedDataLength ?? 0;
+      this.requestCount += 1;
+    });
+  }
+
+  private resetCounters(): void {
+    this.requestTypes.clear();
+    this.resourceBytes = emptyBreakdown();
+    this.requestCount = 0;
+  }
+}
+
+function emptyBreakdown(): ResourceBreakdown {
+  return { document: 0, stylesheet: 0, script: 0, image: 0, font: 0, other: 0 };
+}
+
+function sumBreakdown(b: ResourceBreakdown): number {
+  return b.document + b.stylesheet + b.script + b.image + b.font + b.other;
+}

--- a/e2e/reporting-app/perf/PerfReporter.ts
+++ b/e2e/reporting-app/perf/PerfReporter.ts
@@ -18,6 +18,10 @@ export class PerfReporter {
     this.measurements.push(measurement);
   }
 
+  get size(): number {
+    return this.measurements.length;
+  }
+
   private outDir(): string {
     return process.env.PERF_OUT_DIR ?? path.resolve(__dirname, '../../perf-results');
   }

--- a/e2e/reporting-app/perf/PerfReporter.ts
+++ b/e2e/reporting-app/perf/PerfReporter.ts
@@ -28,30 +28,41 @@ export class PerfReporter {
     return fromEnv || path.resolve(__dirname, '../../perf-results');
   }
 
-  /** Write both perf-baseline.json and perf-baseline.md. Returns the directory. */
-  flush(): string {
+  /**
+   * Write JSON + markdown. `basename` defaults to `perf-baseline`
+   * (e.g. pass `perf-baseline-flow` for multi-step flow runs).
+   */
+  flush(basename = 'perf-baseline'): string {
     const dir = this.outDir();
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(
-      path.join(dir, 'perf-baseline.json'),
+      path.join(dir, `${basename}.json`),
       JSON.stringify(this.measurements, null, 2)
     );
-    fs.writeFileSync(path.join(dir, 'perf-baseline.md'), this.toMarkdown());
+    fs.writeFileSync(path.join(dir, `${basename}.md`), this.toMarkdown(basename));
     return dir;
   }
 
-  private toMarkdown(): string {
+  private toMarkdown(basename: string): string {
+    const hasStep = this.measurements.some((m) => m.stepDurationMs != null);
     const header = [
-      '# Client-facing performance baseline',
+      `# Client-facing performance baseline (${basename})`,
       '',
       'Transfer sizes are bytes over the wire (cold cache). Timings in milliseconds.',
+      hasStep ? 'Step (ms) is wall-clock for measured actions (navigations / uploads).' : '',
       '',
-      '| Page | Profile | Transfer (KB) | Requests | JS (KB) | CSS (KB) | Img (KB) | TTFB | FCP | LCP | Load |',
-      '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
-    ];
+      hasStep
+        ? '| Page | Profile | Transfer (KB) | Requests | JS (KB) | CSS (KB) | Img (KB) | TTFB | FCP | LCP | Load | Step |'
+        : '| Page | Profile | Transfer (KB) | Requests | JS (KB) | CSS (KB) | Img (KB) | TTFB | FCP | LCP | Load |',
+      hasStep
+        ? '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        : '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ].filter((line) => line !== undefined);
+
     const rows = this.measurements.map((m) => {
       const kb = (n: number) => (n / KB).toFixed(1);
-      return `| ${m.page} | ${m.profile} | ${kb(m.transferBytes)} | ${m.requestCount} | ${kb(m.resourceBytes.script)} | ${kb(m.resourceBytes.stylesheet)} | ${kb(m.resourceBytes.image)} | ${m.ttfbMs} | ${m.fcpMs} | ${m.lcpMs} | ${m.loadMs} |`;
+      const base = `| ${m.page} | ${m.profile} | ${kb(m.transferBytes)} | ${m.requestCount} | ${kb(m.resourceBytes.script)} | ${kb(m.resourceBytes.stylesheet)} | ${kb(m.resourceBytes.image)} | ${m.ttfbMs} | ${m.fcpMs} | ${m.lcpMs} | ${m.loadMs}`;
+      return hasStep ? `${base} | ${m.stepDurationMs ?? ''} |` : `${base} |`;
     });
     return [...header, ...rows, ''].join('\n');
   }

--- a/e2e/reporting-app/perf/PerfReporter.ts
+++ b/e2e/reporting-app/perf/PerfReporter.ts
@@ -23,7 +23,9 @@ export class PerfReporter {
   }
 
   private outDir(): string {
-    return process.env.PERF_OUT_DIR ?? path.resolve(__dirname, '../../perf-results');
+    // Make often exports PERF_OUT_DIR="" when unset; treat blank like missing.
+    const fromEnv = process.env.PERF_OUT_DIR?.trim();
+    return fromEnv || path.resolve(__dirname, '../../perf-results');
   }
 
   /** Write both perf-baseline.json and perf-baseline.md. Returns the directory. */

--- a/e2e/reporting-app/perf/PerfReporter.ts
+++ b/e2e/reporting-app/perf/PerfReporter.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+import { PageMeasurement } from './PerfCollector';
+
+const KB = 1024;
+
+/**
+ * Accumulates page measurements across profiles and writes a machine-readable
+ * JSON file plus a human-readable markdown table (paste-ready for the ticket).
+ *
+ * Output goes to e2e/perf-results/ by default; override with PERF_OUT_DIR.
+ */
+export class PerfReporter {
+  private readonly measurements: PageMeasurement[] = [];
+
+  add(measurement: PageMeasurement): void {
+    this.measurements.push(measurement);
+  }
+
+  private outDir(): string {
+    return process.env.PERF_OUT_DIR ?? path.resolve(__dirname, '../../perf-results');
+  }
+
+  /** Write both perf-baseline.json and perf-baseline.md. Returns the directory. */
+  flush(): string {
+    const dir = this.outDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'perf-baseline.json'),
+      JSON.stringify(this.measurements, null, 2)
+    );
+    fs.writeFileSync(path.join(dir, 'perf-baseline.md'), this.toMarkdown());
+    return dir;
+  }
+
+  private toMarkdown(): string {
+    const header = [
+      '# Client-facing performance baseline',
+      '',
+      'Transfer sizes are bytes over the wire (cold cache). Timings in milliseconds.',
+      '',
+      '| Page | Profile | Transfer (KB) | Requests | JS (KB) | CSS (KB) | Img (KB) | TTFB | FCP | LCP | Load |',
+      '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ];
+    const rows = this.measurements.map((m) => {
+      const kb = (n: number) => (n / KB).toFixed(1);
+      return `| ${m.page} | ${m.profile} | ${kb(m.transferBytes)} | ${m.requestCount} | ${kb(m.resourceBytes.script)} | ${kb(m.resourceBytes.stylesheet)} | ${kb(m.resourceBytes.image)} | ${m.ttfbMs} | ${m.fcpMs} | ${m.lcpMs} | ${m.loadMs} |`;
+    });
+    return [...header, ...rows, ''].join('\n');
+  }
+}

--- a/e2e/reporting-app/perf/flowBaselines.ts
+++ b/e2e/reporting-app/perf/flowBaselines.ts
@@ -1,0 +1,249 @@
+import path from 'path';
+
+import { Page } from '@playwright/test';
+
+import {
+  ActivityDetailsPage,
+  ActivityReportPage,
+  ActivityTypePage,
+  BeforeYouStartPage,
+  ChooseMonthsPage,
+  SupportingDocumentsPage,
+} from '../pages/members/activity-reports';
+import { DashboardPage } from '../pages/members/DashboardPage';
+import {
+  ExemptionDocumentsPage,
+  ExemptionMayQualifyPage,
+  ExemptionReviewPage,
+  ExemptionScreenerCompletePage,
+  ExemptionScreenerPage,
+  ExemptionScreenerQuestionPage,
+} from '../pages/members/exemptions';
+import { NetworkProfile } from './NetworkProfiles';
+import { PageMeasurement, PerfCollector } from './PerfCollector';
+
+const FIXTURES = path.resolve(__dirname, '../fixtures');
+export const ACTIVITY_PDF = path.join(FIXTURES, 'paystub_test_feb_2026_paydate.pdf');
+export const EXEMPTION_PDF = path.join(FIXTURES, 'exemption_medically_frail.pdf');
+
+type Measure = (name: string, action: () => Promise<void>) => Promise<PageMeasurement>;
+
+function makeMeasure(collector: PerfCollector, profile: NetworkProfile): Measure {
+  return (name, action) => collector.measureAction(name, profile, action);
+}
+
+/**
+ * Manual-walk match: No through entire exemption screener → 2 hours activities
+ * (with supporting docs) → 1 income activity with supporting doc → submit.
+ * Uses classic (non-DocAI) activity report upload.
+ */
+export async function runAllNoScreenerActivitiesFlow(
+  page: Page,
+  collector: PerfCollector,
+  profile: NetworkProfile
+): Promise<PageMeasurement[]> {
+  const measure = makeMeasure(collector, profile);
+  const out: PageMeasurement[] = [];
+
+  const dashboard = await new DashboardPage(page).go();
+
+  out.push(
+    await measure('Dashboard → screener index', async () => {
+      await dashboard.clickGetStarted();
+    })
+  );
+
+  out.push(
+    await measure('Screener index → Start', async () => {
+      await new ExemptionScreenerPage(page).clickStart();
+    })
+  );
+
+  let question = 1;
+  while (!page.url().includes('/exemption-screener/complete')) {
+    const n = question;
+    out.push(
+      await measure(`Screener No #${n}`, async () => {
+        const q = new ExemptionScreenerQuestionPage(page);
+        await q.noRadio.dispatchEvent('click');
+        await q.continueButton.click();
+        await page.waitForURL(/exemption-screener\/(question|complete)/);
+      })
+    );
+    question += 1;
+    if (question > 20) {
+      throw new Error('Screener No loop exceeded 20 steps — aborting');
+    }
+  }
+
+  out.push(
+    await measure('Screener complete → Report activities', async () => {
+      await new ExemptionScreenerCompletePage(page).clickReportActivities();
+    })
+  );
+
+  out.push(
+    await measure('Before you start → Skip AI / Start', async () => {
+      await new BeforeYouStartPage(page).clickStart();
+    })
+  );
+
+  out.push(
+    await measure('Choose months → save', async () => {
+      await new ChooseMonthsPage(page).selectFirstReportingPeriodAndSave();
+    })
+  );
+
+  let report = new ActivityReportPage(page);
+
+  out.push(
+    await measure('Add hours activity #1 (type)', async () => {
+      const type = await report.clickAddActivity();
+      await type.fillHoursEducationActivityType();
+    })
+  );
+  out.push(
+    await measure('Hours activity #1 details', async () => {
+      await new ActivityDetailsPage(page).fillActivityDetails('Org A', '40');
+    })
+  );
+  out.push(
+    await measure('Hours activity #1 upload_documents', async () => {
+      await new SupportingDocumentsPage(page).uploadDocument(ACTIVITY_PDF);
+    })
+  );
+  out.push(
+    await measure('Hours activity #1 docs continue', async () => {
+      report = await new SupportingDocumentsPage(page).clickContinue();
+    })
+  );
+
+  out.push(
+    await measure('Add hours activity #2 (type)', async () => {
+      const type = await report.clickAddActivity();
+      await type.fillHoursEducationActivityType();
+    })
+  );
+  out.push(
+    await measure('Hours activity #2 details', async () => {
+      await new ActivityDetailsPage(page).fillActivityDetails('Org B', '40');
+    })
+  );
+  out.push(
+    await measure('Hours activity #2 upload_documents', async () => {
+      await new SupportingDocumentsPage(page).uploadDocument(ACTIVITY_PDF);
+    })
+  );
+  out.push(
+    await measure('Hours activity #2 docs continue', async () => {
+      report = await new SupportingDocumentsPage(page).clickContinue();
+    })
+  );
+
+  out.push(
+    await measure('Add income activity (type)', async () => {
+      await report.clickAddActivity();
+      await new ActivityTypePage(page).fillIncomeEmploymentActivityType();
+    })
+  );
+  out.push(
+    await measure('Income activity details', async () => {
+      await new ActivityDetailsPage(page).fillIncomeActivityDetails('Employer Inc', '1500');
+    })
+  );
+  out.push(
+    await measure('Income activity upload_documents', async () => {
+      await new SupportingDocumentsPage(page).uploadDocument(ACTIVITY_PDF);
+    })
+  );
+  out.push(
+    await measure('Income activity docs continue', async () => {
+      report = await new SupportingDocumentsPage(page).clickContinue();
+    })
+  );
+
+  out.push(
+    await measure('Review and submit', async () => {
+      const review = await report.clickReviewAndSubmit();
+      await review.clickSubmit();
+    })
+  );
+
+  return out;
+}
+
+/**
+ * Medical exemption Yes path with regular (non-DocAI) document upload.
+ * No ×2 → Yes medical_condition → upload → submit.
+ */
+export async function runMedicalExemptionYesFlow(
+  page: Page,
+  collector: PerfCollector,
+  profile: NetworkProfile
+): Promise<PageMeasurement[]> {
+  const measure = makeMeasure(collector, profile);
+  const out: PageMeasurement[] = [];
+
+  const dashboard = await new DashboardPage(page).go();
+
+  out.push(
+    await measure('Dashboard → screener index', async () => {
+      await dashboard.clickGetStarted();
+    })
+  );
+
+  out.push(
+    await measure('Screener index → Start', async () => {
+      await new ExemptionScreenerPage(page).clickStart();
+    })
+  );
+
+  out.push(
+    await measure('Screener No #1 (caregiver_disability)', async () => {
+      await new ExemptionScreenerQuestionPage(page).answerNo();
+    })
+  );
+
+  out.push(
+    await measure('Screener No #2 (caregiver_child)', async () => {
+      await new ExemptionScreenerQuestionPage(page).answerNo();
+    })
+  );
+
+  out.push(
+    await measure('Screener Yes (medical_condition)', async () => {
+      await new ExemptionScreenerQuestionPage(page).answerYes();
+    })
+  );
+
+  out.push(
+    await measure('May qualify → Request exemption', async () => {
+      await new ExemptionMayQualifyPage(page).clickRequestExemption();
+    })
+  );
+
+  out.push(
+    await measure('Exemption upload_documents', async () => {
+      const docs = new ExemptionDocumentsPage(page);
+      await docs.fileInput.setInputFiles(EXEMPTION_PDF);
+      await docs.uploadButton.click();
+      await docs.waitForURLtoMatchPagePath();
+    })
+  );
+
+  out.push(
+    await measure('Exemption docs → Continue', async () => {
+      const docs = new ExemptionDocumentsPage(page);
+      await docs.continueLink.click();
+      await new ExemptionReviewPage(page).waitForURLtoMatchPagePath();
+    })
+  );
+
+  out.push(
+    await measure('Exemption review → Submit', async () => {
+      await new ExemptionReviewPage(page).submit();
+    })
+  );
+
+  return out;
+}

--- a/e2e/reporting-app/perf/index.ts
+++ b/e2e/reporting-app/perf/index.ts
@@ -1,0 +1,5 @@
+export { PerfCollector } from './PerfCollector';
+export type { PageMeasurement, ResourceBreakdown } from './PerfCollector';
+export { PerfReporter } from './PerfReporter';
+export { SLOW_3G, FAST_3G, UNTHROTTLED, selectedProfiles } from './NetworkProfiles';
+export type { NetworkProfile } from './NetworkProfiles';

--- a/e2e/reporting-app/perf/index.ts
+++ b/e2e/reporting-app/perf/index.ts
@@ -1,5 +1,18 @@
 export { PerfCollector } from './PerfCollector';
 export type { PageMeasurement, ResourceBreakdown } from './PerfCollector';
 export { PerfReporter } from './PerfReporter';
-export { SLOW_3G, FAST_3G, UNTHROTTLED, selectedProfiles } from './NetworkProfiles';
+export {
+  SLOW_3G,
+  FAST_3G,
+  UNTHROTTLED,
+  ALL_PROFILES,
+  selectedProfiles,
+  lighthouseSlow3gSimulatedThrottling,
+} from './NetworkProfiles';
 export type { NetworkProfile } from './NetworkProfiles';
+export {
+  signInAsNewMember,
+  captureDashboardAndScreenerTargets,
+  collectBaselineTargets,
+} from './memberPerfSetup';
+export type { BaselineTarget } from './memberPerfSetup';

--- a/e2e/reporting-app/perf/index.ts
+++ b/e2e/reporting-app/perf/index.ts
@@ -16,3 +16,9 @@ export {
   collectBaselineTargets,
 } from './memberPerfSetup';
 export type { BaselineTarget } from './memberPerfSetup';
+export {
+  runAllNoScreenerActivitiesFlow,
+  runMedicalExemptionYesFlow,
+  ACTIVITY_PDF,
+  EXEMPTION_PDF,
+} from './flowBaselines';

--- a/e2e/reporting-app/perf/memberPerfSetup.ts
+++ b/e2e/reporting-app/perf/memberPerfSetup.ts
@@ -1,0 +1,55 @@
+import { Page } from '@playwright/test';
+
+import { EmailService } from '../../lib/services/email/EmailService';
+import { AccountCreationFlow } from '../flows';
+import { CertificationRequestPage } from '../pages';
+import { DashboardPage } from '../pages/members/DashboardPage';
+
+export type BaselineTarget = {
+  name: string;
+  url: string;
+};
+
+const DEFAULT_PASSWORD = 'testPassword';
+
+/**
+ * Creates a new member account and signs in (skips MFA), matching the path used
+ * by other member e2e specs. Shared by Track A (baseline) and Track B (Lighthouse).
+ */
+export async function signInAsNewMember(page: Page, emailService: EmailService): Promise<void> {
+  const email = emailService.generateEmailAddress(emailService.generateUsername());
+
+  const certPage = await new CertificationRequestPage(page).go();
+  await certPage.fillAndSubmit(email);
+
+  const signInPage = await new AccountCreationFlow(page, emailService).run(email, DEFAULT_PASSWORD);
+  const mfaPreferencePage = await signInPage.signIn(email, DEFAULT_PASSWORD);
+  await mfaPreferencePage.skipMFA();
+}
+
+/**
+ * Walks dashboard → exemption screener once and returns stable GET-restorable URLs.
+ * Multi-step form pages are intentionally omitted (direct URL navigation can redirect).
+ */
+export async function captureDashboardAndScreenerTargets(page: Page): Promise<{
+  dashboard: BaselineTarget;
+  screener: BaselineTarget;
+}> {
+  const dashboardPage = await new DashboardPage(page).go();
+  const dashboard = { name: 'Dashboard', url: page.url() };
+
+  await dashboardPage.clickGetStarted();
+  const screener = { name: 'Exemption screener (index)', url: page.url() };
+
+  return { dashboard, screener };
+}
+
+/** Targets used by the Track A baseline harness (sign-in + authenticated pages). */
+export async function collectBaselineTargets(page: Page): Promise<BaselineTarget[]> {
+  const { dashboard, screener } = await captureDashboardAndScreenerTargets(page);
+  const signIn: BaselineTarget = {
+    name: 'Sign in',
+    url: new URL('/users/sign_in', page.url()).toString(),
+  };
+  return [signIn, dashboard, screener];
+}

--- a/e2e/reporting-app/perf/memberPerfSetup.ts
+++ b/e2e/reporting-app/perf/memberPerfSetup.ts
@@ -15,8 +15,14 @@ const DEFAULT_PASSWORD = 'testPassword';
 /**
  * Creates a new member account and signs in (skips MFA), matching the path used
  * by other member e2e specs. Shared by Track A (baseline) and Track B (Lighthouse).
+ *
+ * Clears cookies first so multi-profile loops (and re-entry) do not reuse an old
+ * Devise session — otherwise verify redirects to `/users/sign_in`, which bounces
+ * authenticated users to `/dashboard` ("You are already signed in") and hangs.
  */
 export async function signInAsNewMember(page: Page, emailService: EmailService): Promise<void> {
+  await page.context().clearCookies();
+
   const email = emailService.generateEmailAddress(emailService.generateUsername());
 
   const certPage = await new CertificationRequestPage(page).go();

--- a/e2e/reporting-app/playwright.config.js
+++ b/e2e/reporting-app/playwright.config.js
@@ -2,10 +2,18 @@ import baseConfig from '../playwright.config';
 import { deepMerge } from '../lib/util';
 import { defineConfig } from '@playwright/test';
 
+/**
+ * Perf / Lighthouse harnesses (performanceBaseline, lighthouseBudget) are
+ * opt-in via PERF=1 so they do not run in the default CI e2e suite.
+ * See docs/e2e/e2e-checks.md ("Performance baselines").
+ */
+const perfOptIn = process.env.PERF === '1';
+
 export default defineConfig(
   deepMerge(baseConfig, {
     use: {
       baseURL: baseConfig.use.baseURL || 'http://localhost:3000',
     },
+    testIgnore: perfOptIn ? [] : ['**/performanceBaseline.spec.ts', '**/lighthouseBudget.spec.ts'],
   })
 );

--- a/e2e/reporting-app/playwright.config.js
+++ b/e2e/reporting-app/playwright.config.js
@@ -3,8 +3,9 @@ import { deepMerge } from '../lib/util';
 import { defineConfig } from '@playwright/test';
 
 /**
- * Perf / Lighthouse harnesses (performanceBaseline, lighthouseBudget) are
- * opt-in via PERF=1 so they do not run in the default CI e2e suite.
+ * Perf / Lighthouse harnesses are **opt-in** via PERF=1 and are ignored otherwise
+ * (`performanceBaseline`, `performanceBaselineFlow`, `lighthouseBudget`).
+ * Default `make e2e-test` / CI must NOT set PERF=1 — flow baselines are very slow.
  * See docs/e2e/e2e-checks.md ("Performance baselines").
  */
 const perfOptIn = process.env.PERF === '1';
@@ -14,6 +15,12 @@ export default defineConfig(
     use: {
       baseURL: baseConfig.use.baseURL || 'http://localhost:3000',
     },
-    testIgnore: perfOptIn ? [] : ['**/performanceBaseline.spec.ts', '**/lighthouseBudget.spec.ts'],
+    testIgnore: perfOptIn
+      ? []
+      : [
+          '**/performanceBaseline.spec.ts',
+          '**/performanceBaselineFlow.spec.ts',
+          '**/lighthouseBudget.spec.ts',
+        ],
   })
 );

--- a/e2e/reporting-app/tests/lighthouseBudget.spec.ts
+++ b/e2e/reporting-app/tests/lighthouseBudget.spec.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { Config } from 'lighthouse';
+import { playAudit } from 'playwright-lighthouse';
+
+import { test } from '../../fixtures';
+import { AccountCreationFlow } from '../flows';
+import { CertificationRequestPage } from '../pages';
+import { DashboardPage } from '../pages/members/DashboardPage';
+
+/**
+ * Runs Lighthouse against the authenticated member pages and enforces a
+ * performance budget (e2e/reporting-app/lighthouse/budget.json). Supports the
+ * "frontier / limited connectivity" work (issue #747): AC "meet a defined
+ * performance budget".
+ *
+ * Lighthouse attaches to the Playwright-controlled Chromium over CDP, so
+ * Playwright owns authentication (one login path) and Lighthouse reuses the
+ * session cookies. The browser must expose a remote debugging port — set below.
+ *
+ * NOTE: run this file on its own (workers=1) so the fixed CDP port does not
+ * clash with parallel workers:
+ *   make e2e-test-native APP_NAME=reporting-app \
+ *     E2E_ARGS=reporting-app/tests/lighthouseBudget.spec.ts
+ */
+
+const LH_PORT = 9222;
+
+test.use({ launchOptions: { args: [`--remote-debugging-port=${LH_PORT}`] } });
+
+const budgets = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../lighthouse/budget.json'), 'utf-8')
+);
+
+// Simulated Slow-3G-ish mobile throttling (matches the Track A "Slow 3G" intent).
+const THROTTLING = {
+  rttMs: 400,
+  throughputKbps: 400,
+  requestLatencyMs: 400 * 3.75,
+  downloadThroughputKbps: 400 * 0.9,
+  uploadThroughputKbps: 400 * 0.9,
+  cpuSlowdownMultiplier: 4,
+};
+
+test('member pages meet the performance budget under 3G', async ({ page, emailService }) => {
+  test.setTimeout(10 * 60 * 1000);
+
+  const email = emailService.generateEmailAddress(emailService.generateUsername());
+  const password = 'testPassword';
+
+  // Authenticate (same path as the other member specs).
+  const certPage = await new CertificationRequestPage(page).go();
+  await certPage.fillAndSubmit(email);
+  const signInPage = await new AccountCreationFlow(page, emailService).run(email, password);
+  const mfaPreferencePage = await signInPage.signIn(email, password);
+  await mfaPreferencePage.skipMFA();
+
+  // Reach the pages to audit and capture their URLs (capture before navigating on).
+  const dashboard = await new DashboardPage(page).go();
+  const dashboardUrl = page.url();
+  await dashboard.clickGetStarted();
+  const screenerUrl = page.url();
+
+  const targets = [
+    { name: 'dashboard', url: dashboardUrl },
+    { name: 'exemption-screener-index', url: screenerUrl },
+  ];
+
+  // `budgets` is a valid runtime lighthouse setting (settings.budgets) but is
+  // absent from lighthouse's exported Config types, so cast the settings object.
+  const lighthouseConfig: Config = {
+    extends: 'lighthouse:default',
+    settings: {
+      formFactor: 'mobile',
+      onlyCategories: ['performance', 'accessibility'],
+      throttlingMethod: 'simulate',
+      throttling: THROTTLING,
+      budgets,
+    } as Config['settings'],
+  };
+
+  for (const target of targets) {
+    await page.goto(target.url);
+    await playAudit({
+      page,
+      port: LH_PORT,
+      // Category-score floors; budget.json enforces size/timing budgets.
+      thresholds: { performance: 50, accessibility: 90 },
+      config: lighthouseConfig,
+      reports: {
+        formats: { html: true, json: true },
+        name: `lighthouse-${target.name}`,
+        directory: path.resolve(__dirname, '../../perf-results/lighthouse'),
+      },
+    });
+  }
+});

--- a/e2e/reporting-app/tests/lighthouseBudget.spec.ts
+++ b/e2e/reporting-app/tests/lighthouseBudget.spec.ts
@@ -5,24 +5,26 @@ import type { Config } from 'lighthouse';
 import { playAudit } from 'playwright-lighthouse';
 
 import { test } from '../../fixtures';
-import { AccountCreationFlow } from '../flows';
-import { CertificationRequestPage } from '../pages';
-import { DashboardPage } from '../pages/members/DashboardPage';
+import {
+  captureDashboardAndScreenerTargets,
+  lighthouseSlow3gSimulatedThrottling,
+  signInAsNewMember,
+} from '../perf';
 
 /**
- * Runs Lighthouse against the authenticated member pages and enforces a
- * performance budget (e2e/reporting-app/lighthouse/budget.json). Supports the
- * "frontier / limited connectivity" work (issue #747): AC "meet a defined
- * performance budget".
+ * Runs Lighthouse against authenticated member pages. Supports the
+ * "frontier / limited connectivity" work (issue #747).
  *
- * Lighthouse attaches to the Playwright-controlled Chromium over CDP, so
- * Playwright owns authentication (one login path) and Lighthouse reuses the
- * session cookies. The browser must expose a remote debugging port — set below.
+ * Opt-in only — excluded from the default e2e suite unless PERF=1:
+ *   make e2e-perf-lighthouse APP_NAME=reporting-app
  *
- * NOTE: run this file on its own (workers=1) so the fixed CDP port does not
- * clash with parallel workers:
- *   make e2e-test-native APP_NAME=reporting-app \
- *     E2E_ARGS=reporting-app/tests/lighthouseBudget.spec.ts
+ * By default this is **capture-first**: HTML/JSON reports are written under
+ * e2e/perf-results/lighthouse/ without failing on placeholder budgets or
+ * category-score floors. Set PERF_ENFORCE_BUDGET=1 to enforce budget.json and
+ * score thresholds after baselines are calibrated.
+ *
+ * Lighthouse attaches to Playwright Chromium over CDP (fixed port below).
+ * Run with workers=1 / a single project so the port does not clash.
  */
 
 const LH_PORT = 9222;
@@ -33,50 +35,39 @@ const budgets = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../lighthouse/budget.json'), 'utf-8')
 );
 
-// Simulated Slow-3G-ish mobile throttling (matches the Track A "Slow 3G" intent).
-const THROTTLING = {
-  rttMs: 400,
-  throughputKbps: 400,
-  requestLatencyMs: 400 * 3.75,
-  downloadThroughputKbps: 400 * 0.9,
-  uploadThroughputKbps: 400 * 0.9,
-  cpuSlowdownMultiplier: 4,
-};
+const enforceBudget = process.env.PERF_ENFORCE_BUDGET === '1';
 
-test('member pages meet the performance budget under 3G', async ({ page, emailService }) => {
+test('member pages meet the performance budget under 3G', async ({
+  page,
+  emailService,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'chromium',
+    'Lighthouse requires a single Chromium CDP port; skip other projects.'
+  );
+
   test.setTimeout(10 * 60 * 1000);
 
-  const email = emailService.generateEmailAddress(emailService.generateUsername());
-  const password = 'testPassword';
+  await signInAsNewMember(page, emailService);
 
-  // Authenticate (same path as the other member specs).
-  const certPage = await new CertificationRequestPage(page).go();
-  await certPage.fillAndSubmit(email);
-  const signInPage = await new AccountCreationFlow(page, emailService).run(email, password);
-  const mfaPreferencePage = await signInPage.signIn(email, password);
-  await mfaPreferencePage.skipMFA();
-
-  // Reach the pages to audit and capture their URLs (capture before navigating on).
-  const dashboard = await new DashboardPage(page).go();
-  const dashboardUrl = page.url();
-  await dashboard.clickGetStarted();
-  const screenerUrl = page.url();
-
+  const { dashboard, screener } = await captureDashboardAndScreenerTargets(page);
   const targets = [
-    { name: 'dashboard', url: dashboardUrl },
-    { name: 'exemption-screener-index', url: screenerUrl },
+    { name: 'dashboard', url: dashboard.url },
+    { name: 'exemption-screener-index', url: screener.url },
   ];
 
   // `budgets` is a valid runtime lighthouse setting (settings.budgets) but is
   // absent from lighthouse's exported Config types, so cast the settings object.
+  // Track B uses Lighthouse *simulate* throttling derived from Slow 3G constants;
+  // it is not identical to CDP Network.emulateNetworkConditions (Track A).
   const lighthouseConfig: Config = {
     extends: 'lighthouse:default',
     settings: {
       formFactor: 'mobile',
       onlyCategories: ['performance', 'accessibility'],
       throttlingMethod: 'simulate',
-      throttling: THROTTLING,
-      budgets,
+      throttling: lighthouseSlow3gSimulatedThrottling(),
+      ...(enforceBudget ? { budgets } : {}),
     } as Config['settings'],
   };
 
@@ -85,8 +76,10 @@ test('member pages meet the performance budget under 3G', async ({ page, emailSe
     await playAudit({
       page,
       port: LH_PORT,
-      // Category-score floors; budget.json enforces size/timing budgets.
-      thresholds: { performance: 50, accessibility: 90 },
+      // Soft floors unless PERF_ENFORCE_BUDGET=1 (capture-first workflow).
+      thresholds: enforceBudget
+        ? { performance: 50, accessibility: 90 }
+        : { performance: 0, accessibility: 0 },
       config: lighthouseConfig,
       reports: {
         formats: { html: true, json: true },

--- a/e2e/reporting-app/tests/performanceBaseline.spec.ts
+++ b/e2e/reporting-app/tests/performanceBaseline.spec.ts
@@ -1,0 +1,69 @@
+import { test } from '../../fixtures';
+import { AccountCreationFlow } from '../flows';
+import { CertificationRequestPage } from '../pages';
+import { DashboardPage } from '../pages/members/DashboardPage';
+import { PerfCollector, PerfReporter, selectedProfiles } from '../perf';
+
+/**
+ * Captures client-facing performance baselines (transfer size, request count,
+ * paint/timing metrics) for the member-facing critical path under throttled
+ * network profiles. Supports the "frontier / limited connectivity" work
+ * (github.com/navapbc/oscer/issues/747): establishes the numbers a performance
+ * budget is set against.
+ *
+ * Run a subset of profiles with PERF_PROFILES (e.g. PERF_PROFILES="Slow 3G").
+ * Results are written to e2e/perf-results/ (perf-baseline.json + .md).
+ */
+test('capture client-facing performance baselines under throttled networks', async ({
+  page,
+  emailService,
+}) => {
+  // Slow 3G adds ~2s latency per request; the full sweep needs a long budget.
+  test.setTimeout(10 * 60 * 1000);
+
+  const email = emailService.generateEmailAddress(emailService.generateUsername());
+  const password = 'testPassword';
+
+  // --- Reach an authenticated session (mirrors the exemption spec) ---
+  const certPage = await new CertificationRequestPage(page).go();
+  await certPage.fillAndSubmit(email);
+
+  const signInPage = await new AccountCreationFlow(page, emailService).run(email, password);
+  const mfaPreferencePage = await signInPage.signIn(email, password);
+  await mfaPreferencePage.skipMFA();
+
+  // --- Walk the flow once to capture stable URLs of the pages we baseline ---
+  // Only pages that are reliably restorable by a plain GET are re-measured in
+  // the profile loop below (each iteration re-navigates by URL). Multi-step
+  // form pages (screener questions, activity-report steps) are NOT included:
+  // navigating straight to their URL can redirect and silently mis-measure.
+  // To baseline those, extend the walk to re-drive the flow per profile.
+  const targets: { name: string; url: string }[] = [];
+
+  const dashboard = await new DashboardPage(page).go();
+  targets.push({ name: 'Dashboard', url: page.url() });
+
+  await dashboard.clickGetStarted();
+  targets.push({ name: 'Exemption screener (index)', url: page.url() });
+
+  // The sign-in page is public but part of the member entry path — baseline it too.
+  targets.unshift({ name: 'Sign in', url: new URL('/users/sign_in', page.url()).toString() });
+
+  // --- Measure every target under every selected network profile ---
+  const reporter = new PerfReporter();
+  for (const profile of selectedProfiles()) {
+    const collector = new PerfCollector(page);
+    await collector.start(profile);
+    for (const target of targets) {
+      await page.goto(target.url);
+      const measurement = await collector.measure(target.name);
+      measurement.profile = profile.name;
+      reporter.add(measurement);
+    }
+    await collector.stop();
+  }
+
+  const dir = reporter.flush();
+  // eslint-disable-next-line no-console
+  console.log(`\nPerformance baseline written to ${dir}\n`);
+});

--- a/e2e/reporting-app/tests/performanceBaseline.spec.ts
+++ b/e2e/reporting-app/tests/performanceBaseline.spec.ts
@@ -1,8 +1,13 @@
+import { expect } from '@playwright/test';
+
 import { test } from '../../fixtures';
-import { AccountCreationFlow } from '../flows';
-import { CertificationRequestPage } from '../pages';
-import { DashboardPage } from '../pages/members/DashboardPage';
-import { PerfCollector, PerfReporter, selectedProfiles } from '../perf';
+import {
+  PerfCollector,
+  PerfReporter,
+  collectBaselineTargets,
+  selectedProfiles,
+  signInAsNewMember,
+} from '../perf';
 
 /**
  * Captures client-facing performance baselines (transfer size, request count,
@@ -11,57 +16,48 @@ import { PerfCollector, PerfReporter, selectedProfiles } from '../perf';
  * (github.com/navapbc/oscer/issues/747): establishes the numbers a performance
  * budget is set against.
  *
+ * Opt-in only — excluded from the default e2e suite unless PERF=1:
+ *   make e2e-perf-baseline APP_NAME=reporting-app
+ *   # or: PERF=1 make e2e-test-native APP_NAME=reporting-app \
+ *   #      E2E_ARGS=reporting-app/tests/performanceBaseline.spec.ts
+ *
  * Run a subset of profiles with PERF_PROFILES (e.g. PERF_PROFILES="Slow 3G").
  * Results are written to e2e/perf-results/ (perf-baseline.json + .md).
  */
 test('capture client-facing performance baselines under throttled networks', async ({
   page,
   emailService,
-}) => {
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'chromium',
+    'Perf baselines run on the chromium project only (set PERF=1).'
+  );
+
   // Slow 3G adds ~2s latency per request; the full sweep needs a long budget.
   test.setTimeout(10 * 60 * 1000);
 
-  const email = emailService.generateEmailAddress(emailService.generateUsername());
-  const password = 'testPassword';
+  await signInAsNewMember(page, emailService);
 
-  // --- Reach an authenticated session (mirrors the exemption spec) ---
-  const certPage = await new CertificationRequestPage(page).go();
-  await certPage.fillAndSubmit(email);
-
-  const signInPage = await new AccountCreationFlow(page, emailService).run(email, password);
-  const mfaPreferencePage = await signInPage.signIn(email, password);
-  await mfaPreferencePage.skipMFA();
-
-  // --- Walk the flow once to capture stable URLs of the pages we baseline ---
   // Only pages that are reliably restorable by a plain GET are re-measured in
-  // the profile loop below (each iteration re-navigates by URL). Multi-step
-  // form pages (screener questions, activity-report steps) are NOT included:
-  // navigating straight to their URL can redirect and silently mis-measure.
-  // To baseline those, extend the walk to re-drive the flow per profile.
-  const targets: { name: string; url: string }[] = [];
+  // the profile loop below. Multi-step form pages are NOT included.
+  const targets = await collectBaselineTargets(page);
+  const profiles = selectedProfiles();
+  const expectedCount = profiles.length * targets.length;
 
-  const dashboard = await new DashboardPage(page).go();
-  targets.push({ name: 'Dashboard', url: page.url() });
-
-  await dashboard.clickGetStarted();
-  targets.push({ name: 'Exemption screener (index)', url: page.url() });
-
-  // The sign-in page is public but part of the member entry path — baseline it too.
-  targets.unshift({ name: 'Sign in', url: new URL('/users/sign_in', page.url()).toString() });
-
-  // --- Measure every target under every selected network profile ---
   const reporter = new PerfReporter();
-  for (const profile of selectedProfiles()) {
+  for (const profile of profiles) {
     const collector = new PerfCollector(page);
     await collector.start(profile);
     for (const target of targets) {
-      await page.goto(target.url);
-      const measurement = await collector.measure(target.name);
-      measurement.profile = profile.name;
-      reporter.add(measurement);
+      reporter.add(await collector.measure(target.name, profile, target.url));
     }
     await collector.stop();
   }
+
+  expect(
+    reporter.size,
+    `expected ${expectedCount} measurements (${profiles.length} profiles × ${targets.length} pages)`
+  ).toBe(expectedCount);
 
   const dir = reporter.flush();
   // eslint-disable-next-line no-console

--- a/e2e/reporting-app/tests/performanceBaselineFlow.spec.ts
+++ b/e2e/reporting-app/tests/performanceBaselineFlow.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../fixtures';
+import {
+  PerfCollector,
+  PerfReporter,
+  runAllNoScreenerActivitiesFlow,
+  runMedicalExemptionYesFlow,
+  selectedProfiles,
+  signInAsNewMember,
+} from '../perf';
+
+/**
+ * Multi-step flow performance baselines under throttled networks (OSCER-747).
+ *
+ * ⚠️  LONG-RUNNING — NOT FOR CI / DEFAULT `make e2e-test`
+ * ---------------------------------------------------------------------------
+ * These tests walk full member flows under Slow/Fast 3G and Unthrottled.
+ * Expect **tens of minutes to ~1+ hour** for all profiles (90m timeout).
+ * Prefer `PERF_PROFILES="Slow 3G"` (or a single profile) for a shorter run.
+ *
+ * They are **excluded from the default Playwright suite and CI** unless you
+ * explicitly set `PERF=1`. Do not enable PERF in GitHub Actions e2e workflows.
+ *
+ * Two flows (separate tests; fresh member + all selected profiles each).
+ * Make runs with `--workers=1`; each profile clears cookies before signup.
+ * 1. Match manual walk: No through screener → 2 hours activities + docs →
+ *    1 income + doc → submit (classic upload, not DocAI).
+ * 2. Medical exemption Yes + regular document upload → submit.
+ *
+ * Run locally only:
+ *   make e2e-perf-baseline-flow APP_NAME=reporting-app
+ *   PERF_PROFILES="Slow 3G" make e2e-perf-baseline-flow APP_NAME=reporting-app
+ *
+ * Writes e2e/perf-results/perf-baseline-flow-*.json/.md
+ */
+
+const FLOW_TIMEOUT_MS = 90 * 60 * 1000;
+
+test.describe('performance baseline flows', () => {
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'chromium',
+      'Perf flow baselines run on the chromium project only (set PERF=1).'
+    );
+  });
+
+  test('all-No screener + hours/income activities with supporting docs', async ({
+    page,
+    emailService,
+  }) => {
+    test.setTimeout(FLOW_TIMEOUT_MS);
+
+    const profiles = selectedProfiles();
+    const reporter = new PerfReporter();
+
+    for (const profile of profiles) {
+      await signInAsNewMember(page, emailService);
+      const collector = new PerfCollector(page);
+      await collector.start(profile);
+      const steps = await runAllNoScreenerActivitiesFlow(page, collector, profile);
+      for (const step of steps) {
+        reporter.add(step);
+      }
+      await collector.stop();
+    }
+
+    expect(reporter.size).toBeGreaterThan(0);
+    const dir = reporter.flush('perf-baseline-flow-activities');
+    // eslint-disable-next-line no-console
+    console.log(`\nFlow baseline (activities) written to ${dir}\n`);
+  });
+
+  test('medical exemption Yes + regular document upload', async ({ page, emailService }) => {
+    test.setTimeout(FLOW_TIMEOUT_MS);
+
+    const profiles = selectedProfiles();
+    const reporter = new PerfReporter();
+
+    for (const profile of profiles) {
+      await signInAsNewMember(page, emailService);
+      const collector = new PerfCollector(page);
+      await collector.start(profile);
+      const steps = await runMedicalExemptionYesFlow(page, collector, profile);
+      for (const step of steps) {
+        reporter.add(step);
+      }
+      await collector.stop();
+    }
+
+    expect(reporter.size).toBeGreaterThan(0);
+    const dir = reporter.flush('perf-baseline-flow-exemption');
+    // eslint-disable-next-line no-console
+    console.log(`\nFlow baseline (exemption) written to ${dir}\n`);
+  });
+});


### PR DESCRIPTION
## Ticket

Resolves [OSCER-747](https://github.com/navapbc/oscer/issues/747)

## Changes

- Add client-facing performance baseline tooling under `e2e/reporting-app/perf/`:
  - **Track A** (`performanceBaseline.spec.ts`): CDP throttling with Chrome DevTools Slow/Fast 3G constants; writes `e2e/perf-results/perf-baseline.json` + `.md`
  - **Flow baselines** (`performanceBaselineFlow.spec.ts`): multi-step activities + medical exemption walks; writes `perf-baseline-flow-*.json/.md`; Make target `e2e-perf-baseline-flow` (`--workers=1`, cookie clear between profiles)
  - **Track B** (`lighthouseBudget.spec.ts`): Lighthouse over CDP with Slow 3G–derived simulate throttling; writes reports under `e2e/perf-results/lighthouse/`
- Exclude perf specs from the default e2e suite / CI unless `PERF=1`; chromium-only Make targets `e2e-perf-baseline`, `e2e-perf-baseline-flow`, and `e2e-perf-lighthouse`
- Capture-first Lighthouse: budgets and score floors only when `PERF_ENFORCE_BUDGET=1`
- Shared member auth + URL helpers (`memberPerfSetup.ts`); single-navigation `PerfCollector.measure` + `measureAction`; fail-fast `PERF_PROFILES`
- Treat blank `PERF_OUT_DIR` (Make exports `""` when unset) as missing so baseline flush writes to `e2e/perf-results/`
- Document usage in `docs/e2e/e2e-checks.md`; mount `e2e/perf-results` in Docker e2e runs; add `lighthouse` / `playwright-lighthouse` deps

## Context for reviewers

- This PR delivers the **tooling** to capture baselines for frontier / low-bandwidth (issue AC). It does not commit calibrated baseline numbers into the repo or turn on CI budget gates (`perf-results/` is gitignored).
- Track A (CDP) timings are DevTools-parity; Track B (Lighthouse simulate) is **not** 1:1 comparable—documented in code and `docs/e2e/e2e-checks.md`.
- Manual alternative: Chrome DevTools → Network → Slow 3G (works with mock auth).
- Run locally (app up, `AUTH_ADAPTER=cognito`, Playwright Chromium installed):
  ```bash
  make e2e-perf-baseline APP_NAME=reporting-app
  PERF_PROFILES="Slow 3G" make e2e-perf-baseline APP_NAME=reporting-app
  PERF_PROFILES="Slow 3G" make e2e-perf-baseline-flow APP_NAME=reporting-app  # LONG
  make e2e-perf-lighthouse APP_NAME=reporting-app
  ```
- Results land in `e2e/perf-results/` (gitignored)—paste `.md` into the ticket or copy elsewhere to retain.
- Captured findings (local / vault, not committed): Slow 3G activities flow **~7.7 min** sum of steps / exemption **~2.5 min**; small-fixture uploads **~20–23s**. Manual large-doc walk still saw `upload_documents` **~1.8 min** vs **132 ms** unthrottled.

## Testing

- `make e2e-type-check-native` — passed
- Default suite list excludes perf specs unless `PERF=1`
- Local Track A + full flow baseline runs succeeded after Cognito + AWS credentials were configured; sample Track A (cold cache, ms):

  | Page | Profile | Transfer (KB) | FCP | LCP | Load |
  | --- | --- | ---: | ---: | ---: | ---: |
  | Sign in | Slow 3G | 409.0 | 9656 | 9764 | 16502 |
  | Dashboard | Slow 3G | 407.9 | 7520 | 7624 | 13621 |
  | Exemption screener (index) | Slow 3G | 387.7 | 7496 | 7596 | 13563 |

- Flow harness (sum of `stepDurationMs`, Slow 3G): activities **~7.7 min** (25 steps); exemption **~2.5 min** (9 steps)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->