### PR TITLE
Orchestrate non-exclusion verification data sources in priority order

### DIFF
--- a/reporting-app/app/models/verification/orchestration_result.rb
+++ b/reporting-app/app/models/verification/orchestration_result.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Verification
+  # Result of one orchestration pass over the ordered non-exclusion data sources
+  # (see {Verification::DataSourceOrchestrator}).
+  #
+  # It carries enough for a caller to both make a determination and audit the
+  # pass: whether a source produced a positive result (+satisfied+), the winning
+  # +source_id+ and its full {DataSourceResult} (which includes +outcomes+ and
+  # redacted +audit_data+), and +attempted+ — the ordered list of every source
+  # called, each as +{ source_id:, result: }+ — so skipped/errored sources are
+  # never silently dropped.
+  #
+  # Value object in the style of {DataSourceResult}.
+  class OrchestrationResult < ValueObject
+    attribute :satisfied, default: false
+    attribute :source_id
+    attribute :result
+    attribute :attempted, default: -> { [] }
+
+    def satisfied?
+      satisfied
+    end
+  end
+end

--- a/reporting-app/app/models/verification/orchestration_result.rb
+++ b/reporting-app/app/models/verification/orchestration_result.rb
@@ -11,7 +11,10 @@ module Verification
   # called, each as +{ source_id:, result: }+ — so skipped/errored sources are
   # never silently dropped.
   #
-  # Value object in the style of {DataSourceResult}.
+  # A plain attribute-based value object. Unlike {DataSourceResult} it carries no
+  # status/outcome invariants of its own: {DataSourceOrchestrator} is its only
+  # constructor and populates it with an already-validated winning
+  # {DataSourceResult} and the ordered {#attempted} list.
   class OrchestrationResult < ValueObject
     attribute :satisfied, default: false
     attribute :source_id

--- a/reporting-app/app/services/verification/adapters/mock_emergency_county.rb
+++ b/reporting-app/app/services/verification/adapters/mock_emergency_county.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Verification
+  module Adapters
+    # Mock data source demonstrating the ordered non-exclusion pass in
+    # Verification::DataSourceOrchestrator (OSCER-805). Like MockDrugTreatment, it
+    # derives its outcome from the last digit of the member's va_icn:
+    #
+    #   * absent ICN                -> :skipped
+    #   * ICN not ending in a digit -> :success, no outcomes ("no result")
+    #   * last digit even           -> :success, [:resides_in_declared_emergency_county]
+    #   * last digit odd            -> :success, no outcomes ("no result")
+    #
+    # va_icn is an unrelated identity field, chosen (as in MockDrugTreatment) so the
+    # outcome is a deterministic function of a single always-present scalar, letting
+    # specs drive every branch. Keying off an unrelated field also keeps the demo
+    # honest: it does NOT re-read dates_in_declared_emergency_county, the in-hand
+    # field ExceptionDeterminationService already evaluates, so it stands in for an
+    # *external* source rather than duplicating the in-hand check.
+    #
+    # Outcome: :resides_in_declared_emergency_county (a non-exclusion exception key).
+    # Because it declares no exclusion outcome, this source is order-bearing and is
+    # consulted only by the orchestrator, never by ExclusionDeterminationService.
+    class MockEmergencyCounty < Verification::DataSource
+      SOURCE = "mock_emergency_county"
+      OUTCOME_EXCEPTED = :resides_in_declared_emergency_county
+
+      def self.declared_outcomes
+        [ OUTCOME_EXCEPTED ]
+      end
+
+      protected
+
+      def precondition_met?(certification)
+        certification.member_data&.va_icn.present?
+      end
+
+      def perform(certification:)
+        success_result(
+          outcomes: outcomes_for(certification.member_data.va_icn),
+          audit_data: { source: SOURCE }
+        )
+      end
+
+      private
+
+      # Only the last character matters; a non-digit last character is "no result".
+      def outcomes_for(va_icn)
+        last = va_icn[-1]
+        return [] unless last&.match?(/\A\d\z/)
+
+        last.to_i.even? ? [ OUTCOME_EXCEPTED ] : []
+      end
+    end
+  end
+end

