### PR TITLE
OSCER-767: Consult verification data sources in exclusion determination

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -46,6 +46,7 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   # --- Transitions: External exclusion check ---
   transition(EXTERNAL_EXCLUSION_CHECK_STEP, "DeterminedNotExcluded", EXTERNAL_EXCEPTION_CHECK_STEP)
   transition(EXTERNAL_EXCLUSION_CHECK_STEP, "DeterminedExcluded", END_STEP)
+  transition(EXTERNAL_EXCLUSION_CHECK_STEP, "DeterminedExcepted", END_STEP)
 
   # --- Transitions: External exception check ---
   # DeterminedExcepted: case ends (member need not report).

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -3,28 +3,108 @@
 class ExclusionDeterminationService
   include Strata::VirtualActor
   class << self
-    # Called by CertificationBusinessProcess at EXTERNAL_EXCLUSION_CHECK_STEP
-    # Service handles: evaluation, recording via model, and publishing events
-    # Business process handles: transitions and notifications
+    # Called by CertificationBusinessProcess at EXTERNAL_EXCLUSION_CHECK_STEP.
+    #
+    # Takes the highest-priority exclusion from the rules engine, then lets the
+    # verification data sources improve on it. Records an exclusion if one
+    # applies, otherwise an exception if a source emitted one, otherwise nothing.
+    #
+    # Service handles: evaluation, recording via model, and publishing events.
+    # Business process handles: transitions and notifications.
     # @param kase [CertificationCase]
     def determine(kase)
       certification = Certification.find(kase.certification_id)
-      eligibility_fact = evaluate_exclusion_eligibility(certification)
 
-      if eligibility_fact.value
-        kase.record_exclusion_determination([ highest_priority_reason_code(eligibility_fact) ], self)
-        Strata::EventManager.publish("DeterminedExcluded", { case_id: kase.id, certification_id: kase.certification_id })
+      current_best = rules_engine_best_exclusion(certification)
+      current_best, exception_keys = consult_data_sources(certification, current_best)
+
+      if current_best
+        kase.record_exclusion_determination([ reason_code(current_best[:key]) ], self)
+        publish(kase, "DeterminedExcluded")
+      elsif exception_keys.any?
+        kase.record_exception_determination([ reason_code(exception_keys.first) ], self)
+        publish(kase, "DeterminedExcepted")
       else
-        Strata::AuditLog.write!(
-          action: "case.exclusion.denied",
-          actor: self,
-          subject: certification,
-        )
-        Strata::EventManager.publish("DeterminedNotExcluded", { case_id: kase.id, certification_id: kase.certification_id })
+        Strata::AuditLog.write!(action: "case.exclusion.denied", actor: self, subject: certification)
+        publish(kase, "DeterminedNotExcluded")
       end
     end
 
     private
+
+    def publish(kase, event)
+      Strata::EventManager.publish(event, { case_id: kase.id, certification_id: kase.certification_id })
+    end
+
+    # The highest-priority exclusion (lowest priority number) the rules engine
+    # found, as { key:, priority: }, or nil when none applies.
+    def rules_engine_best_exclusion(certification)
+      eligibility_fact = evaluate_exclusion_eligibility(certification)
+      return nil unless eligibility_fact.value
+
+      eligibility_fact.reasons
+        .select(&:value)
+        .map { |fact| { key: fact.name, priority: exclusion_priority(fact.name) } }
+        .min_by { |scored| scored[:priority] }
+    end
+
+    # Walks the enabled data sources by best declared priority first, calling one
+    # only while the best exclusion it could emit could still outrank the running
+    # best. Returns the (possibly improved) best exclusion and any exception
+    # outcomes emitted along the way. Exception-only sources are skipped here.
+    def consult_data_sources(certification, current_best)
+      exception_keys = []
+
+      candidates = data_sources
+        .map { |source| { source: source, priority: best_declared_priority(source) } }
+        .select { |candidate| candidate[:priority] }
+        .sort_by { |candidate| candidate[:priority] }
+
+      candidates.each do |candidate|
+        break unless outranks?(candidate, current_best)
+
+        result = candidate[:source].new.call(certification: certification)
+        emitted = best_exclusion(result.outcomes)
+        current_best = emitted if emitted && outranks?(emitted, current_best)
+        exception_keys.concat(exception_outcomes(result.outcomes))
+      end
+
+      [ current_best, exception_keys ]
+    end
+
+    def data_sources
+      Rails.application.config.verification_data_sources
+        .select { |entry| entry[:enabled] }
+        .map { |entry| entry[:adapter_class].constantize }
+    end
+
+    def best_declared_priority(source)
+      source.declared_outcomes.filter_map { |key| exclusion_priority_or_nil(key) }.min
+    end
+
+    # The highest-priority exclusion among emitted outcome keys, as { key:,
+    # priority: }, or nil when none resolve to an exclusion.
+    def best_exclusion(outcomes)
+      outcomes
+        .map { |key| { key: key, priority: exclusion_priority_or_nil(key) } }
+        .select { |scored| scored[:priority] }
+        .min_by { |scored| scored[:priority] }
+    end
+
+    # Emitted outcome keys that are not exclusions (e.g. the *_excepted facts).
+    def exception_outcomes(outcomes)
+      outcomes.reject { |key| exclusion_priority_or_nil(key) }
+    end
+
+    # Lower priority number wins; nil current_best means nothing yet, so any
+    # candidate outranks it. Both are { priority: } hashes.
+    def outranks?(candidate, current_best)
+      current_best.nil? || candidate[:priority] < current_best[:priority]
+    end
+
+    def reason_code(key)
+      Determination::REASON_CODE_MAPPING.fetch(key)
+    end
 
     def evaluate_exclusion_eligibility(certification)
       ruleset = Rules::ExclusionRuleset.new
