### PR TITLE
OSCER-809: Propagate matched data source to certification outcome

### DIFF
--- a/reporting-app/app/models/api/certifications/outcome.rb
+++ b/reporting-app/app/models/api/certifications/outcome.rb
@@ -18,7 +18,7 @@ class Api::Certifications::Outcome < ValueObject
     else
       obj.status = determination.outcome
       obj.reason = determination.reasons.first
-      obj.source = determination.automated? ? "api" : "member"
+      obj.source = determination.source
     end
     obj
   end

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -187,8 +187,18 @@ class CertificationCase < Strata::Case
   # Model only handles state changes - service handles selection and events
   # @param reason_codes [Array<String>] reason code(s) for the selected exclusion
   # @param actor [Strata::VirtualActor] recording the exclusion
-  def record_exclusion_determination(reason_codes, actor)
+  # @param data_source [String] origin of the exclusion — a verification data source id, or Determination::API_SOURCE
+  def record_exclusion_determination(reason_codes, actor, data_source)
     certification = Certification.find(certification_id)
+
+    # determination_data is a jsonb column holding a structured Hash (OSCER convention; see the
+    # Determination docs). For automated exclusions the type is carried by the reason codes, which
+    # the dashboard reads via decision_method branching, so we record those codes here. It must stay
+    # a Hash: writing a JSON String (e.g. reasons.to_json) double-encodes into the jsonb column and
+    # reads back as a String, which 500'd the member dashboard. See
+    # https://github.com/navapbc/oscer/issues/680. Api::Certifications::Outcome surfaces
+    # "data_source" as the outcome source.
+    determination_data = { "exclusion_reasons" => reason_codes, "data_source" => data_source }
 
     transaction do
       self.exemption_request_approval_status = "approved"
@@ -199,13 +209,7 @@ class CertificationCase < Strata::Case
         decision_method: :automated,
         reasons: reason_codes,
         outcome: :excluded,
-        # determination_data is a jsonb column holding a structured Hash (OSCER convention; see
-        # the Determination docs). For automated exclusions the type is carried by the reason
-        # codes, which the dashboard reads via decision_method branching, so we record those
-        # codes here. It must stay a Hash: writing a JSON String (e.g. reasons.to_json)
-        # double-encodes into the jsonb column and reads back as a String, which 500'd the
-        # member dashboard. See https://github.com/navapbc/oscer/issues/680.
-        determination_data: { "exclusion_reasons" => reason_codes },
+        determination_data: determination_data,
         determined_at: certification.certification_requirements.certification_date,
         actor:
       )
@@ -217,8 +221,15 @@ class CertificationCase < Strata::Case
   #
   # @param reason_codes [Array<String>] reason codes for the matched exception check(s)
   # @param actor [Strata::VirtualActor] recording the exception
-  def record_exception_determination(reason_codes, actor)
+  # @param data_source [String, nil] id of the verification data source, when available
+  def record_exception_determination(reason_codes, actor, data_source: nil)
     certification = Certification.find(certification_id)
+
+    # determination_data is a jsonb column holding a structured Hash (OSCER convention; must stay a
+    # Hash, not a JSON String — see record_exclusion_determination). The exception type is carried by
+    # the reason codes, recorded here.
+    determination_data = { "exception_reasons" => reason_codes }
+    determination_data["data_source"] = data_source if data_source.present?
 
     transaction do
       close!
@@ -227,10 +238,7 @@ class CertificationCase < Strata::Case
         decision_method: :automated,
         reasons: reason_codes,
         outcome: :excepted,
-        # determination_data is a jsonb column holding a structured Hash (OSCER convention; must
-        # stay a Hash, not a JSON String — see record_exclusion_determination). The exception type
-        # is carried by the reason codes, recorded here.
-        determination_data: { "exception_reasons" => reason_codes },
+        determination_data: determination_data,
         determined_at: certification.certification_requirements.certification_date,
         actor:
       )

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -61,6 +61,11 @@ class Determination < Strata::Determination
   SATISFIED_BY_NEITHER = "neither"
   CALCULATION_METHOD_AUTOMATED_INCOME_INTAKE = "automated_income_intake"
 