--- a/reporting-app/app/services/verification/data_source_orchestrator.rb
+++ b/reporting-app/app/services/verification/data_source_orchestrator.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Verification
+  # Evaluates the ordered non-exclusion verification data sources for a
+  # certification, stopping at the first source that produces a positive result.
+  #
+  # This is the consumer the Data Source registry (VerificationDataSourcesLoader)
+  # was built for but deferred: the registry stores each source's call +order+ and
+  # says "Consumers (orchestrator) must sort by order themselves." This does that.
+  #
+  # "Non-exclusion" sources are the order-bearing entries: by loader convention an
+  # exclusion-only source has +order: nil+ (its outcome ranking is owned by
+  # Exclusion.priority_order, not by call order), so it is not part of this pass.
+  # Hybrid sources that mix exclusion and non-exclusion results are out of scope.
+  #
+  # The pass calls sources in ascending +order+ (the loader guarantees +order+
+  # distinctness at boot, so the sort is deterministic) and stops at the first
+  # {DataSourceResult} that is +success?+ AND carries at least one outcome. A
+  # +:success+ with empty outcomes is a documented "called, no matching outcome"
+  # negative, so it does not stop the pass; neither do +:skipped+ or +:error+.
+  # Unexpected errors from a source propagate (consistent with DataSource#call's
+  # fail-loud contract); only an adapter's declared expected errors become
+  # +:error+ results, which the base class handles.
+  class DataSourceOrchestrator
+    class << self
+      # @param certification [Certification]
+      # @return [Verification::OrchestrationResult]
+      def evaluate(certification)
+        new.evaluate(certification)
+      end
+    end
+
+    def evaluate(certification)
+      attempted = []
+
+      ordered_sources.each do |entry|
+        result = build_source(entry).call(certification: certification)
+        attempted << { source_id: entry[:id], result: result }
+
+        if positive?(result)
+          return OrchestrationResult.new(
+            satisfied: true,
+            source_id: entry[:id],
+            result: result,
+            attempted: attempted
+          )
+        end
+      end
+
+      OrchestrationResult.new(satisfied: false, attempted: attempted)
+    end
+
+    private
+
+    def ordered_sources
+      Rails.application.config.verification_data_sources
+        .select { |entry| entry[:enabled] && !entry[:order].nil? }
+        .sort_by { |entry| entry[:order] }
+    end
+
+    def build_source(entry)
+      entry[:adapter_class].constantize.new
+    end
+
+    def positive?(result)
+      result.success? && result.outcomes.present?
+    end
+  end
+end

--- a/reporting-app/config/custom/verification_data_sources.yml
+++ b/reporting-app/config/custom/verification_data_sources.yml
@@ -72,3 +72,11 @@ mock_drug_treatment:
   enabled: true
   adapter_class: "Verification::Adapters::MockDrugTreatment"
   order: null
+
+# Mock data source for use by Verification::DataSourceOrchestrator (OSCER-805).
+# order-bearing (non-exclusion), so the orchestrator consults it; it emits the
+# resides_in_declared_emergency_county exception outcome.
+mock_emergency_county:
+  enabled: true
+  adapter_class: "Verification::Adapters::MockEmergencyCounty"
+  order: 10