@@ -48,16 +128,6 @@ class ExclusionDeterminationService
       engine.evaluate(:eligible_for_exclusion)
     end
 
-    # Of the exclusions that evaluated true, return the reason code of the single
-    # highest-priority one (lowest Exclusion priority number wins).
-    def highest_priority_reason_code(eligibility_fact)
-      best_fact = eligibility_fact.reasons
-        .select(&:value)
-        .min_by { |fact| exclusion_priority(fact.name) }
-
-      Determination::REASON_CODE_MAPPING.fetch(best_fact.name)
-    end
-
     # Ruled exclusion ids match their ruleset fact names, so the fact name is the
     # config id. Raises (naming the fact) if a fact has no configured exclusion —
     # the fail-loud drift guard for the fact/config seam.
@@ -65,6 +135,11 @@ class ExclusionDeterminationService
       exclusion = Exclusion.find(fact_name) ||
         raise(KeyError, "no configured exclusion for fact #{fact_name.inspect}")
       exclusion.fetch(:priority)
+    end
+
+    # Non-raising sibling of exclusion_priority: nil for non-exclusion keys.
+    def exclusion_priority_or_nil(key)
+      Exclusion.find(key)&.fetch(:priority)
     end
 
     def extract_attribute(certification, attribute)

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -64,6 +64,7 @@ class ExclusionDeterminationService
         break unless outranks?(candidate, current_best)
 
         result = candidate[:source].new.call(certification: certification)
+        # TODO: Handle failure OSCAR-810
         emitted = best_exclusion(result.outcomes)
         current_best = emitted if emitted && outranks?(emitted, current_best)
         exception_keys.concat(exception_outcomes(result.outcomes))

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
         expect(certification_case).to be_open
       end
     end
