### PR TITLE
OSCER-767: Mock Data Source

### DIFF
--- a/reporting-app/app/services/verification/adapters/mock_drug_treatment.rb
+++ b/reporting-app/app/services/verification/adapters/mock_drug_treatment.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Verification
+  module Adapters
+    # Mock data source deriving a drug-treatment outcome from the last digit of
+    # the member's va_icn:
+    #
+    #   * absent ICN                          -> :skipped
+    #   * ICN not ending in a digit           -> :success, no outcomes ("no result")
+    #   * last digit divisible by 3           -> :success, [:drug_treatment]        (exclusion)
+    #   * last digit odd, not divisible by 3  -> :success, [:was_in_drug_treatment] (exception)
+    #   * last digit even, not divisible by 3 -> :success, no outcomes              (no result)
+    #
+    # Outcomes: :drug_treatment (exclusion), :was_in_drug_treatment (exception).
+    class MockDrugTreatment < Verification::DataSource
+      SOURCE = "mock_drug_treatment"
+      OUTCOME_EXCLUDED = :drug_treatment
+      OUTCOME_EXCEPTED = :was_in_drug_treatment
+
+      def self.declared_outcomes
+        [ OUTCOME_EXCLUDED, OUTCOME_EXCEPTED ]
+      end
+
+      protected
+
+      def precondition_met?(certification)
+        certification.member_data&.va_icn.present?
+      end
+
+      def perform(certification:)
+        success_result(
+          outcomes: outcomes_for(certification.member_data.va_icn),
+          audit_data: { source: SOURCE }
+        )
+      end
+
+      private
+
+      # Only the last character matters; a non-digit last character is "no result".
+      def outcomes_for(va_icn)
+        last = va_icn[-1]
+        return [] unless last&.match?(/\A\d\z/)
+
+        digit = last.to_i
+        if (digit % 3).zero?
+          [ OUTCOME_EXCLUDED ]
+        elsif digit.odd?
+          [ OUTCOME_EXCEPTED ]
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/reporting-app/app/services/verification_data_sources_loader.rb
+++ b/reporting-app/app/services/verification_data_sources_loader.rb
@@ -9,8 +9,8 @@ require_relative "config_loading"
 # A "data source" is an external verification adapter (a Verification::DataSource
 # subclass). Config owns enablement, wiring, and call order; the adapter class
 # owns which outcome symbols it may emit via {.declared_outcomes}. Boot
-# validation confirms those outcomes exist in the Exclusion / ExternalException
-# registries (CE membership lands with a CE registry later).
+# validation confirms those outcomes are known Determination::REASON_CODE_MAPPING
+# keys (the "emit the key" convention).
 #
 # Call order among verification sources is configured here via the per-source
 # order integer. Exception and community-engagement sources may interleave in
@@ -26,9 +26,9 @@ require_relative "config_loading"
 #     order types + distinctness) and needs no application constants, so it runs
 #     in the initializer body and is unit-testable in isolation.
 #   * .validate_registry! constantizes adapter_class, requires .declared_outcomes,
-#     and checks each outcome against the known registries. That requires
-#     autoloadable app constants (and the sibling exclusion/exception
-#     initializers to have run), so the initializer defers it to a to_prepare hook.
+#     and checks each outcome against Determination::REASON_CODE_MAPPING keys.
+#     That requires autoloadable app constants, so the initializer defers it to a
+#     to_prepare hook.
 #
 # Mirrors ExclusionTypesLoader / ExemptionTypesLoader; the YAML load/parse/error
 # plumbing lives in the shared ConfigLoading module (extend below).
@@ -40,18 +40,9 @@ module VerificationDataSourcesLoader
   # lexical scope, so no raise site needs qualifying.
   ConfigurationError = ConfigLoading::ConfigurationError
 
-  # OSCER-owned defaults. Deployments customize via the override file, not by
-  # editing this constant. The VA disability-rating source lands here as the
-  # first real registered source (OSCER-755 adapter, OSCER-756 registry).
-  # Outcomes for that adapter live on
-  # Verification::Adapters::VaDisabilityRating.declared_outcomes — not here.
-  DEFAULTS = {
-    "va_disability_rating" => {
-      "enabled" => true,
-      "adapter_class" => "Verification::Adapters::VaDisabilityRating",
-      "order" => nil
-    }
-  }.freeze
+  # OSCER-owned defaults. Empty: OSCER ships no default sources, so deployments
+  # register their own via the override file rather than editing this constant.
+  DEFAULTS = {}.freeze
 
   module_function
 
@@ -69,20 +60,16 @@ module VerificationDataSourcesLoader
   end
 
   # Application-constant-dependent validation. Must run after autoloading is