+  # Values for +source+ naming an origin inside the system rather than an external verification
+  # data source: the API supplied the data, or a member or staff user entered it.
+  API_SOURCE = "api"
+  MEMBER_SOURCE = "member"
+
   REASON_CODE_MAPPING = {
     age_under_19: "age_under_19_excluded",
     age_over_65: "age_over_65_excluded",
@@ -138,5 +143,15 @@ class Determination < Strata::Determination
     return nil if determination_data.blank?
 
     determination_data.stringify_keys["calculation_type"].presence
+  end
+
+  # Origin of the determination, for reporting (e.g. the API outcome). Prefers the origin its writer
+  # named under +determination_data["data_source"]+ — a verification data source id, or +API_SOURCE+.
+  # Falls back to actor provenance for the writers that record no source
+  # (ExceptionDeterminationService, the CE compliance and exemption paths) and for legacy rows
+  # predating the key. Reads defensively since JSONB rows come back with string keys.
+  # @return [String]
+  def source
+    determination_data&.stringify_keys&.dig("data_source").presence || (automated? ? API_SOURCE : MEMBER_SOURCE)
   end
 end

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -2,6 +2,7 @@
 
 class ExclusionDeterminationService
   include Strata::VirtualActor
+
   class << self
     # Called by CertificationBusinessProcess at EXTERNAL_EXCLUSION_CHECK_STEP.
     #
@@ -16,13 +17,14 @@ class ExclusionDeterminationService
       certification = Certification.find(kase.certification_id)
 
       current_best = rules_engine_best_exclusion(certification)
-      current_best, exception_keys = consult_data_sources(certification, current_best)
+      current_best, exceptions = consult_data_sources(certification, current_best)
 
       if current_best
-        kase.record_exclusion_determination([ reason_code(current_best[:key]) ], self)
+        kase.record_exclusion_determination([ reason_code(current_best[:key]) ], self, current_best[:source])
         publish(kase, "DeterminedExcluded")
-      elsif exception_keys.any?
-        kase.record_exception_determination([ reason_code(exception_keys.first) ], self)
+      elsif exceptions.any?
+        first = exceptions.first
+        kase.record_exception_determination([ reason_code(first[:key]) ], self, data_source: first[:source])
         publish(kase, "DeterminedExcepted")
       else
         Strata::AuditLog.write!(action: "case.exclusion.denied", actor: self, subject: certification)
@@ -37,7 +39,8 @@ class ExclusionDeterminationService
     end
 
     # The highest-priority exclusion (lowest priority number) the rules engine
-    # found, as { key:, priority: }, or nil when none applies.
+    # found, as { key:, priority:, source: }, or nil when none applies. Its facts
+    # come from API-supplied member data, so it names Determination::API_SOURCE.
     def rules_engine_best_exclusion(certification)
       eligibility_fact = evaluate_exclusion_eligibility(certification)
       return nil unless eligibility_fact.value
@@ -46,14 +49,16 @@ class ExclusionDeterminationService
         .select(&:value)
         .map { |fact| { key: fact.name, priority: exclusion_priority(fact.name) } }
         .min_by { |scored| scored[:priority] }
+        &.merge(source: Determination::API_SOURCE)
     end
 
     # Walks the enabled data sources by best declared priority first, calling one
     # only while the best exclusion it could emit could still outrank the running
     # best. Returns the (possibly improved) best exclusion and any exception
-    # outcomes emitted along the way. Exception-only sources are skipped here.
+    # outcomes emitted along the way, each tagged with the emitting source's id.
+    # Exception-only sources are skipped here.
     def consult_data_sources(certification, current_best)
-      exception_keys = []
+      exceptions = []
 
       candidates = data_sources
         .map { |source| { source: source, priority: best_declared_priority(source) } }
@@ -65,12 +70,14 @@ class ExclusionDeterminationService
 
         result = candidate[:source].new.call(certification: certification)
         # TODO: Handle failure OSCAR-810
+        source_id = result.audit_data[:source]
+
         emitted = best_exclusion(result.outcomes)
-        current_best = emitted if emitted && outranks?(emitted, current_best)
-        exception_keys.concat(exception_outcomes(result.outcomes))
+        current_best = emitted.merge(source: source_id) if emitted && outranks?(emitted, current_best)
+        exception_outcomes(result.outcomes).each { |key| exceptions << { key: key, source: source_id } }
       end
 
-      [ current_best, exception_keys ]
+      [ current_best, exceptions ]
     end
 
     def data_sources

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
         expect(certification_case).to be_open
 
         # Step 2: System process determines applicant is eligible for exclusion
-        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], ExclusionDeterminationService)
+        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], ExclusionDeterminationService, Determination::API_SOURCE)
         Strata::EventManager.publish("DeterminedExcluded", { case_id: certification_case.id, certification_id: certification_case.certification_id })
         certification_case.reload
 