--- a/reporting-app/spec/services/verification/adapters/mock_emergency_county_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/mock_emergency_county_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Mock verification data source used to demonstrate the ordered non-exclusion
+# pass in Verification::DataSourceOrchestrator (OSCER-805). Like
+# Verification::Adapters::MockDrugTreatment, it derives its outcome purely from
+# the LAST DIGIT of the member's va_icn, so specs can drive every branch
+# deterministically:
+#
+#   * absent ICN                 -> :skipped (precondition not met)
+#   * ICN not ending in a digit  -> :success, no outcomes ("no result")
+#   * last digit even            -> :success, [:resides_in_declared_emergency_county]
+#   * last digit odd             -> :success, no outcomes ("no result")
+#
+# va_icn is an unrelated identity field, chosen (as in MockDrugTreatment) so the
+# outcome is a deterministic function of a single always-present scalar. Keying
+# off an unrelated field also keeps the demo honest: it does NOT re-read
+# dates_in_declared_emergency_county, the in-hand field ExceptionDeterminationService
+# already evaluates, so it stands in for an *external* source rather than
+# duplicating the in-hand check.
+#
+# The single outcome :resides_in_declared_emergency_county is a
+# Determination::REASON_CODE_MAPPING key (the "emit the key" convention) that is
+# not an exclusion id, so this source is order-bearing (non-exclusion) and is
+# consulted only by the orchestrator, never by ExclusionDeterminationService.
+RSpec.describe Verification::Adapters::MockEmergencyCounty do
+  subject(:result) { described_class.new.call(certification: certification) }
+
+  let(:certification) { build(:certification, member_data: build(:certification_member_data, va_icn: va_icn)) }
+
+  describe ".declared_outcomes" do
+    it "declares the emergency-county exception outcome key" do
+      expect(described_class.declared_outcomes).to contain_exactly(:resides_in_declared_emergency_county)
+    end
+
+    it "declares only Determination reason-code mapping keys" do
+      expect(described_class.declared_outcomes).to all(be_in(Determination::REASON_CODE_MAPPING.keys))
+    end
+
+    it "declares only non-exclusion (order-bearing) outcome keys" do
+      expect(described_class.declared_outcomes).to all(satisfy { |key| Exclusion.find(key).nil? })
+    end
+  end
+
+  describe "#call" do
+    context "when the ICN is absent" do
+      let(:va_icn) { nil }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the ICN is a blank string" do
+      let(:va_icn) { "" }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the ICN does not end in a digit (e.g. '12345V')" do
+      let(:va_icn) { "12345V" }
+
+      it_behaves_like "a successful verification result"
+
+      it "returns no result (empty outcomes)" do
+        expect(result.outcomes).to eq([])
+      end
+
+      it "tags the audit data with the source" do
+        expect(result.audit_data[:source]).to eq("mock_emergency_county")
+      end
+    end
+
+    context "when the last digit is even" do
+      context "with '4'" do
+        let(:va_icn) { "4" }
+
+        it_behaves_like "a successful verification result"
+
+        it "emits the emergency-county exception outcome" do
+          expect(result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+        end
+      end
+
+      context "with '0' (zero is even)" do
+        let(:va_icn) { "10" }
+
+        it "emits the emergency-county exception outcome" do
+          expect(result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+        end
+      end
+
+      context "with a realistic VA ICN ending in an even digit" do
+        let(:va_icn) { "1012861229V078998" }
+
+        it "emits the emergency-county exception outcome (last digit 8)" do
+          expect(result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+        end
+      end
+    end
+
+    context "when the last digit is odd" do
+      context "with '7'" do
+        let(:va_icn) { "7" }
+
+        it_behaves_like "a successful verification result"
+
+        it "returns no result (empty outcomes)" do
+          expect(result.outcomes).to eq([])
+        end
+      end
+
+      context "with a realistic VA ICN ending in an odd digit" do
+        let(:va_icn) { "1012861229V078999" }
+
+        it "returns no result (empty outcomes, last digit 9)" do
+          expect(result.outcomes).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Verification::DataSourceOrchestrator do
       end
 
       it "is satisfied and reports the producing source and its result" do
+        expect(evaluate).to be_satisfied
         expect(evaluate).to have_attributes(
           satisfied: true,
           source_id: :first
@@ -153,6 +154,7 @@ RSpec.describe Verification::DataSourceOrchestrator do
       it "reports not satisfied with no attempts" do
         stub_registry([])
 
+        expect(evaluate).not_to be_satisfied
         expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
         expect(evaluate.attempted).to be_empty
       end

--- a/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Verification::DataSourceOrchestrator do
+  subject(:evaluate) { described_class.evaluate(certification) }
+
+  # The orchestrator never inspects the certification itself; it hands it to each
+  # source's #call. A double keeps the unit test off the DB/factories.
+  let(:certification) { instance_double(Certification) }
+
+  # Builds and registers a fake Verification::DataSource whose #call returns a
+  # scripted DataSourceResult (or raises). Mirrors the stub_const(Class.new(...))
+  # idiom in verification_data_sources_loader_spec.rb.
+  def stub_source(const_name, result: nil, raises: nil)
+    klass = Class.new(Verification::DataSource) do
+      def self.declared_outcomes = [ :high_unemployment_county ]
+    end
+    klass.define_method(:call) do |certification:|
+      raise raises if raises
+
+      result
+    end
+    stub_const(const_name, klass)
+    const_name
+  end
+
+  def registry_entry(id:, adapter_class:, order:, enabled: true)
+    { id: id, enabled: enabled, adapter_class: adapter_class, order: order }
+  end
+
+  def stub_registry(entries)
+    allow(Rails.application.config).to receive(:verification_data_sources).and_return(entries)
+  end
+
+  def success(outcomes:, audit_data: {})
+    Verification::DataSourceResult.success(outcomes: outcomes, audit_data: audit_data)
+  end
+
+  describe ".evaluate" do
+    context "when an ordered source succeeds with a matched outcome" do
+      before do
+        stub_source("FirstSource", result: success(outcomes: [ :high_unemployment_county ], audit_data: { source: "first" }))
+        stub_registry([ registry_entry(id: :first, adapter_class: "FirstSource", order: 10) ])
+      end
+
+      it "is satisfied and reports the producing source and its result" do
+        expect(evaluate).to have_attributes(
+          satisfied: true,
+          source_id: :first
+        )
+        expect(evaluate.result.outcomes).to eq([ :high_unemployment_county ])
+        expect(evaluate.result.audit_data).to eq({ source: "first" })
+      end
+    end
+
+    context "with several ordered sources" do
+      it "calls them in ascending order and stops at the first success-with-outcome" do
+        stub_source("LowOrder", result: success(outcomes: [ :high_unemployment_county ]))
+        stub_source("HighOrder", result: success(outcomes: [ :inpatient_medical_care ]))
+        stub_registry(
+          [
+            registry_entry(id: :high, adapter_class: "HighOrder", order: 20),
+            registry_entry(id: :low, adapter_class: "LowOrder", order: 10)
+          ]
+        )
+
+        # LowOrder (order 10) is evaluated first and wins; HighOrder is never reached.
+        expect(evaluate.source_id).to eq(:low)
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :low ])
+      end
+    end
+
+    context "when an ordered source succeeds with EMPTY outcomes" do
+      it "does not stop and does not treat the empty success as satisfied" do
+        stub_source("EmptySuccess", result: success(outcomes: []))
+        stub_source("RealHit", result: success(outcomes: [ :high_unemployment_county ]))
+        stub_registry(
+          [
+            registry_entry(id: :empty, adapter_class: "EmptySuccess", order: 10),
+            registry_entry(id: :hit, adapter_class: "RealHit", order: 20)
+          ]
+        )
+
+        expect(evaluate).to have_attributes(satisfied: true, source_id: :hit)
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :empty, :hit ])
+      end
+    end
+
+    context "when earlier sources are skipped or errored" do
+      it "continues past them, wins on a later source, and retains all attempts" do
+        stub_source("Skipper", result: Verification::DataSourceResult.skipped(reason: :no_icn))
+        stub_source("Errorer", result: Verification::DataSourceResult.error(error_code: :boom, error_message: "x", audit_data: {}))
+        stub_source("Winner", result: success(outcomes: [ :high_unemployment_county ], audit_data: { source: "winner" }))
+        stub_registry(
+          [
+            registry_entry(id: :skip, adapter_class: "Skipper", order: 10),
+            registry_entry(id: :err, adapter_class: "Errorer", order: 20),
+            registry_entry(id: :win, adapter_class: "Winner", order: 30)
+          ]
+        )
+
+        expect(evaluate).to have_attributes(satisfied: true, source_id: :win)
+        expect(evaluate.result.audit_data).to eq({ source: "winner" })
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :skip, :err, :win ])
+        expect(evaluate.attempted.map { |a| a[:result].status }).to eq(%i[skipped error success])
+      end
+    end
+
+    context "when a source is disabled" do
+      it "does not call it even if its order would place it first" do
+        stub_source("DisabledEarly", result: success(outcomes: [ :high_unemployment_county ]))
+        stub_source("EnabledLater", result: success(outcomes: [ :inpatient_medical_care ]))
+        stub_registry(
+          [
+            registry_entry(id: :disabled, adapter_class: "DisabledEarly", order: 5, enabled: false),
+            registry_entry(id: :enabled, adapter_class: "EnabledLater", order: 10)
+          ]
+        )
+
+        expect(evaluate.source_id).to eq(:enabled)
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :enabled ])
+      end
+    end
+
+    context "when a source has a nil order (exclusion-only)" do
+      it "is never included in the non-exclusion pass" do
+        stub_source("ExclusionOnly", result: success(outcomes: [ :is_veteran_with_disability ]))
+        stub_registry([ registry_entry(id: :exclusion, adapter_class: "ExclusionOnly", order: nil) ])
+
+        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
+        expect(evaluate.attempted).to be_empty
+      end
+    end
+
+    context "when no ordered source succeeds with an outcome" do
+      it "reports not satisfied while retaining the attempts" do
+        stub_source("EmptyOne", result: success(outcomes: []))
+        stub_source("SkippedOne", result: Verification::DataSourceResult.skipped)
+        stub_registry(
+          [
+            registry_entry(id: :empty, adapter_class: "EmptyOne", order: 10),
+            registry_entry(id: :skip, adapter_class: "SkippedOne", order: 20)
+          ]
+        )
+
+        expect(evaluate).to have_attributes(satisfied: false, source_id: nil, result: nil)
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :empty, :skip ])
+      end
+    end
+
+    context "with an empty ordered set" do
+      it "reports not satisfied with no attempts" do
+        stub_registry([])
+
+        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
+        expect(evaluate.attempted).to be_empty
+      end
+    end
+
+    context "when a source raises an unexpected error" do
+      it "propagates rather than swallowing it (fail-loud, per DataSource#call)" do
+        stub_source("Raiser", raises: RuntimeError.new("unexpected"))
+        stub_registry([ registry_entry(id: :raiser, adapter_class: "Raiser", order: 10) ])
+
+        expect { evaluate }.to raise_error(RuntimeError, "unexpected")
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
@@ -167,4 +167,42 @@ RSpec.describe Verification::DataSourceOrchestrator do
       end
     end
   end