+
+    context 'when a data source yields an exception during the exclusion check' do
+      it 'transitions to end' do
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::EXTERNAL_EXCLUSION_CHECK_STEP)
+
+        # ExclusionDeterminationService can now record an exception (rather than an exclusion)
+        # when the only surviving data-source outcome is an exception.
+        Strata::EventManager.publish("DeterminedExcepted", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
+      end
+    end
   end
 
   describe 'external_exception_check' do

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ExclusionDeterminationService do
 
     # The single Determination recorded on the excluded path (nil when not excluded).
     def recorded_exclusion
-      Determination.where(subject: certification, outcome: "excluded").first
+      Determination.where(subject: certification, outcome: "excluded").order(created_at: :desc).first
     end
 
     context 'when a single exclusion applies' do
@@ -301,7 +301,7 @@ RSpec.describe ExclusionDeterminationService do
       end
 
       context 'without any matching condition' do
-        let(:member_data) { build(:certification_member_data, race_ethnicity: "white", cert_date:) }
+        let(:member_data) { build(:certification_member_data, cert_date:) }
 
         it 'publishes DeterminedNotExcluded and leaves the case open' do
           service.determine(kase)
@@ -343,6 +343,267 @@ RSpec.describe ExclusionDeterminationService do
 
       context 'when 65 or older with no other exclusion' do
         let(:member_data) { build(:certification_member_data, date_of_birth: cert_date - 65.years, race_ethnicity: "white", cert_date:) }
+
+        it 'publishes DeterminedNotExcluded' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        end
+      end
+    end
+  end
+
+  # After the rules engine runs, the service consults the registered verification
+  # data sources. A source is only called when the best exclusion it could emit
+  # (the highest-priority Exclusion among its declared reason-code keys) could
+  # outrank the exclusion the rules engine already found. When a called source
+  # emits a higher-priority exclusion it wins; when the only surviving outcome is
+  # an exception the service records it as an exception instead.
+  describe '#determine consulting verification data sources' do
+    let(:cert_date) { Date.new(2025, 7, 1) }
+    let(:certification) do
+      create(
+        :certification,
+        member_data: member_data,
+        certification_requirements: build(:certification_certification_requirements, certification_date: cert_date)
+      )
+    end
+    let(:kase) { create(:certification_case, certification_id: certification.id) }
+    # Records which fixture sources actually had #call invoked (used to assert gating).
+    let(:calls) { [] }
+
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+      allow(NotificationService).to receive(:send_email_notification)
+    end
+
+    def recorded_exclusion
+      Determination.where(subject: certification, outcome: "excluded").order(created_at: :desc).first
+    end
+
+    def recorded_exception
+      Determination.where(subject: certification, outcome: "excepted").order(created_at: :desc).first
+    end
+
+    # Anonymous Verification::DataSource subclass: declares `declared` outcome
+    # keys and, when called, records the call and returns a success result
+    # emitting `emits`. #call is overridden directly so tests need not set up a
+    # precondition — the point under test is the service's call/gate decision.
+    def fixture_source(declared:, emits:)
+      recorder = calls
+      Class.new(Verification::DataSource) do
+        define_singleton_method(:declared_outcomes) { declared }
+        define_method(:call) do |certification:|
+          recorder << self.class.name
+          Verification::DataSourceResult.success(outcomes: emits, audit_data: { source: self.class.name })
+        end
+      end
+    end
+
+    # Registers `sources` (Array of [const_name, klass, opts]) as the verification
+    # data source registry for this example.
+    def register(*sources)
+      entries = sources.map do |name, klass, opts|
+        stub_const(name, klass)
+        { id: name.underscore.to_sym, enabled: opts.fetch(:enabled, true), adapter_class: name, order: opts[:order] }
+      end
+      allow(Rails.application.config).to receive(:verification_data_sources).and_return(entries)
+    end
+
+    context 'when a source cannot outrank the exclusion the rules engine found' do
+      # Rules engine finds AIAN (priority 10); the source could at best emit
+      # drug_treatment (priority 70), so it is never called.
+      let(:member_data) { build(:certification_member_data, race_ethnicity: "american_indian_or_alaska_native", cert_date:) }
+
+      before do
+        register([ "LowerPotentialSource", fixture_source(declared: [ :drug_treatment ], emits: [ :drug_treatment ]), {} ])
+      end
+
+      it 'does not call the source' do
+        service.determine(kase)
+        expect(calls).to be_empty
+      end
+
+      it 'records the rules-engine exclusion' do
+        service.determine(kase)
+        expect(recorded_exclusion.reasons).to eq([ "american_indian_alaska_native_excluded" ])
+      end
+    end
+
+    context 'when a source can outrank the rules-engine exclusion and emits it' do
+      # Rules engine finds pregnancy (80); the source's best declared exclusion, veteran-disability (30), outranks it.
+      let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, cert_date:) }
+
+      before do
+        register([ "VeteranSource", fixture_source(declared: [ :is_veteran_with_disability ], emits: [ :is_veteran_with_disability ]), {} ])
+      end
+
+      it 'calls the source and records its higher-priority exclusion' do
+        service.determine(kase)
+        expect(calls).to eq([ "VeteranSource" ])
+        expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+      end
+    end
+
+    context 'when a source is called but emits nothing that outranks the rules engine' do
+      let(:member_data) { build(:certification_member_data, pregnancy_due_or_parturition_date: cert_date, cert_date:) }
+
+      before do
+        register([ "VeteranSource", fixture_source(declared: [ :is_veteran_with_disability ], emits: []), {} ])
+      end
+
+      it 'keeps the rules-engine exclusion' do
+        service.determine(kase)
+        expect(calls).to eq([ "VeteranSource" ])
+        expect(recorded_exclusion.reasons).to eq([ "pregnancy_excluded" ])
+      end
+    end
+
+    context 'with two candidate sources' do
+      # No rules-engine exclusion (white, no signals), so both sources are candidates.
+      let(:member_data) { build(:certification_member_data, cert_date:) }
+
+      context 'when the stronger source emits an outcome weaker than the second source could emit' do
+        # source1 best declared AIAN (10) but emits medically_frail (40); source2 best declared veteran (30).
+        # 40 is weaker than 30, so source2 is called and wins.
+        before do
+          register(
+            [ "FirstSource", fixture_source(declared: [ :is_american_indian_or_alaska_native, :medically_frail ], emits: [ :medically_frail ]), {} ],
+            [ "SecondSource", fixture_source(declared: [ :is_veteran_with_disability ], emits: [ :is_veteran_with_disability ]), {} ]
+          )
+        end
+
+        it 'calls both sources and records the second source’s higher-priority exclusion' do
+          service.determine(kase)
+          expect(calls).to contain_exactly("FirstSource", "SecondSource")
+          expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+        end
+      end
+
+      context 'when the stronger source emits an outcome stronger than the second source could emit' do
+        # source1 best declared AIAN (10), emits veteran (30); source2 best declared medically_frail (40).
+        # 30 already beats 40, so source2 is never called.
+        before do
+          register(
+            [ "FirstSource", fixture_source(declared: [ :is_american_indian_or_alaska_native, :is_veteran_with_disability ], emits: [ :is_veteran_with_disability ]), {} ],
+            [ "SecondSource", fixture_source(declared: [ :medically_frail ], emits: [ :medically_frail ]), {} ]
+          )
+        end
+
+        it 'records the first source’s exclusion without calling the second' do
+          service.determine(kase)
+          expect(calls).to eq([ "FirstSource" ])
+          expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+        end
+      end
+    end
+
+    context 'when the only surviving outcome is an exception' do
+      # No rules-engine exclusion; the source could emit drug_treatment (70) so it is
+      # called, but it emits the exception outcome instead.
+      let(:member_data) { build(:certification_member_data, cert_date:) }
+
+      before do
+        register([ "DrugTreatmentSource", fixture_source(declared: [ :drug_treatment, :was_in_drug_treatment ], emits: [ :was_in_drug_treatment ]), {} ])
+      end
+
+      it 'records an exception rather than an exclusion' do
+        service.determine(kase)
+        expect(recorded_exclusion).to be_nil
+        expect(recorded_exception.reasons).to eq([ "drug_treatment_excepted" ])
+      end
+
+      it 'publishes DeterminedExcepted and closes the case' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedExcepted', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(kase.reload.status).to eq("closed")
+      end
+    end
+
+    context 'when a called source emits nothing at all' do
+      let(:member_data) { build(:certification_member_data, cert_date:) }
+
+      before do
+        register([ "DrugTreatmentSource", fixture_source(declared: [ :drug_treatment ], emits: []), {} ])
+      end
+
+      it 'publishes DeterminedNotExcluded and records nothing' do
+        service.determine(kase)
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        expect(recorded_exclusion).to be_nil
+        expect(recorded_exception).to be_nil
+      end
+    end
+
+    context 'when a source is disabled' do
+      let(:member_data) { build(:certification_member_data, cert_date:) }
+
+      before do
+        register([ "DisabledSource", fixture_source(declared: [ :is_veteran_with_disability ], emits: [ :is_veteran_with_disability ]), { enabled: false } ])
+      end
+
+      it 'is never called' do
+        service.determine(kase)
+        expect(calls).to be_empty
+        expect(recorded_exclusion).to be_nil
+      end
+    end
+
+    context 'when a source declares no exclusion outcomes' do
+      # An exception-only source declares no exclusion, so the exclusion check
+      # never calls it — its exception is left for the external exception check.
+      let(:member_data) { build(:certification_member_data, cert_date:) }
+
+      before do
+        register([ "ExceptionOnlySource", fixture_source(declared: [ :was_in_drug_treatment ], emits: [ :was_in_drug_treatment ]), {} ])
+      end
+
+      it 'is never called and yields no determination here' do
+        service.determine(kase)
+        expect(calls).to be_empty
+        expect(recorded_exclusion).to be_nil
+        expect(recorded_exception).to be_nil
+        expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+      end
+    end
+
+    context 'with the real MockDrugTreatment data source' do
+      let(:member_data) { build(:certification_member_data, va_icn: va_icn, cert_date:) }
+
+      before do
+        allow(Rails.application.config).to receive(:verification_data_sources).and_return(
+          [ { id: :mock_drug_treatment, enabled: true, adapter_class: "Verification::Adapters::MockDrugTreatment", order: nil } ]
+        )
+      end
+
+      context 'when the ICN is divisible by 3' do
+        let(:va_icn) { "9" }
+
+        it 'records the drug_treatment exclusion' do
+          service.determine(kase)
+          expect(recorded_exclusion.reasons).to eq([ "drug_treatment_excluded" ])
+        end
+      end
+
+      context 'when the ICN is odd and not divisible by 3' do
+        let(:va_icn) { "7" }
+
+        it 'records the drug_treatment exception' do
+          service.determine(kase)
+          expect(recorded_exception.reasons).to eq([ "drug_treatment_excepted" ])
+        end
+      end
+
+      context 'when the ICN is even and not divisible by 3' do
+        let(:va_icn) { "8" }
+
+        it 'publishes DeterminedNotExcluded' do
+          service.determine(kase)
+          expect(Strata::EventManager).to have_received(:publish).with('DeterminedNotExcluded', { case_id: kase.id, certification_id: kase.certification_id })
+        end
+      end
+
+      context 'when the ICN is absent (source skipped)' do
+        let(:va_icn) { nil }
 
         it 'publishes DeterminedNotExcluded' do
           service.determine(kase)