--- a/reporting-app/spec/models/api/certifications/outcome_spec.rb
+++ b/reporting-app/spec/models/api/certifications/outcome_spec.rb
@@ -25,12 +25,30 @@ RSpec.describe Api::Certifications::Outcome, type: :model do
                reasons: [ "age_under_19_excluded" ])
       end
 
-      it "returns status 'excluded' sourced from the API" do
+      it "returns status 'excluded' sourced from the API when no data source is recorded" do
         outcome = described_class.from_certification(certification)
 
         expect(outcome.status).to eq("excluded")
         expect(outcome.reason).to eq("age_under_19_excluded")
         expect(outcome.source).to eq("api")
+      end
+    end
+
+    context "when the exclusion determination recorded a matched verification data source" do
+      before do
+        create(:determination,
+               subject: certification,
+               outcome: "excluded",
+               decision_method: "automated",
+               reasons: [ "drug_treatment_excluded" ],
+               determination_data: { "exclusion_reasons" => [ "drug_treatment_excluded" ], "data_source" => "mock_drug_treatment" })
+      end
+
+      it "reports the data source as the outcome source" do
+        outcome = described_class.from_certification(certification)
+
+        expect(outcome.status).to eq("excluded")
+        expect(outcome.source).to eq("mock_drug_treatment")
       end
     end
 

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe CertificationCase, type: :model do
         Strata::AuditLine.where(action: 'case.exception.approved').count
       }.by(1)
     end
+
+    it 'records the matched data source in determination_data when one is given' do
+      certification_case.record_exception_determination(reason_codes, ExceptionDeterminationService, data_source: 'mock_drug_treatment')
+      determination = Determination.where(outcome: 'excepted').order(created_at: :desc).first
+      expect(determination.determination_data).to eq(
+        'exception_reasons' => reason_codes, 'data_source' => 'mock_drug_treatment'
+      )
+    end
+
+    it 'omits the data_source key when no source is given (member-data exception)' do
+      certification_case.record_exception_determination(reason_codes, ExceptionDeterminationService)
+      determination = Determination.where(outcome: 'excepted').order(created_at: :desc).first
+      expect(determination.determination_data).to eq('exception_reasons' => reason_codes)
+    end
   end
 
   describe '#accept_activity_report' do
@@ -70,7 +84,7 @@ RSpec.describe CertificationCase, type: :model do
     it 'records compliant determination' do
       certification_case.accept_activity_report(user, application_form)
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("hours_reported_compliant")
@@ -148,7 +162,7 @@ RSpec.describe CertificationCase, type: :model do
     it 'records not_compliant determination' do
       certification_case.deny_activity_report(user, application_form)
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("hours_reported_insufficient")
@@ -227,7 +241,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(certification_case.exemption_request_approval_status_updated_at).to be_present
       expect(certification_case).to be_closed
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("exemption_request_compliant")
@@ -241,7 +255,7 @@ RSpec.describe CertificationCase, type: :model do
 
       certification_case.accept_exemption_request(user, incarceration_form)
 
-      expect(Determination.first.determination_data).to eq({ "exemption_type" => "incarceration" })
+      expect(Determination.sole.determination_data).to eq({ "exemption_type" => "incarceration" })
     end
 
     it 'publishes DeterminedExempt event' do
@@ -306,7 +320,7 @@ RSpec.describe CertificationCase, type: :model do
     it 'records a compliant determination' do
       certification_case.accept_denial_response(user, application_form)
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("denial_response_convincing")
@@ -348,7 +362,7 @@ RSpec.describe CertificationCase, type: :model do
     it 'records a not_compliant determination' do
       certification_case.deny_denial_response(user, application_form)
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("denial_response_not_convincing")
@@ -413,7 +427,7 @@ RSpec.describe CertificationCase, type: :model do
     before { stub_const("MockSubmitter", Class.new { include Strata::VirtualActor }) }
 
     it 'sets approval status and closes case' do