+
+  # Exercises the ACTUAL booted Rails.application.config.verification_data_sources
+  # rather than a stubbed registry, so Phase B's registration in
+  # config/custom/verification_data_sources.yml is proven end-to-end. The only
+  # order-bearing source shipped there is mock_emergency_county (mock_drug_treatment
+  # is order: nil and belongs to the exclusion path, so it is never in this pass).
+  describe "against the real registered configuration" do
+    let(:certification) do
+      build(:certification, member_data: build(:certification_member_data, va_icn: va_icn))
+    end
+
+    context "when the registered mock emits a matched outcome (even ICN last digit)" do
+      let(:va_icn) { "1012861229V078998" }
+
+      it "is satisfied by mock_emergency_county with the emergency-county outcome" do
+        expect(evaluate).to have_attributes(satisfied: true, source_id: :mock_emergency_county)
+        expect(evaluate.result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+      end
+    end
+
+    context "when the registered mock returns no result (odd ICN last digit)" do
+      let(:va_icn) { "1012861229V078999" }
+
+      it "is not satisfied but records the attempt" do
+        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
+        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :mock_emergency_county ])
+      end
+    end
+
+    context "when the member has no ICN (precondition not met)" do
+      let(:va_icn) { nil }
+
+      it "is not satisfied; the source is attempted and skipped" do
+        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
+        expect(evaluate.attempted.map { |a| a[:result].status }).to eq(%i[skipped])
+      end
+    end
+  end
 end