-  # ready and after the sibling registries are populated, so the initializer
-  # calls this from a to_prepare hook rather than the body.
+  # ready, so the initializer calls this from a to_prepare hook rather than the
+  # body.
   def validate_registry!(entries)
-    # Snapshot once per boot validation pass — outcome lookups reuse these sets
-    # instead of re-mapping Exclusion / ExternalException on every outcome.
-    registries = {
-      exclusion: Exclusion.valid_values.map(&:to_sym),
-      exception: ExternalException.all.map { |registry_entry| registry_entry[:id] }
-    }
+    # Snapshot the valid keys once per boot validation pass.
+    valid_outcomes = Determination::REASON_CODE_MAPPING.keys
 
     entries.each do |entry|
       klass = validate_adapter_class!(entry)
       outcomes = fetch_declared_outcomes!(entry, klass)
-      validate_outcome_ids!(entry, outcomes, registries)
+      validate_outcome_ids!(entry, outcomes, valid_outcomes)
     end
   end
 
@@ -174,27 +161,14 @@ module VerificationDataSourcesLoader
     declared
   end
 
-  # Every declared outcome must be a known exclusion or external-exception id.
-  # CE ids are not membership-checked yet (no CE registry); until that lands,
-  # outcomes that are neither exclusion nor exception raise so typos fail loudly
-  # rather than being silently treated as CE.
-  def validate_outcome_ids!(entry, outcomes, registries)
-    unknown = outcomes.reject { |outcome| outcome_category(outcome, registries) }
+  # Every declared outcome must be a known Determination reason-code key;
+  # unknown keys raise so typos fail loudly at boot.
+  def validate_outcome_ids!(entry, outcomes, valid_outcomes)
+    unknown = outcomes - valid_outcomes
     return if unknown.empty?
 
-    known = registries[:exclusion] + registries[:exception]
     raise ConfigurationError,
       "verification_data_sources.#{entry[:id]}: .declared_outcomes references unknown id(s) #{unknown.map(&:to_s)}; " \
-      "valid ids are Exclusion.valid_values and ExternalException registry entries " \
-      "(#{known.map(&:to_s).sort})"
-  end
-
-  # The category an outcome belongs to, or nil when it is in neither registry.
-  # Exclusion takes precedence should an id ever appear in both (it should not).
-  def outcome_category(outcome, registries)
-    return :exclusion if registries[:exclusion].include?(outcome)
-    return :exception if registries[:exception].include?(outcome)
-
-    nil
+      "valid ids are Determination::REASON_CODE_MAPPING keys (#{valid_outcomes.map(&:to_s).sort})"
   end
 end

--- a/reporting-app/config/custom/verification_data_sources.yml
+++ b/reporting-app/config/custom/verification_data_sources.yml
@@ -39,9 +39,9 @@
 # The loader validates at boot and raises a ConfigurationError naming the
 # offending entry for: a missing/blank required key; an adapter_class that does
 # not constantize (or is not a Verification::DataSource subclass); a missing /
-# malformed .declared_outcomes; a declared outcome absent from Exclusion /
-# ExternalException registries; a non-Integer order; or two sources sharing an
-# order (call order must be unambiguous). Unknown keys are ignored.
+# malformed .declared_outcomes; a declared outcome that is not a
+# Determination::REASON_CODE_MAPPING key; a non-Integer order; or two sources
+# sharing an order (call order must be unambiguous). Unknown keys are ignored.
 #
 # ## Examples
 #
@@ -64,7 +64,11 @@
 #
 # ## Empty-file note
 #
-# If you want to ship no overrides, leave the empty hash below as-is, or delete
+# If you want to ship no overrides, leave an empty hash (`{}`) here, or delete
 # the file entirely — the loader treats a missing file as no overrides.
 
-{}
+# Mock data source for use by ExclusionDeterminationService.
+mock_drug_treatment:
+  enabled: true
+  adapter_class: "Verification::Adapters::MockDrugTreatment"
+  order: null