### PR DESCRIPTION
## Ticket

Resolves #767

## Changes

- `ExclusionDeterminationService` now consults the registered verification data sources after the rules engine. It starts from the rules engine's highest-priority exclusion, then walks the enabled sources by best declared priority first, calling a source only while the best exclusion it could emit could still outrank the running best (stopping early once none can). A source that emits a higher-priority exclusion wins.
- Added an exception fallback: when no exclusion applies but a source emitted an exception outcome (a non-exclusion key such as the `*_excepted` facts), the case is recorded as an exception and `DeterminedExcepted` is published.
- Added the `EXTERNAL_EXCLUSION_CHECK_STEP → DeterminedExcepted → END_STEP` transition to `CertificationBusinessProcess` so the exception fallback ends the case cleanly.

## Context for reviewers

Second and final slice of #767. The foundation slice (#807) added the mock data source, switched loader validation to emit-the-key, and left the registry inert. This slice wires the sources into the determination path; it depends on that foundation, now on `main`.

Key points in `ExclusionDeterminationService`:
- `rules_engine_best_exclusion` returns the engine's best exclusion as a `{ key:, priority: }` hash (lowest priority number wins), or `nil`.
- `consult_data_sources` sorts source candidates by `best_declared_priority` (min exclusion priority across a source's declared outcome keys; exception-only keys don't count), then gates each call with `outranks?` so a source is instantiated and called only when it could still beat the current best.
- `exclusion_priority_or_nil` is the non-raising sibling of `exclusion_priority`, used to distinguish exclusion keys from exception keys without tripping the fail-loud drift guard.

`ExclusionDeterminationService` was deliberately **not** renamed — see the exemption/exclusion/exception legal-term distinction.

Out of scope: recording *which* data source produced the winning outcome. The determination stores only the reason code, not the originating source; persisting source provenance is deferred.

## Testing

- `make test` — 2972 examples, 0 failures (line 96.68% / branch 84.15%).
- `make lint` — 553 files, no offenses.

New/expanded specs cover: rules-engine-only exclusion, a source improving on the engine's exclusion, early-stop when no source can outrank, the exception fallback path, and the new `DeterminedExcepted` transition in `certification_business_process_spec`.

Manual demo verification of the `MockDrugTreatment` source, driving the outcome via the certification's `va_icn` last digit:
- **Non-integer ICN** (no result emitted) → no exclusion or exception; case proceeds to the reporting step.
- **ICN ending in a digit divisible by 3** (emits `drug_treatment`) → case excluded.
- **ICN ending in an odd digit not divisible by 3** (emits `was_in_drug_treatment`) → case excepted (exception fallback).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->