--- a/reporting-app/spec/services/verification_data_sources_loader_spec.rb
+++ b/reporting-app/spec/services/verification_data_sources_loader_spec.rb
@@ -286,8 +286,20 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       merged = described_class.merge_with_defaults(overrides)
       entries = described_class.transform(merged)
 
-      expect(entries.map { |e| e[:id] }).to include(:mock_drug_treatment)
+      expect(entries.map { |e| e[:id] }).to include(:mock_drug_treatment, :mock_emergency_county)
       expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+
+    it "registers mock_emergency_county as an order-bearing non-exclusion source" do
+      override_path = Rails.root.join("config/custom/verification_data_sources.yml")
+      overrides = described_class.safe_load_optional(override_path)
+      entries = described_class.transform(described_class.merge_with_defaults(overrides))
+
+      entry = entries.find { |e| e[:id] == :mock_emergency_county }
+      expect(entry[:enabled]).to be(true)
+      expect(entry[:adapter_class]).to eq("Verification::Adapters::MockEmergencyCounty")
+      # An Integer order (not nil) is what makes it part of the orchestrator's pass.
+      expect(entry[:order]).to be_an(Integer)
     end
   end
 
@@ -302,6 +314,17 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       expect(mock).not_to have_key(:checks)
       expect(Verification::Adapters::MockDrugTreatment.declared_outcomes)
         .to eq([ :drug_treatment, :was_in_drug_treatment ])