-      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
+      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter, "api")
       certification_case.reload
 
       expect(certification_case.exemption_request_approval_status).to eq("approved")
@@ -424,14 +438,14 @@ RSpec.describe CertificationCase, type: :model do
     it "logs approved decision to audit log" do
       certification = Certification.find(certification_case.certification_id)
       expect do
-        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
+        certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter, "api")
       end.to change { Strata::AuditLine.where(subject: certification, actor_type: MockSubmitter.name, action: "case.exclusion.approved").count }.by(1)
     end
 
     it 'creates a determination that records the given reason code' do
-      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter)
+      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter, "api")
 
-      determination = Determination.first
+      determination = Determination.sole
 
       expect(determination.decision_method).to eq("automated")
       expect(determination.reasons).to eq([ "pregnancy_excluded" ])
@@ -441,7 +455,15 @@ RSpec.describe CertificationCase, type: :model do
       # String (writing reasons.to_json double-encodes it into a String — see #680). For
       # automated exclusions it records the granting reason codes.
       expect(determination.determination_data).to be_a(Hash)
-      expect(determination.determination_data).to eq({ "exclusion_reasons" => [ "pregnancy_excluded" ] })
+      expect(determination.determination_data).to eq({ "exclusion_reasons" => [ "pregnancy_excluded" ], "data_source" => "api" })
+    end
+
+    it 'records the given data source in determination_data' do
+      certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter, "va_disability_rating")
+
+      expect(Determination.sole.determination_data).to eq(
+        "exclusion_reasons" => [ "pregnancy_excluded" ], "data_source" => "va_disability_rating"
+      )
     end
   end
 

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -308,4 +308,22 @@ RSpec.describe Determination, type: :model do
       expect(described_class::CALCULATION_TYPE_EXTERNAL_CE_COMBINED_LEGACY).to eq('ex_parte_ce_combined')
     end
   end
+
+  describe '#source' do
+    it 'returns the matched verification data source when one was recorded' do
+      determination = build(:determination, decision_method: 'automated',
+                                            determination_data: { 'data_source' => 'mock_drug_treatment' })
+      expect(determination.source).to eq('mock_drug_treatment')
+    end
+
+    it "falls back to 'api' for an automated determination with no data source" do
+      determination = build(:determination, decision_method: 'automated', determination_data: {})
+      expect(determination.source).to eq('api')
+    end
+
+    it "falls back to 'member' for a manual determination" do
+      determination = build(:determination, decision_method: 'manual', determination_data: {})
+      expect(determination.source).to eq('member')
+    end
+  end
 end

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -427,6 +427,11 @@ RSpec.describe ExclusionDeterminationService do
         service.determine(kase)
         expect(recorded_exclusion.reasons).to eq([ "american_indian_alaska_native_excluded" ])
       end
+
+      it 'records the rules engine as the data source' do
+        service.determine(kase)
+        expect(recorded_exclusion.determination_data["data_source"]).to eq("api")
+      end
     end
 
     context 'when a source can outrank the rules-engine exclusion and emits it' do
@@ -441,6 +446,11 @@ RSpec.describe ExclusionDeterminationService do
         service.determine(kase)
         expect(calls).to eq([ "VeteranSource" ])
         expect(recorded_exclusion.reasons).to eq([ "veteran_disability_excluded" ])
+      end
+
+      it 'records the winning source in determination_data' do
+        service.determine(kase)
+        expect(recorded_exclusion.determination_data["data_source"]).to eq("VeteranSource")
       end
     end
 
@@ -510,6 +520,11 @@ RSpec.describe ExclusionDeterminationService do
         service.determine(kase)
         expect(recorded_exclusion).to be_nil
         expect(recorded_exception.reasons).to eq([ "drug_treatment_excepted" ])
+      end
+
+      it 'records the source that emitted the exception' do
+        service.determine(kase)
+        expect(recorded_exception.determination_data["data_source"]).to eq("DrugTreatmentSource")
       end
 
       it 'publishes DeterminedExcepted and closes the case' do
@@ -582,6 +597,11 @@ RSpec.describe ExclusionDeterminationService do
           service.determine(kase)
           expect(recorded_exclusion.reasons).to eq([ "drug_treatment_excluded" ])
         end