--- a/reporting-app/spec/services/verification/adapters/mock_drug_treatment_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/mock_drug_treatment_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Mock verification data source used to demonstrate the dynamic data-source call
+# in ExclusionDeterminationService. It derives its outcome purely from the LAST
+# DIGIT of the member's va_icn, so specs can drive every branch deterministically:
+#
+#   * absent ICN                       -> :skipped (precondition not met)
+#   * ICN not ending in a digit        -> :success, no outcomes ("no result")
+#   * last digit divisible by 3        -> :success, [:drug_treatment]        (exclusion)
+#   * last digit odd, not divisible by 3 -> :success, [:was_in_drug_treatment] (exception)
+#   * last digit even, not divisible by 3 -> :success, no outcomes           (no result)
+#
+# Only the last digit matters, so "13" is excluded (last digit 3) while "12" is a
+# no-result (last digit 2), even though 12 is the one divisible by 3 as a whole
+# number. Outcomes are Determination::REASON_CODE_MAPPING keys (the "emit the
+# key" convention): :drug_treatment maps to "drug_treatment_excluded" and
+# :was_in_drug_treatment maps to "drug_treatment_excepted".
+RSpec.describe Verification::Adapters::MockDrugTreatment do
+  subject(:result) { described_class.new.call(certification: certification) }
+
+  let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: va_icn)) }
+
+  describe ".declared_outcomes" do
+    it "declares the exclusion and exception outcome keys" do
+      expect(described_class.declared_outcomes).to contain_exactly(:drug_treatment, :was_in_drug_treatment)
+    end
+
+    it "declares only Determination reason-code mapping keys" do
+      expect(described_class.declared_outcomes).to all(be_in(Determination::REASON_CODE_MAPPING.keys))
+    end
+  end
+
+  describe "#call" do
+    context "when the ICN is absent" do
+      let(:va_icn) { nil }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the ICN is a blank string" do
+      let(:va_icn) { "" }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the ICN does not end in a digit (e.g. '12345V')" do
+      let(:va_icn) { "12345V" }
+
+      it_behaves_like "a successful verification result"
+
+      it "returns no result (empty outcomes)" do
+        expect(result.outcomes).to eq([])
+      end
+
+      it "tags the audit data with the source" do
+        expect(result.audit_data[:source]).to eq("mock_drug_treatment")
+      end
+    end
+
+    context "when the last digit is divisible by 3" do
+      context "when odd (e.g. '9')" do
+        let(:va_icn) { "9" }
+
+        it_behaves_like "a successful verification result"
+
+        it "emits the drug_treatment exclusion outcome" do
+          expect(result.outcomes).to eq([ :drug_treatment ])
+        end
+      end
+
+      context "when zero (e.g. '10')" do
+        let(:va_icn) { "10" }
+
+        it "emits the drug_treatment exclusion outcome" do
+          expect(result.outcomes).to eq([ :drug_treatment ])
+        end
+      end
+
+      context "when the whole number is not divisible by 3 (e.g. '13')" do
+        let(:va_icn) { "13" }
+
+        it "emits the drug_treatment exclusion outcome (last digit 3)" do
+          expect(result.outcomes).to eq([ :drug_treatment ])
+        end
+      end
+
+      context "with a realistic VA ICN ending in a divisible-by-3 digit" do
+        let(:va_icn) { "1012861229V078999" }
+
+        it "emits the drug_treatment exclusion outcome (last digit 9)" do
+          expect(result.outcomes).to eq([ :drug_treatment ])
+        end
+      end
+    end
+
+    context "when the last digit is odd and not divisible by 3" do
+      context "with '7'" do
+        let(:va_icn) { "7" }
+
+        it_behaves_like "a successful verification result"
+
+        it "emits the drug_treatment exception outcome" do
+          expect(result.outcomes).to eq([ :was_in_drug_treatment ])
+        end
+      end
+
+      context "with '25' (last digit 5)" do
+        let(:va_icn) { "25" }
+
+        it "emits the drug_treatment exception outcome" do
+          expect(result.outcomes).to eq([ :was_in_drug_treatment ])
+        end
+      end
+    end
+
+    context "when the last digit is even and not divisible by 3" do
+      context "with '8'" do
+        let(:va_icn) { "8" }
+
+        it_behaves_like "a successful verification result"
+
+        it "returns no result (empty outcomes)" do
+          expect(result.outcomes).to eq([])
+        end
+      end
+
+      context "with '12', whose last digit is 2 even though 12 is divisible by 3" do
+        let(:va_icn) { "12" }
+
+        it "returns no result (empty outcomes)" do
+          expect(result.outcomes).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/verification_data_sources_loader_spec.rb
+++ b/reporting-app/spec/services/verification_data_sources_loader_spec.rb
@@ -55,17 +55,6 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       end
     end
 
-    context "with an override that toggles a shipped source off" do
-      it "deep-merges: the override wins and unrelated keys are preserved" do
-        result = described_class.merge_with_defaults(
-          "va_disability_rating" => { "enabled" => false }
-        )
-        entry = result["va_disability_rating"]
-        expect(entry["enabled"]).to be(false)
-        expect(entry["adapter_class"]).to eq("Verification::Adapters::VaDisabilityRating")
-      end
-    end
-
     context "with an override that adds a new source" do
       it "produces all defaults plus the new entry" do
         result = described_class.merge_with_defaults(
@@ -230,7 +219,7 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       }.to raise_error(described_class::ConfigurationError, /must be a Verification::DataSource subclass/)
     end
 