+    end
+
+    it "wires mock_emergency_county with an Integer order for the orchestrator pass" do
+      sources = Rails.application.config.verification_data_sources
+
+      mock = sources.find { |s| s[:id] == :mock_emergency_county }
+      expect(mock[:enabled]).to be(true)
+      expect(mock[:adapter_class]).to eq("Verification::Adapters::MockEmergencyCounty")
+      expect(mock[:order]).to be_an(Integer)
+      expect(Verification::Adapters::MockEmergencyCounty.declared_outcomes)
+        .to eq([ :resides_in_declared_emergency_county ])
     end
   end
 end


### PR DESCRIPTION
## Ticket

Part of #805. The business-process wiring that consumes the orchestrator is a separate follow-up PR.

## Changes

- Add `Verification::DataSourceOrchestrator`: evaluates the order-bearing (non-exclusion) verification data sources for a certification in ascending `order`, stopping at the first result that is `success?` and carries at least one outcome.
- Add `Verification::OrchestrationResult` value object: carries `satisfied`, the winning `source_id` and its full `DataSourceResult`, plus `attempted` (every source called, with its result) so skipped or errored sources are never silently dropped.
- Add `Verification::Adapters::MockEmergencyCounty`: a demo non-exclusion source emitting `resides_in_declared_emergency_county`, derived from the last digit of the member's `va_icn`.
- Register `mock_emergency_county` in `config/custom/verification_data_sources.yml` with `order: 10`.

## Context for reviewers

The verification Data Source registry (#756) stores each source's call `order` and states that consumers sort by `order` themselves, but nothing consumed it. This adds that consumer.

Nothing calls the orchestrator yet, so this makes no behavior change on its own; the service that consumes it is a separate follow-up PR. This follows the same pattern as #807, which registered its mock before #808 wired it into determination. Registering `mock_emergency_county` as `enabled: true` is safe even though nothing consumes the orchestrator: it declares only a non-exclusion outcome, so `ExclusionDeterminationService` (which selects sources by exclusion priority) skips it, and only the orchestrator picks up order-bearing sources.

**Note on scope:** #805's acceptance criteria mention a `FEATURE_MOCK_DATA_SOURCES` flag. That AC predates #807, which established registering mocks directly in the deployment-owned `config/custom/verification_data_sources.yml` (gated by `enabled:`) with no flag. This PR follows that convention, so no flag is added; the ticket AC is left for follow-up.

## Testing

- `make test` (full suite): 3031 examples, 0 failures (96.71% line / 84.12% branch coverage).
- `make lint`: no offenses.
- Specs cover the orchestrator's ordering, stop-on-first-positive, skip of `nil`-order and disabled sources, empty-set handling, and fail-loud propagation of unexpected errors (unit, stubbed registry), plus a real-registry integration pass against the booted config; the mock adapter's every branch; and loader registration and boot-validation of the new source.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->