+
+        it 'records mock_drug_treatment as the exclusion data source' do
+          service.determine(kase)
+          expect(recorded_exclusion.determination_data["data_source"]).to eq("mock_drug_treatment")
+        end
       end
 
       context 'when the ICN is odd and not divisible by 3' do
@@ -590,6 +610,11 @@ RSpec.describe ExclusionDeterminationService do
         it 'records the drug_treatment exception' do
           service.determine(kase)
           expect(recorded_exception.reasons).to eq([ "drug_treatment_excepted" ])
+        end
+
+        it 'records mock_drug_treatment as the exception data source' do
+          service.determine(kase)
+          expect(recorded_exception.determination_data["data_source"]).to eq("mock_drug_treatment")
         end
       end
 


### PR DESCRIPTION
## Ticket

Resolves #809

## Changes

- `ExclusionDeterminationService` names the origin of every exclusion and exception it records: the id of the verification data source that emitted the outcome, or `Determination::API_SOURCE` for one the rules engine found from API-supplied member data.
- `CertificationCase#record_exclusion_determination` takes that origin as a required argument and records it under `determination_data["data_source"]`.
- `Determination` defines `API_SOURCE` and `MEMBER_SOURCE`, and `Determination#source` resolves the reported origin — the recorded data source when present, otherwise actor provenance.
- `Api::Certifications::Outcome` reports `Determination#source` instead of branching on `automated?`.

## Context for reviewers

Follow-up to #808, which added the data source consultation but deferred recording which source produced the winning outcome.

**The origin is surfaced through the existing `outcome.source` field, not a new one.** Rules-engine and member-data outcomes keep reporting `api` / `member` exactly as before; only outcomes a verification data source produced report something new (e.g. `mock_drug_treatment`, `va_disability_rating`). One field, three possible value shapes.

**Resolution lives on `Determination#source`, not in the API projection.** `Api::Certifications::Outcome` stays a thin read of the determination. No migration — `determination_data` is jsonb.

**Worth knowing:** exclusion rows now always carry a `data_source` key, where before it was absent. Pre-existing rows don't have it and `Determination#source` falls back to actor provenance for them, so the API response is unchanged for old rows and no backfill is needed — but anything reading the raw jsonb for reporting will see two row shapes.

**Scope:** only `ExclusionDeterminationService` names its own origin so far. `ExceptionDeterminationService` and the CE compliance and exemption paths still rely on the fallback, which is why `record_exception_determination` keeps an optional `data_source:` keyword while the exclusion equivalent is required. A separate ticket moves those writers over, after which the fallback in `Determination#source` can go.

Checked for side effects: no other caller of `record_exclusion_determination`; `MemberDashboardCompliance` branches on `decision_method` so automated rows never read the jsonb Hash; no raw jsonb filters anywhere in `app/` or `lib/`; the OpenAPI spec types outcome `source` as a free-form nullable string, so no regeneration is needed; and both verification adapters set `audit_data[:source]` on every non-skipped path.

Drive-by: replaced `Determination.first` with `Determination.sole` throughout the `CertificationCase` spec, per the repo's UUID primary key guidance.

## Testing

Manually verified through the demo flow that the determination records the expected origin in each of the three recording paths:

| Outcome | Origin |
|---|---|
| `drug_treatment_excepted` | the `MockDrugTreatment` data source |
| `drug_treatment_excluded` | the `MockDrugTreatment` data source |
| `pregnancy_excluded` | the rules engine, recorded as `api` |

The last row is the behavior change called out above — a rules-engine exclusion now persists `data_source` where the key was previously absent.

```
$ make test
2984 examples, 0 failures
Line coverage: 5373 / 5557 (96.68%)
Branch coverage: 1285 / 1529 (84.04%)

$ make lint
553 files inspected, no offenses detected
```

New coverage:

- `Determination#source` — all three arms: a recorded data source, the automated fallback to `api`, and the manual fallback to `member`.
- `ExclusionDeterminationService` — records `api` for a rules-engine exclusion, the emitting source's id when a data source outranks the rules engine, and the emitting source's id for an exception; plus the real `MockDrugTreatment` adapter recording `mock_drug_treatment` for both an exclusion and an exception.
- `CertificationCase#record_exclusion_determination` — stores the given origin in `determination_data`.
- `Api::Certifications::Outcome` — reports a matched data source, and still reports `api` when none was recorded.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->