-    it "raises when a declared outcome is not in Exclusion or ExternalException registries" do
+    it "raises when a declared outcome is not a Determination reason-code key" do
       stub_const("SpecFixtureSource", Class.new(Verification::DataSource) do
         def self.declared_outcomes
           [ :not_a_real_outcome ]
@@ -241,13 +230,14 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       )
       expect {
         described_class.validate_registry!(entries)
-      }.to raise_error(described_class::ConfigurationError, /unknown id\(s\).*not_a_real_outcome/)
+      }.to raise_error(described_class::ConfigurationError, /unknown.*not_a_real_outcome/)
     end
 
-    it "accepts a real exception outcome from the ExternalException registry" do
-      exception_id = ExternalException.all.first[:id]
+    it "accepts a reason-code key that maps to an exclusion fact" do
       stub_const("SpecFixtureSource", Class.new(Verification::DataSource) do
-        define_singleton_method(:declared_outcomes) { [ exception_id ] }
+        def self.declared_outcomes
+          [ :drug_treatment ]
+        end
       end)
       entries = described_class.transform(
         "src" => source_attrs("adapter_class" => "SpecFixtureSource")
@@ -255,10 +245,23 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       expect { described_class.validate_registry!(entries) }.not_to raise_error
     end
 
-    it "accepts order for a source with exception and exclusion outcomes" do
-      exception_id = ExternalException.all.first[:id]
+    it "accepts a reason-code key that maps to an exception fact" do
       stub_const("SpecFixtureSource", Class.new(Verification::DataSource) do
-        define_singleton_method(:declared_outcomes) { [ exception_id, :is_veteran_with_disability ] }
+        def self.declared_outcomes
+          [ :was_in_drug_treatment ]
+        end
+      end)
+      entries = described_class.transform(
+        "src" => source_attrs("adapter_class" => "SpecFixtureSource")
+      )
+      expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+
+    it "accepts order for a source mixing exception and exclusion reason-code keys" do
+      stub_const("SpecFixtureSource", Class.new(Verification::DataSource) do
+        def self.declared_outcomes
+          [ :was_in_drug_treatment, :is_veteran_with_disability ]
+        end
       end)
       entries = described_class.transform(
         "src" => source_attrs("adapter_class" => "SpecFixtureSource", "order" => 10)
@@ -283,7 +286,7 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       merged = described_class.merge_with_defaults(overrides)
       entries = described_class.transform(merged)
 
-      expect(entries.map { |e| e[:id] }).to include(:va_disability_rating)
+      expect(entries.map { |e| e[:id] }).to include(:mock_drug_treatment)
       expect { described_class.validate_registry!(entries) }.not_to raise_error
     end
   end
@@ -293,12 +296,12 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       sources = Rails.application.config.verification_data_sources
       expect(sources).to be_an(Array)
 
-      va = sources.find { |s| s[:id] == :va_disability_rating }
-      expect(va[:enabled]).to be(true)
-      expect(va[:adapter_class]).to eq("Verification::Adapters::VaDisabilityRating")
-      expect(va).not_to have_key(:checks)
-      expect(Verification::Adapters::VaDisabilityRating.declared_outcomes)
-        .to eq([ :is_veteran_with_disability ])
+      mock = sources.find { |s| s[:id] == :mock_drug_treatment }
+      expect(mock[:enabled]).to be(true)
+      expect(mock[:adapter_class]).to eq("Verification::Adapters::MockDrugTreatment")
+      expect(mock).not_to have_key(:checks)
+      expect(Verification::Adapters::MockDrugTreatment.declared_outcomes)
+        .to eq([ :drug_treatment, :was_in_drug_treatment ])
     end
   end
 end


### PR DESCRIPTION
## Ticket

Sets up #767

## Changes

- Add `Verification::Adapters::MockDrugTreatment`, a mock verification data source that derives a drug-treatment exclusion/exception outcome from the last digit of the member's VA ICN.
- Switch `VerificationDataSourcesLoader` registry validation from the Exclusion / ExternalException id registries to `Determination::REASON_CODE_MAPPING` keys (the "emit the key" convention), so a source may declare exception-fact outcomes (e.g. `:was_in_drug_treatment`) that are not exclusion ids.
- Empty `DEFAULTS` — OSCER ships no default sources; deployments register their own via the override file. Register the demo mock in `config/custom/verification_data_sources.yml`.

## Context for reviewers

- Foundation slice: nothing consults these sources yet. The mock is registered and boot-validated but inert — there is no behavior change until a later change wires `ExclusionDeterminationService` to consult data sources.
- `Verification::Adapters::VaDisabilityRating` is deliberately removed from `DEFAULTS`. It was registered but never actually consulted; dropping it keeps the follow-up service change from silently activating it. The class itself is untouched.

## Testing

- `make test args="spec/services/verification_data_sources_loader_spec.rb spec/services/verification/adapters/mock_drug_treatment_spec.rb"` → 83 examples, 0 failures.
- `make lint` clean.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->