### PR TITLE
Consult verification data sources before concluding non-compliance

### DIFF
--- a/reporting-app/app/business_processes/certification_business_process.rb
+++ b/reporting-app/app/business_processes/certification_business_process.rb
@@ -5,6 +5,8 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   EXTERNAL_EXCLUSION_CHECK_STEP = "external_exclusion_check"
   EXTERNAL_EXCEPTION_CHECK_STEP = "external_exception_check"
   EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP = "external_community_engagement_check"
+  # Trailing step: where OSCER calls OUT, after the preceding steps assess data in hand (OSCER-805).
+  VERIFICATION_DATA_SOURCE_CHECK_STEP = "verification_data_source_check"
 
   # User task steps
   REPORT_ACTIVITIES_STEP = "report_activities"
@@ -32,6 +34,11 @@ class CertificationBusinessProcess < Strata::BusinessProcess
     CommunityEngagementCheckService.determine(kase)
   })
 
+  # Verification data sources: see DataSourceCheckService. Owns the negative determination.
+  system_process(VERIFICATION_DATA_SOURCE_CHECK_STEP, ->(kase) {
+    DataSourceCheckService.determine(kase)
+  })
+
   # User tasks
   applicant_task(REPORT_ACTIVITIES_STEP)
   staff_task(REVIEW_ACTIVITY_REPORT_STEP, ReviewActivityReportTask)
@@ -54,13 +61,20 @@ class CertificationBusinessProcess < Strata::BusinessProcess
   transition(EXTERNAL_EXCEPTION_CHECK_STEP, "DeterminedExcepted", END_STEP)
   transition(EXTERNAL_EXCEPTION_CHECK_STEP, "DeterminedNotExcepted", EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP)
 
-  # --- Transitions: External CE check (combined hours/income; generic community-engagement event names) ---
-  # DeterminedCommunityEngagementMet: At least one CE track (hours or income) satisfied
-  # DeterminedCommunityEngagementActionRequired: Both tracks failed and no external hours on file
-  # DeterminedCommunityEngagementInsufficient: Both tracks failed but some external hours exist (+hours_data+, +income_data+)
+  # --- Transitions: External CE check (in-hand combined hours/income) ---
+  # DeterminedCommunityEngagementNotMet is an internal routing event with no
+  # NotificationsEventListener subscription, so the member is not told they fell short before the
+  # outbound data sources have been consulted.
   transition(EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedCommunityEngagementMet", END_STEP)
-  transition(EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedCommunityEngagementInsufficient", REPORT_ACTIVITIES_STEP)
-  transition(EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedCommunityEngagementActionRequired", REPORT_ACTIVITIES_STEP)
+  transition(EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP, "DeterminedCommunityEngagementNotMet", VERIFICATION_DATA_SOURCE_CHECK_STEP)
+
+  # --- Transitions: Verification data source check (trailing; OSCER-805) ---
+  # No source produced an outcome splits two ways: Insufficient when inbound-pushed hours exist,
+  # ActionRequired when none do.
+  transition(VERIFICATION_DATA_SOURCE_CHECK_STEP, "DeterminedExcepted", END_STEP)
+  transition(VERIFICATION_DATA_SOURCE_CHECK_STEP, "DeterminedCommunityEngagementMet", END_STEP)
+  transition(VERIFICATION_DATA_SOURCE_CHECK_STEP, "DeterminedCommunityEngagementInsufficient", REPORT_ACTIVITIES_STEP)
+  transition(VERIFICATION_DATA_SOURCE_CHECK_STEP, "DeterminedCommunityEngagementActionRequired", REPORT_ACTIVITIES_STEP)
 
   # --- Transitions: Activity report workflow ---
   # Reviewer determines compliance: approved = compliant, denied = not compliant.

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -282,10 +282,9 @@ class CertificationCase < Strata::Case
     )
   end
 
-  # Called by DataSourceCheckService when an outbound source attests community engagement is met.
-  # NOT +#record_external_ce_combined_assessment+: that shape records the *in-hand* assessment, and a
-  # source attests without reporting hours, so +hours_ok: true+ there would claim in-hand support the
-  # data does not give. Mirrors +#record_exception_determination+ instead, with a flat payload.
+  # Called by DataSourceCheckService when a data source attests community engagement is met. A source
+  # returns a verdict, not hours or income, so this cannot reuse
+  # +#record_external_ce_combined_assessment+, whose payload states figures we would have to invent.
   def record_data_source_ce_determination(reason_codes, actor, data_source:)
     # jsonb column; must stay a Hash, not a JSON String (see record_exclusion_determination).
     determination_data = {

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -282,6 +282,27 @@ class CertificationCase < Strata::Case
     )
   end
 
+  # Called by DataSourceCheckService when an outbound source attests community engagement is met.
+  # NOT +#record_external_ce_combined_assessment+: that shape records the *in-hand* assessment, and a
+  # source attests without reporting hours, so +hours_ok: true+ there would claim in-hand support the
+  # data does not give. Mirrors +#record_exception_determination+ instead, with a flat payload.
+  def record_data_source_ce_determination(reason_codes, actor, data_source:)
+    # jsonb column; must stay a Hash, not a JSON String (see record_exclusion_determination).
+    determination_data = {
+      "calculation_type" => Determination::CALCULATION_TYPE_DATA_SOURCE_CE,
+      "data_source" => data_source
+    }
+
+    # Reused for its close_on_compliant default, so a source-attested compliant member leaves the
+    # open-case queues exactly as an in-hand compliant member does.
+    record_automated_ce_compliance(
+      :compliant,
+      determination_data,
+      reasons: reason_codes,
+      actor: actor
+    )
+  end
+
   # External CE check: one automated determination with both tracks in +determination_data+.
   # Member is compliant if either +hours_ok+ or +income_ok+; not compliant only when both are false.
   # Events/notifications are published by CommunityEngagementCheckService (via Strata).

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -54,6 +54,10 @@ class Determination < Strata::Determination
   CALCULATION_TYPE_EXTERNAL_CE_COMBINED = "external_ce_combined"
   # Historical +determination_data["calculation_type"]+ before +external_ce_combined+; use for BI/read filters on old rows.
   CALCULATION_TYPE_EXTERNAL_CE_COMBINED_LEGACY = "ex_parte_ce_combined"
+  # Community engagement attested by an outbound data source, unlike
+  # +CALCULATION_TYPE_EXTERNAL_CE_COMBINED+, which records the in-hand assessment. A source attests
+  # without reporting hours, so the payload is a flat Hash with no VO behind it.
+  CALCULATION_TYPE_DATA_SOURCE_CE = "data_source_ce"
   # Stored in +determination_data["satisfied_by"]+ when +calculation_type+ is +CALCULATION_TYPE_EXTERNAL_CE_COMBINED+ (or legacy).
   SATISFIED_BY_BOTH = "both"
   SATISFIED_BY_HOURS = "hours"
@@ -101,7 +105,8 @@ class Determination < Strata::Determination
     participating_in_other_program: "other_program_excepted"
   }.freeze
 
-  # A community-engagement track reached its threshold. Recorded as +:compliant+.
+  # A community-engagement track reached its threshold. Recorded as +:compliant+, with
+  # CALCULATION_TYPE_DATA_SOURCE_CE when a data source is what attested it.
   CE_MET_REASON_CODES = {
     hours_reported_compliant: "hours_reported_compliant",
     income_reported_compliant: "income_reported_compliant"
@@ -137,8 +142,8 @@ class Determination < Strata::Determination
   # size check.
   REASON_CODE_MAPPING = REASON_CODE_GROUPS.reduce(:merge).freeze
 
-  # Which determination a non-exclusion outcome calls for. VerificationDataSourcesLoader
-  # boot-validates every order-bearing source's declared outcomes against this partition.
+  # Which determination DataSourceCheckService records for a non-exclusion outcome.
+  # VerificationDataSourcesLoader boot-validates every order-bearing source's outcomes against it.
   EXCEPTION_OUTCOME_KEYS = EXCEPTION_REASON_CODES.keys.freeze
   CE_OUTCOME_KEYS = CE_MET_REASON_CODES.keys.freeze
   NON_EXCLUSION_OUTCOME_KEYS = (EXCEPTION_OUTCOME_KEYS + CE_OUTCOME_KEYS).freeze

--- a/reporting-app/app/services/community_engagement_check_service.rb
+++ b/reporting-app/app/services/community_engagement_check_service.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
-# Called by CertificationBusinessProcess at the external community engagement step.
-# Aggregates hours and income, records a combined determination on the case, and publishes
-# generic community-engagement Strata events (+DeterminedCommunityEngagementMet+ / +Insufficient+ / +ActionRequired+;
-# see NotificationsEventListener).
+# Called by CertificationBusinessProcess at the external community engagement step. Aggregates the
+# in-hand hours and income (inbound-pushed plus member-reported) and decides whether either track
+# satisfies the community-engagement requirement.
+#
+# Met: records the combined determination and publishes +DeterminedCommunityEngagementMet+.
+#
+# Not met: records NOTHING and publishes +DeterminedCommunityEngagementNotMet+, handing the member to
+# the trailing VERIFICATION_DATA_SOURCE_CHECK_STEP, which owns the negative determination and the
+# report_activities handoff (OSCER-805). That event has no NotificationsEventListener subscription:
+# the listener binds to event NAMES with no step awareness, so a member-facing negative here would
+# email the member before the sources were consulted, and again if one then excepted them.
 class CommunityEngagementCheckService
   include Strata::VirtualActor
 
-  # The in-hand assessment: both aggregates and their per-track verdicts. Extracted from #determine
-  # so a second step can reuse the derivation instead of repeating it, where the two could drift.
+  # The in-hand assessment: both aggregates and their per-track verdicts. DataSourceCheckService
+  # recomputes this when no data source produced an outcome, so the derivation lives here once
+  # instead of in both steps, where the two could drift apart.
   Assessment = Struct.new(:hours_data, :income_data, :hours_ok, :income_ok, keyword_init: true) do
     def met?
       hours_ok || income_ok
@@ -20,6 +28,11 @@ class CommunityEngagementCheckService
     def determine(kase)
       certification = Certification.find(kase.certification_id)
       assessment = assess(certification)
+      payload_base = { case_id: kase.id, certification_id: certification.id }
+
+      unless assessment.met?
+        return Strata::EventManager.publish("DeterminedCommunityEngagementNotMet", payload_base)
+      end
 
       kase.record_external_ce_combined_assessment(
         actor: self,
@@ -30,13 +43,7 @@ class CommunityEngagementCheckService
         income_ok: assessment.income_ok
       )
 
-      publish_workflow_events(
-        kase: kase,
-        certification: certification,
-        hours_data: assessment.hours_data,
-        income_data: assessment.income_data,
-        either_track_compliant: assessment.met?
-      )
+      Strata::EventManager.publish("DeterminedCommunityEngagementMet", payload_base)
     end
 
     # @param certification [Certification]
@@ -51,26 +58,6 @@ class CommunityEngagementCheckService
         hours_ok: HoursComplianceDeterminationService.compliant_for_total_hours?(hours_data[:total_hours]),
         income_ok: IncomeComplianceDeterminationService.compliant_for_total_income?(income_data[:total_income])
       )
-    end
-
-    private
-
-    def publish_workflow_events(kase:, certification:, hours_data:, income_data:, either_track_compliant:)
-      payload_base = {
-        case_id: kase.id,
-        certification_id: certification.id
-      }
-
-      if either_track_compliant
-        Strata::EventManager.publish("DeterminedCommunityEngagementMet", payload_base)
-      elsif hours_data.dig(:hours_by_source, :external).to_f.positive?
-        Strata::EventManager.publish("DeterminedCommunityEngagementInsufficient", payload_base.merge(
-          hours_data: hours_data,
-          income_data: income_data
-        ))
-      else
-        Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", payload_base)
-      end
     end
   end
 end

--- a/reporting-app/app/services/data_source_check_service.rb
+++ b/reporting-app/app/services/data_source_check_service.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# Called by CertificationBusinessProcess at VERIFICATION_DATA_SOURCE_CHECK_STEP (OSCER-805).
+# Consults the ordered non-exclusion data sources via {Verification::DataSourceOrchestrator} and
+# records the winning outcome, or concludes non-compliance and hands the member to
+# report_activities. This is where OSCER calls OUT; the preceding steps assess data already in hand.
+#
+# The negative is recorded HERE, not at the community-engagement check: a member a source goes on to
+# except would otherwise be left with a superseded +not_compliant+ row and a false
+# +case.activity_report.denied+ audit line. Exactly one determination per member.
+class DataSourceCheckService
+  include Strata::VirtualActor
+
+  # Raised when a source emits an outcome with no determination shape here. Reachable by config: the
+  # loader lets an order-bearing source declare exclusion outcomes, which this pass cannot rank.
+  class UnsupportedOutcomeError < StandardError; end
+
+  class << self
+    # @param kase [CertificationCase]
+    def determine(kase)
+      certification = Certification.find(kase.certification_id)
+      orchestration = Verification::DataSourceOrchestrator.evaluate(certification)
+
+      return record_source_attestation(kase, orchestration) if orchestration.satisfied?
+
+      # An errored source is not a source that said "no". Two gaps, neither covered by
+      # https://github.com/navapbc/oscer/issues/810 (scoped to ExclusionDeterminationService): this
+      # log is the only record that evidence was missing, since the row below is indistinguishable
+      # from a clean negative; and an undeclared error propagates by design, but Strata's
+      # execute_current_step is +rescue Exception+ plus a log, so the case strands with no
+      # determination, notification or staff task. Both need a ticket before a real adapter lands.
+      log_failed_attempts(kase, orchestration)
+
+      record_requirement_not_met(kase, certification)
+    end
+
+    private
+
+    def log_failed_attempts(kase, orchestration)
+      failed = orchestration.attempted.select { |attempt| attempt[:result].status == Verification::DataSourceResult::STATUS_ERROR }
+      return if failed.empty?
+
+      Rails.logger.warn(
+        "#{name}: recording community-engagement non-compliance for case #{kase.id} while " \
+        "#{failed.count} verification data source(s) failed: " \
+        "#{failed.map { |a| "#{a[:source_id]}=#{a[:result].error_code}" }.join(', ')}. " \
+        "A source that would have produced an outcome may not have been reached."
+      )
+    end
+
+    def record_source_attestation(kase, orchestration)
+      outcomes = orchestration.result.outcomes
+      validate_outcomes!(outcomes, orchestration.source_id)
+      data_source = orchestration.source_id.to_s
+
+      exception_keys = outcomes & Determination::EXCEPTION_OUTCOME_KEYS
+
+      # KNOWN GAP: no ExternalException.enabled? gate, so a source can attest an optional exception a
+      # deployment disabled, which the in-hand check honors (exception_determination_service.rb:151).
+      # Unreachable while external_exceptions.yml carries no overrides. Do NOT gate it here: the
+      # orchestrator already stopped at the first source to return anything, so dropping a disabled
+      # outcome would shadow a valid one from a higher-order source. Belongs in
+      # DataSourceOrchestrator#positive?, with an explicit outcome-key to ExternalException-id map
+      # (medical_travel vs traveling_for_medical_care).
+      #
+      # An exception outranks a CE attestation from the same source, mirroring the flow's own order.
+      if exception_keys.any?
+        kase.record_exception_determination(reason_codes(exception_keys), self, data_source: data_source)
+        publish(kase, "DeterminedExcepted")
+      else
+        kase.record_data_source_ce_determination(reason_codes(outcomes), self, data_source: data_source)
+        publish(kase, "DeterminedCommunityEngagementMet")
+      end
+    end
+
+    # No source produced an outcome, so the in-hand assessment stands. Recomputed because Strata
+    # hands a system_process only the case, never the event; shares
+    # CommunityEngagementCheckService.assess so the two steps cannot derive it differently.
+    def record_requirement_not_met(kase, certification)
+      assessment = CommunityEngagementCheckService.assess(certification)
+
+      kase.record_external_ce_combined_assessment(
+        actor: self,
+        certification: certification,
+        hours_data: assessment.hours_data,
+        income_data: assessment.income_data,
+        hours_ok: assessment.hours_ok,
+        income_ok: assessment.income_ok
+      )
+
+      # The Insufficient/ActionRequired split moved here with the negative determination, so both
+      # stay with whichever step concludes non-compliance.
+      payload = { case_id: kase.id, certification_id: certification.id }
+
+      if assessment.hours_data.dig(:hours_by_source, :external).to_f.positive?
+        Strata::EventManager.publish("DeterminedCommunityEngagementInsufficient", payload.merge(
+          hours_data: assessment.hours_data,
+          income_data: assessment.income_data
+        ))
+      else
+        Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", payload)
+      end
+    end
+
+    def validate_outcomes!(outcomes, source_id)
+      unsupported = outcomes - Determination::NON_EXCLUSION_OUTCOME_KEYS
+      return if unsupported.empty?
+
+      raise UnsupportedOutcomeError,
+        "verification data source '#{source_id}' emitted outcome(s) #{unsupported.map(&:to_s)} with no " \
+        "determination shape in #{name}; expected exception keys (#{Determination::EXCEPTION_OUTCOME_KEYS.map(&:to_s)}) " \
+        "or community-engagement keys (#{Determination::CE_OUTCOME_KEYS.map(&:to_s)})"
+    end
+
+    def reason_codes(outcome_keys)
+      outcome_keys.map { |key| Determination::REASON_CODE_MAPPING.fetch(key) }
+    end
+
+    def publish(kase, event)
+      Strata::EventManager.publish(event, { case_id: kase.id, certification_id: kase.certification_id })
+    end
+  end
+end

--- a/reporting-app/app/services/data_source_check_service.rb
+++ b/reporting-app/app/services/data_source_check_service.rb
@@ -55,19 +55,14 @@ class DataSourceCheckService
 
       exception_keys = outcomes & Determination::EXCEPTION_OUTCOME_KEYS
 
-      # KNOWN GAP: no ExternalException.enabled? gate, so a source can attest an optional exception a
-      # deployment disabled, which the in-hand check honors (exception_determination_service.rb:151).
-      # Unreachable while external_exceptions.yml carries no overrides. Do NOT gate it here: the
-      # orchestrator already stopped at the first source to return anything, so dropping a disabled
-      # outcome would shadow a valid one from a higher-order source. Belongs in
-      # DataSourceOrchestrator#positive?, with an explicit outcome-key to ExternalException-id map
-      # (medical_travel vs traveling_for_medical_care).
-      #
       # An exception outranks a CE attestation from the same source, mirroring the flow's own order.
       if exception_keys.any?
-        kase.record_exception_determination(reason_codes(exception_keys), self, data_source: data_source)
+        # One reason, like ExclusionDeterminationService and ExceptionDeterminationService. The
+        # source's first emitted key wins, since Array#& above keeps the receiver's order.
+        kase.record_exception_determination(reason_codes(exception_keys.first(1)), self, data_source: data_source)
         publish(kase, "DeterminedExcepted")
       else
+        # All of them, unlike above: hours-met and income-met corroborate rather than compete.
         kase.record_data_source_ce_determination(reason_codes(outcomes), self, data_source: data_source)
         publish(kase, "DeterminedCommunityEngagementMet")
       end

--- a/reporting-app/app/services/verification/adapters/mock_community_engagement.rb
+++ b/reporting-app/app/services/verification/adapters/mock_community_engagement.rb
@@ -9,8 +9,8 @@ module Verification
     # Keys off the member's email, NOT va_icn, and must stay that way: MockDrugTreatment runs at the
     # earlier exclusion step and ends the case for 7 of 10 va_icn last digits, leaving only even ones,
     # which are MockEmergencyCounty's — a va_icn-keyed trigger here would be starved before it ran.
-    # Email is as inert as va_icn (no determination path reads it); the substring idiom follows
-    # Auth::MockAdapter ("unconfirmed").
+    # Guarded by certification_business_process_reachability_spec. Email is as inert as va_icn (no
+    # determination path reads it); the substring idiom follows Auth::MockAdapter ("unconfirmed").
     #
     # A real source must NOT copy this: email describes the member and also joins them to their
     # certification (Certification.find_by_member_email), so one member-influenceable attribute both

--- a/reporting-app/app/services/verification_data_sources_loader.rb
+++ b/reporting-app/app/services/verification_data_sources_loader.rb
@@ -173,10 +173,17 @@ module VerificationDataSourcesLoader
       "valid ids are Determination::REASON_CODE_MAPPING keys (#{valid_outcomes.map(&:to_s).sort})"
   end
 
-  # The non-exclusion pass records an outcome by CATEGORY (exception → :excepted, CE → :compliant),
-  # so an uncategorized outcome clears validate_outcome_ids! and fails only at determination time.
-  # Exclusion keys stay permitted: a hybrid source is registrable by design, its exclusion outcomes
-  # ranked by Exclusion.priority_order. Exclusion-only sources (order: nil) never enter the pass.
+  # The non-exclusion pass records each outcome BY CATEGORY (exception → :excepted, CE → :compliant).
+  # An uncategorized outcome clears validate_outcome_ids!, then raises mid-determination where Strata
+  # rescues and logs — stalling the case with no determination, notification or staff task. Catch it
+  # at boot instead. Exclusion-only sources (order: nil) never enter the pass.
+  #
+  # Exclusion keys stay permitted: a hybrid is registrable by design, its exclusion outcomes ranked by
+  # Exclusion.priority_order. KNOWN GAP, untracked and NOT covered by
+  # https://github.com/navapbc/oscer/issues/810 (scoped to ExclusionDeterminationService):
+  # ordered_sources selects on enabled and order alone, so hybrids are scoped out of the pass but not
+  # filtered from it, and an order-bearing hybrid emitting an exclusion outcome stalls the case the
+  # same silent way. Durable fix is filtering them in DataSourceOrchestrator#ordered_sources.
   def validate_non_exclusion_outcome_categories!(entry, outcomes)
     return if entry[:order].nil?
 

--- a/reporting-app/config/custom/verification_data_sources.yml
+++ b/reporting-app/config/custom/verification_data_sources.yml
@@ -73,17 +73,29 @@ mock_drug_treatment:
   adapter_class: "Verification::Adapters::MockDrugTreatment"
   order: null
 
-# Mock data source for use by Verification::DataSourceOrchestrator (OSCER-805).
-# order-bearing (non-exclusion), so the orchestrator consults it; it emits the
-# resides_in_declared_emergency_county exception outcome.
+# Mock data sources for Verification::DataSourceOrchestrator (OSCER-805). Both are
+# order-bearing, so the orchestrator consults them: no real non-exclusion source exists
+# yet, so these are what exercise the trailing verification_data_source_check step.
+#
+# ## How to exercise each path (verified 2026-07-29)
+#
+#   va_icn last char      email has "ce-met"   result
+#   -----------------------------------------------------------------------------------
+#   0, 3, 6, 9            any                  excluded      (mock_drug_treatment)
+#   1, 5, 7               any                  excepted      (mock_drug_treatment)
+#   2, 4, 8               any                  excepted      (mock_emergency_county)
+#   not a digit, or none  no                   not_compliant -> report_activities
+#   not a digit, or none  yes                  compliant     (mock_community_engagement)
+#
+# The first two rows never reach the orchestrator, because mock_drug_treatment runs at the
+# exclusion step. That is also why the CE source keys off email rather than va_icn: only
+# even digits survive to the orchestrator and those are mock_emergency_county's. Guarded by
+# spec/business_processes/certification_business_process_reachability_spec.rb.
 mock_emergency_county:
   enabled: true
   adapter_class: "Verification::Adapters::MockEmergencyCounty"
   order: 10
 
-# The community-engagement half of the same pass: attests the requirement is met rather
-# than reporting hours. Ordered after mock_emergency_county so the exception source is
-# consulted first. Keys off the member's email, not va_icn — see the adapter for why.
 mock_community_engagement:
   enabled: true
   adapter_class: "Verification::Adapters::MockCommunityEngagement"

--- a/reporting-app/spec/business_processes/certification_business_process_reachability_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_reachability_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Reachability guard for the trailing verification_data_source_check step (OSCER-805). Drives the
+# real cascade from certification creation through the real registry, stubbing nothing in the
+# determination path, so a source that starves another one fails here.
+#
+# Exists because a mock keyed off va_icn was starved by another consulted at the earlier exclusion
+# step, leaving its branch dead. No unit spec could catch that: each adapter's rule was correct in
+# isolation, certification_business_process_spec stubs DataSourceCheckService outright, and the
+# orchestrator's real-registry cases start from a Certification, so they never traverse
+# ExclusionDeterminationService. The failure existed only in the composition of stages.
+RSpec.describe CertificationBusinessProcess, type: :business_process do
+  before do
+    # Outbound email only — nothing in the determination path is stubbed.
+    allow(NotificationService).to receive(:send_email_notification)
+  end
+
+  # A member with no exclusion signals, no in-hand exception signals and no activities,
+  # so the cascade reaches the trailing step rather than terminating in-hand.
+  def drive(va_icn:, email: "member@example.com")
+    certification = create(:certification, member_data: build(
+      :certification_member_data, va_icn: va_icn, account_email: email
+    ))
+
+    {
+      step: CertificationCase.find_by(certification_id: certification.id)&.business_process_current_step,
+      determinations: Strata::Determination.where(subject_id: certification.id).order(:determined_at).to_a
+    }
+  end
+
+  def sole_determination(outcome)
+    expect(outcome[:determinations].size).to eq(1)
+    outcome[:determinations].first
+  end
+
+  let(:trigger) { Verification::Adapters::MockCommunityEngagement::TRIGGER_EMAIL_SUBSTRING }
+  let(:ce_email) { "member+#{trigger}@example.com" }
+
+  describe "the exclusion step (consulted before the orchestrator)" do
+    it "records an exclusion for a va_icn last digit divisible by 3" do
+      outcome = drive(va_icn: "1000000003")
+      determination = sole_determination(outcome)
+
+      expect(outcome[:step]).to eq(CertificationBusinessProcess::END_STEP)
+      expect(determination.outcome).to eq("excluded")
+      expect(determination.determination_data).to include("data_source" => "mock_drug_treatment")
+    end
+
+    it "records an exception for an odd va_icn last digit not divisible by 3" do
+      outcome = drive(va_icn: "1000000007")
+      determination = sole_determination(outcome)
+
+      expect(outcome[:step]).to eq(CertificationBusinessProcess::END_STEP)
+      expect(determination.outcome).to eq("excepted")
+      expect(determination.determination_data).to include("data_source" => "mock_drug_treatment")
+    end
+  end
+
+  describe "the verification_data_source_check step" do
+    it "records a source-attested exception for an even va_icn last digit" do
+      outcome = drive(va_icn: "1000000002")
+      determination = sole_determination(outcome)
+
+      expect(outcome[:step]).to eq(CertificationBusinessProcess::END_STEP)
+      expect(determination.outcome).to eq("excepted")
+      expect(determination.determination_data).to include("data_source" => "mock_emergency_county")
+    end
+
+    it "records a source-attested community engagement for a triggering email" do
+      outcome = drive(va_icn: "1000000X", email: ce_email)
+      determination = sole_determination(outcome)
+
+      expect(outcome[:step]).to eq(CertificationBusinessProcess::END_STEP)
+      expect(determination.outcome).to eq("compliant")
+      expect(determination.reasons).to eq([ "hours_reported_compliant" ])
+      expect(determination.determination_data).to include(
+        "data_source" => "mock_community_engagement",
+        "calculation_type" => Determination::CALCULATION_TYPE_DATA_SOURCE_CE
+      )
+    end
+
+    it "records the negative determination and routes to report_activities when no source matches" do
+      outcome = drive(va_icn: "1000000X")
+      determination = sole_determination(outcome)
+
+      expect(outcome[:step]).to eq(CertificationBusinessProcess::REPORT_ACTIVITIES_STEP)
+      expect(determination.outcome).to eq("not_compliant")
+      expect(determination.determination_data).to include(
+        "calculation_type" => Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED
+      )
+    end
+
+    it "records exactly one determination on the negative path" do
+      # The negative moved from the community-engagement check to this step precisely so a
+      # member cannot end up with a superseded not_compliant row plus a later exception.
+      expect(drive(va_icn: "1000000X")[:determinations].size).to eq(1)
+    end
+  end
+
+  # The guard itself. Stated over the live registry rather than a hardcoded list, so
+  # registering a new order-bearing source without a reachable demo case fails here.
+  describe "every enabled order-bearing source is reachable" do
+    let(:order_bearing_ids) do
+      Rails.application.config.verification_data_sources
+        .select { |entry| entry[:enabled] && entry[:order] }
+        .map { |entry| entry[:id].to_s }
+    end
+
+    it "credits each one in at least one demonstrable path" do
+      credited = [
+        drive(va_icn: "1000000002"),
+        drive(va_icn: "1000000X", email: ce_email)
+      ].flat_map { |outcome| outcome[:determinations] }
+        .map { |determination| determination.determination_data["data_source"] }
+        .compact
+        .uniq
+
+      expect(credited).to include(*order_bearing_ids)
+    end
+  end
+end

--- a/reporting-app/spec/business_processes/certification_business_process_spec.rb
+++ b/reporting-app/spec/business_processes/certification_business_process_spec.rb
@@ -12,14 +12,7 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
     allow(Strata::EventManager).to receive(:publish).and_call_original
     allow(NotificationService).to receive(:send_email_notification)
 
-    # Avoid persisting real external CE combined determinations during factory/BP bootstrap (would
-    # close the case / mark compliant when income aggregate meets threshold).
-    allow(CommunityEngagementCheckService).to receive(:determine) do |kase|
-      Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", {
-        case_id: kase.id,
-        certification_id: kase.certification_id
-      })
-    end
+    stub_cascade_to_report_activities
 
     # Stub aggregate_hours_for_certification for the model's accept/deny methods
     allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification).and_return({
@@ -119,6 +112,85 @@ RSpec.describe CertificationBusinessProcess, type: :business_process do
         # Case transitions to report_activities step is hardcoded in the business process
         expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::REPORT_ACTIVITIES_STEP)
         expect(certification_case.member_status).to eq(MemberStatus::AWAITING_REPORT)
+        expect(certification_case).to be_open
+      end
+    end
+  end
+
+  describe 'external_community_engagement_check' do
+    before do
+      certification_case.update!(
+        business_process_current_step: CertificationBusinessProcess::EXTERNAL_COMMUNITY_ENGAGEMENT_CHECK_STEP
+      )
+    end
+
+    context 'when community engagement is met from in-hand data' do
+      it 'transitions to end without consulting data sources' do
+        Strata::EventManager.publish("DeterminedCommunityEngagementMet", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
+      end
+    end
+
+    context 'when community engagement is not met' do
+      # The re-point: not-met no longer routes straight to report_activities. Data sources
+      # are consulted BEFORE non-compliance is concluded, so the trailing step owns the
+      # negative determination and the report_activities handoff.
+      it 'transitions to the verification data source check, not report_activities' do
+        allow(DataSourceCheckService).to receive(:determine)
+
+        Strata::EventManager.publish("DeterminedCommunityEngagementNotMet", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::VERIFICATION_DATA_SOURCE_CHECK_STEP)
+        expect(certification_case).to be_open
+      end
+    end
+  end
+
+  describe 'verification_data_source_check' do
+    before do
+      certification_case.update!(
+        business_process_current_step: CertificationBusinessProcess::VERIFICATION_DATA_SOURCE_CHECK_STEP
+      )
+    end
+
+    context 'when a data source yields an exception' do
+      it 'transitions to end' do
+        Strata::EventManager.publish("DeterminedExcepted", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
+      end
+    end
+
+    context 'when a data source attests community engagement is met' do
+      it 'transitions to end' do
+        Strata::EventManager.publish("DeterminedCommunityEngagementMet", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::END_STEP)
+      end
+    end
+
+    context 'when no data source produces an outcome and external hours exist' do
+      it 'transitions to report_activities' do
+        Strata::EventManager.publish("DeterminedCommunityEngagementInsufficient", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::REPORT_ACTIVITIES_STEP)
+        expect(certification_case.member_status).to eq(MemberStatus::AWAITING_REPORT)
+        expect(certification_case).to be_open
+      end
+    end
+
+    context 'when no data source produces an outcome and there are no external hours' do
+      it 'transitions to report_activities' do
+        Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", { case_id: certification_case.id, certification_id: certification_case.certification_id })
+        certification_case.reload
+
+        expect(certification_case.business_process_instance.current_step).to eq(CertificationBusinessProcess::REPORT_ACTIVITIES_STEP)
         expect(certification_case).to be_open
       end
     end

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -6,16 +6,9 @@ RSpec.describe CertificationCase, type: :model do
   let(:certification_case) { create(:certification_case) }
   let(:user) { create(:user) }
 
-  # Prevent real external CE from recording a compliant determination during certification bootstrap
-  # (Income aggregate can meet threshold and close the case before examples run).
   before do
     allow(NotificationService).to receive(:send_email_notification)
-    allow(CommunityEngagementCheckService).to receive(:determine) do |kase|
-      Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", {
-        case_id: kase.id,
-        certification_id: kase.certification_id
-      })
-    end
+    stub_cascade_to_report_activities
   end
 
   describe '#record_exception_determination' do
@@ -467,12 +460,90 @@ RSpec.describe CertificationCase, type: :model do
     end
   end
 
+  # A community-engagement determination ATTESTED BY AN OUTBOUND DATA SOURCE
+  # (OSCER-805). Deliberately NOT recorded through
+  # +#record_external_ce_combined_assessment+: that shape is the record of the
+  # in-hand assessment (inbound-pushed + member-reported activity), and a source
+  # attests the requirement is met without reporting hours. Reusing it would
+  # persist an in-hand hours/income result the in-hand data does not support.
+  describe "#record_data_source_ce_determination" do
+    before { stub_const("MockSourceActor", Class.new { include Strata::VirtualActor }) }
+
+    let(:reason_codes) { [ "hours_reported_compliant" ] }
+
+    it "records an automated compliant determination under the data-source CE calculation type" do
+      certification_case.record_data_source_ce_determination(
+        reason_codes, MockSourceActor, data_source: "workforce_feed"
+      )
+
+      determination = latest_determination_for(certification_case.certification_id)
+      expect(determination.outcome).to eq("compliant")
+      expect(determination.decision_method).to eq("automated")
+      expect(determination.reasons).to eq(reason_codes)
+      expect(determination.determination_data["calculation_type"])
+        .to eq(Determination::CALCULATION_TYPE_DATA_SOURCE_CE)
+    end
+
+    it "records the attesting source so Determination#source resolves to it" do
+      certification_case.record_data_source_ce_determination(
+        reason_codes, MockSourceActor, data_source: "workforce_feed"
+      )
+
+      determination = latest_determination_for(certification_case.certification_id)
+      expect(determination.determination_data["data_source"]).to eq("workforce_feed")
+      expect(determination.source).to eq("workforce_feed")
+    end
+
+    it "stores a flat Hash payload, not the combined in-hand assessment shape" do
+      certification_case.record_data_source_ce_determination(
+        reason_codes, MockSourceActor, data_source: "workforce_feed"
+      )
+
+      data = latest_determination_for(certification_case.certification_id).determination_data
+      expect(data.keys).to contain_exactly("calculation_type", "data_source")
+    end
+
+    it "closes the case, as every compliant automated CE path does" do
+      certification_case.record_data_source_ce_determination(
+        reason_codes, MockSourceActor, data_source: "workforce_feed"
+      )
+
+      expect(certification_case.reload).to be_closed
+    end
+
+    it "accepts both community-engagement reason codes on one determination" do
+      certification_case.record_data_source_ce_determination(
+        [ "hours_reported_compliant", "income_reported_compliant" ],
+        MockSourceActor,
+        data_source: "workforce_feed"
+      )
+
+      determination = latest_determination_for(certification_case.certification_id)
+      expect(determination.reasons).to contain_exactly(
+        "hours_reported_compliant",
+        "income_reported_compliant"
+      )
+    end
+
+    # Derived by Determinable#record_determination! from the :compliant outcome plus
+    # non-exemption/non-denial reasons — no explicit audit write in this method.
+    it "writes the approved activity-report audit line" do
+      expect do
+        certification_case.record_data_source_ce_determination(
+          reason_codes, MockSourceActor, data_source: "workforce_feed"
+        )
+      end.to change {
+        Strata::AuditLine.where(
+          subject: Certification.find(certification_case.certification_id),
+          actor_type: "MockSourceActor",
+          action: "case.activity_report.approved"
+        ).count
+      }.by(1)
+    end
+  end
+
   describe "#record_external_ce_combined_assessment" do
     before { stub_const("MockSubmitter", Class.new { include Strata::VirtualActor }) }
-
-    def latest_determination_for(certification_id)
-      Determination.unscope(:order).where(subject_id: certification_id).order(created_at: :desc).first
-    end
 
     let(:certification) { Certification.find(certification_case.certification_id) }
 

--- a/reporting-app/spec/rails_helper.rb
+++ b/reporting-app/spec/rails_helper.rb
@@ -48,6 +48,8 @@ require_relative 'support/env_helpers'
 require_relative 'support/yaml_config_helpers'
 require_relative 'support/verification/data_source_shared_examples'
 require_relative 'support/verification/registry_helpers'
+require_relative 'support/determination_helpers'
+require_relative 'support/certification_cascade_helpers'
 require "strata/testing/api_auth_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
+++ b/reporting-app/spec/requests/review_activity_report_tasks_spec.rb
@@ -14,14 +14,7 @@ RSpec.describe "/review_activity_report_tasks", type: :request do
     login_as user
     allow(NotificationService).to receive(:send_email_notification)
 
-    # Keep the bootstrap community-engagement check from closing the factory-created case
-    # (the hours stub below would otherwise mark it compliant during certification setup).
-    allow(CommunityEngagementCheckService).to receive(:determine) do |bootstrap_case|
-      Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", {
-        case_id: bootstrap_case.id,
-        certification_id: bootstrap_case.certification_id
-      })
-    end
+    stub_cascade_to_report_activities
   end
 
   after do

--- a/reporting-app/spec/services/community_engagement_check_service_spec.rb
+++ b/reporting-app/spec/services/community_engagement_check_service_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe CommunityEngagementCheckService do
            period_start: period_start, period_end: period_end, gross_income: gross_income, **attrs)
   end
 
-  def latest_determination_for(certification_id)
-    Determination.unscope(:order).where(subject_id: certification_id).order(created_at: :desc).first
-  end
-
   # .assess is the derivation .determine used to inline. It is public so a second step can reuse it
   # rather than re-deriving the same four values and risking a different verdict.
   describe ".assess" do
@@ -189,45 +185,48 @@ RSpec.describe CommunityEngagementCheckService do
       end
     end
 
+    # Not-met defers to the trailing step (OSCER-805), which owns the negative determination and
+    # the Insufficient/ActionRequired split, so this service records nothing here.
     context "when neither hours nor income meet targets with some external hours" do
       before do
         create_external_hourly_activity_for(certification, hours: 40)
         create_income_for(certification, gross_income: 400)
       end
 
-      it "records not_compliant with both insufficient reason codes when some external hours are present" do
-        described_class.determine(certification_case)
-
-        determination = latest_determination_for(certification.id)
-        expect(determination.outcome).to eq("not_compliant")
-        expect(determination.reasons).to contain_exactly(
-          "hours_reported_insufficient",
-          "income_reported_insufficient"
-        )
-        data = determination.determination_data
-        expect(data["calculation_type"]).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
-        expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
-        expect(data["hours"]["compliant"]).to be false
-        expect(data["income"]["compliant"]).to be false
+      it "records no determination, deferring the negative to the data-source step" do
+        expect do
+          described_class.determine(certification_case)
+        end.not_to change { Determination.unscope(:order).where(subject_id: certification.id).count }
       end
 
-      it "publishes DeterminedCommunityEngagementInsufficient with hours and income payload" do
+      it "publishes DeterminedCommunityEngagementNotMet to route into the data-source step" do
         described_class.determine(certification_case)
 
         expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedCommunityEngagementInsufficient",
-          hash_including(
-            case_id: certification_case.id,
-            hours_data: kind_of(Hash),
-            income_data: kind_of(Hash)
-          )
+          "DeterminedCommunityEngagementNotMet",
+          hash_including(case_id: certification_case.id)
         )
       end
 
-      it 'logs denied event' do
+      # The member-facing negative events publish from the trailing step instead.
+      # NotificationsEventListener binds handlers to event NAMES with no step
+      # awareness, so publishing either one here would email the member before the
+      # data sources have been consulted.
+      it "publishes neither member-facing negative event" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).not_to have_received(:publish).with(
+          "DeterminedCommunityEngagementInsufficient", anything
+        )
+        expect(Strata::EventManager).not_to have_received(:publish).with(
+          "DeterminedCommunityEngagementActionRequired", anything
+        )
+      end
+
+      it 'does not log the denied event (the data-source step does)' do
         expect do
           described_class.determine(certification_case)
-        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.activity_report.denied').count }.by(1)
+        end.not_to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.activity_report.denied').count }
       end
     end
 
@@ -236,27 +235,19 @@ RSpec.describe CommunityEngagementCheckService do
         create_income_for(certification, gross_income: 100)
       end
 
-      it "records not_compliant with both insufficient reason codes when there are no external hours" do
-        described_class.determine(certification_case)
-
-        determination = latest_determination_for(certification.id)
-        expect(determination.outcome).to eq("not_compliant")
-        expect(determination.reasons).to contain_exactly(
-          "hours_reported_insufficient",
-          "income_reported_insufficient"
-        )
-        data = determination.determination_data
-        expect(data["calculation_type"]).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
-        expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
-        expect(data["hours"]["compliant"]).to be false
-        expect(data["income"]["compliant"]).to be false
+      it "records no determination" do
+        expect do
+          described_class.determine(certification_case)
+        end.not_to change { Determination.unscope(:order).where(subject_id: certification.id).count }
       end
 
-      it "publishes DeterminedCommunityEngagementActionRequired" do
+      # The external-hours branching that chose Insufficient vs ActionRequired moves
+      # to the trailing step, so both not-met flavors leave here as the same event.
+      it "publishes DeterminedCommunityEngagementNotMet" do
         described_class.determine(certification_case)
 
         expect(Strata::EventManager).to have_received(:publish).with(
-          "DeterminedCommunityEngagementActionRequired",
+          "DeterminedCommunityEngagementNotMet",
           hash_including(case_id: certification_case.id)
         )
       end

--- a/reporting-app/spec/services/data_source_check_service_spec.rb
+++ b/reporting-app/spec/services/data_source_check_service_spec.rb
@@ -182,17 +182,15 @@ RSpec.describe DataSourceCheckService do
 
     context "when a source emits several exception outcomes" do
       before do
-        register_one(id: :multi_feed, outcomes: [ :was_inmate, :receiving_inpatient_medical_care ])
+        register_one(id: :multi_feed, outcomes: [ :receiving_inpatient_medical_care, :was_inmate ])
       end
 
-      # Guards against a regression that took only the first exception key.
-      it "records every matched exception reason code" do
+      # Registered in reverse of Determination::EXCEPTION_OUTCOME_KEYS order on purpose: only a
+      # reversed pair tells "the source's order decides" apart from "the canonical order decides".
+      it "records only the first exception reason code the source emitted" do
         described_class.determine(certification_case)
 
-        expect(latest_determination.reasons).to contain_exactly(
-          "inmate_excepted",
-          "inpatient_medical_care_excepted"
-        )
+        expect(latest_determination.reasons).to eq([ "inpatient_medical_care_excepted" ])
       end
     end
 

--- a/reporting-app/spec/services/data_source_check_service_spec.rb
+++ b/reporting-app/spec/services/data_source_check_service_spec.rb
@@ -1,0 +1,501 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# +Strata::EventManager.publish+ is stubbed WITHOUT and_call_original (as in
+# community_engagement_check_service_spec) so the business process never advances; this spec asserts
+# what the service records and publishes in isolation.
+RSpec.describe DataSourceCheckService do
+  before do
+    allow(Strata::EventManager).to receive(:publish)
+    allow(NotificationService).to receive(:send_email_notification)
+  end
+
+  let(:certification) do
+    create(:certification, member_data: build(
+      :certification_member_data, va_icn: va_icn, account_email: account_email
+    ))
+  end
+  let(:certification_case) { create(:certification_case, certification: certification) }
+  let(:va_icn) { "1012861229V078998" }
+  # Non-triggering by default; mock_community_engagement keys off the email, not the ICN.
+  let(:account_email) { "member@example.com" }
+  let(:ce_trigger_email) { "member+#{Verification::Adapters::MockCommunityEngagement::TRIGGER_EMAIL_SUBSTRING}@example.com" }
+
+  # --- source doubles (stub_registry / registry_entry come from VerificationRegistryHelpers) ---
+
+  # Stubs a source whose #call always returns the given result.
+  def stub_source_returning(const_name, result, declared_outcomes:)
+    klass = Class.new(Verification::DataSource) do
+      define_singleton_method(:declared_outcomes) { declared_outcomes }
+    end
+    klass.define_method(:call) { |certification:| result }
+    stub_const(const_name, klass)
+    const_name
+  end
+
+  def stub_source(const_name, outcomes:)
+    stub_source_returning(
+      const_name,
+      Verification::DataSourceResult.success(outcomes: outcomes, audit_data: { source: const_name }),
+      declared_outcomes: outcomes
+    )
+  end
+
+  def register_one(id:, outcomes:, order: 10)
+    const_name = "Stub#{id.to_s.camelize}Source"
+    stub_source(const_name, outcomes: outcomes)
+    stub_registry([ registry_entry(id: id, adapter_class: const_name, order: order) ])
+  end
+
+  def register_erroring(id:, error_code: :read_timeout, order: 10)
+    const_name = stub_source_returning(
+      "Stub#{id.to_s.camelize}Source",
+      Verification::DataSourceResult.error(
+        error_code: error_code, error_message: "upstream unavailable", audit_data: {}
+      ),
+      declared_outcomes: [ :was_inmate ]
+    )
+    stub_registry([ registry_entry(id: id, adapter_class: const_name, order: order) ])
+  end
+
+  def create_external_hourly_activity_for(certification, hours:)
+    lookback = certification.certification_requirements.continuous_lookback_period
+    create(:external_hourly_activity,
+      member_id: certification.member_id,
+      period_start: lookback.start.to_date,
+      period_end: lookback.start.to_date.end_of_month,
+      hours: hours)
+  end
+
+  def latest_determination
+    latest_determination_for(certification.id)
+  end
+
+  describe ".determine" do
+    context "when a source emits an exception outcome" do
+      before do
+        register_one(id: :emergency_feed, outcomes: [ :resides_in_declared_emergency_county ])
+      end
+
+      it "records an excepted determination carrying the producing source id" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("excepted")
+        expect(latest_determination.reasons).to eq([ "declared_emergency_county_excepted" ])
+        expect(latest_determination.determination_data["data_source"]).to eq("emergency_feed")
+        expect(latest_determination.source).to eq("emergency_feed")
+      end
+
+      it "closes the case" do
+        described_class.determine(certification_case)
+
+        expect(certification_case.reload).to be_closed
+      end
+
+      it "publishes DeterminedExcepted" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedExcepted",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+
+      it "publishes no community-engagement events" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).not_to have_received(:publish).with(
+          a_string_matching(/CommunityEngagement/), anything
+        )
+      end
+
+      it "writes the exception audit line derived from the excepted outcome" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change {
+          Strata::AuditLine.where(
+            subject: certification,
+            actor_type: described_class.name,
+            action: "case.exception.approved"
+          ).count
+        }.by(1)
+      end
+    end
+
+    context "when a source attests community engagement is met" do
+      before do
+        register_one(id: :workforce_feed, outcomes: [ :hours_reported_compliant ])
+      end
+
+      it "records a compliant determination under the source-attested CE calculation type" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("compliant")
+        expect(latest_determination.reasons).to eq([ "hours_reported_compliant" ])
+        expect(latest_determination.determination_data["calculation_type"])
+          .to eq(Determination::CALCULATION_TYPE_DATA_SOURCE_CE)
+      end
+
+      it "carries the producing source id as the determination source" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.determination_data["data_source"]).to eq("workforce_feed")
+        expect(latest_determination.source).to eq("workforce_feed")
+      end
+
+      it "does NOT record the in-hand external-CE-combined shape" do
+        described_class.determine(certification_case)
+
+        # The source attests the requirement is met; it reports no hours. Recording
+        # the combined shape would assert an in-hand hours/income result.
+        expect(latest_determination.determination_data.keys).to contain_exactly("calculation_type", "data_source")
+      end
+
+      it "closes the case" do
+        described_class.determine(certification_case)
+
+        expect(certification_case.reload).to be_closed
+      end
+
+      it "publishes DeterminedCommunityEngagementMet" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementMet",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+
+      it "writes the approved audit line derived from the compliant outcome" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change {
+          Strata::AuditLine.where(
+            subject: certification,
+            actor_type: described_class.name,
+            action: "case.activity_report.approved"
+          ).count
+        }.by(1)
+      end
+    end
+
+    context "when a source emits several exception outcomes" do
+      before do
+        register_one(id: :multi_feed, outcomes: [ :was_inmate, :receiving_inpatient_medical_care ])
+      end
+
+      # Guards against a regression that took only the first exception key.
+      it "records every matched exception reason code" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.reasons).to contain_exactly(
+          "inmate_excepted",
+          "inpatient_medical_care_excepted"
+        )
+      end
+    end
+
+    context "when a source emits both community-engagement outcomes" do
+      before do
+        register_one(id: :combined_feed, outcomes: [ :hours_reported_compliant, :income_reported_compliant ])
+      end
+
+      it "records both compliant reason codes on one determination" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("compliant")
+        expect(latest_determination.reasons).to contain_exactly(
+          "hours_reported_compliant",
+          "income_reported_compliant"
+        )
+      end
+    end
+
+    context "when a source emits both an exception and a community-engagement outcome" do
+      before do
+        register_one(id: :hybrid_feed, outcomes: [ :hours_reported_compliant, :was_inmate ])
+      end
+
+      # Precedence: an exception excuses the member for the period regardless of
+      # activity levels, and the flow itself checks exceptions before CE.
+      it "records the exception and ignores the community-engagement outcome" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("excepted")
+        expect(latest_determination.reasons).to eq([ "inmate_excepted" ])
+      end
+
+      it "publishes DeterminedExcepted, not DeterminedCommunityEngagementMet" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with("DeterminedExcepted", anything)
+        expect(Strata::EventManager).not_to have_received(:publish).with(
+          "DeterminedCommunityEngagementMet", anything
+        )
+      end
+
+      it "records exactly one determination" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change { Determination.unscope(:order).where(subject_id: certification.id).count }.by(1)
+      end
+    end
+
+    # Defense in depth, not the primary guard: an order-bearing source declaring an
+    # uncategorized outcome now fails at boot (VerificationDataSourcesLoader), and a source
+    # returning an outcome it did not declare raises ContractError in
+    # Verification::DataSource#call. This asserts the service still refuses to misfile if a
+    # result reaches it anyway.
+    context "when a source emits an outcome in neither whitelist" do
+      before do
+        # A valid REASON_CODE_MAPPING key with no determination shape on this path.
+        register_one(id: :rogue_feed, outcomes: [ :exemption_request_compliant ])
+      end
+
+      it "raises rather than misfiling the outcome" do
+        expect do
+          described_class.determine(certification_case)
+        end.to raise_error(DataSourceCheckService::UnsupportedOutcomeError, /exemption_request_compliant/)
+      end
+
+      it "records no determination" do
+        expect do
+          described_class.determine(certification_case)
+        rescue DataSourceCheckService::UnsupportedOutcomeError
+          nil
+        end.not_to change { Determination.unscope(:order).where(subject_id: certification.id).count }
+      end
+    end
+
+    # The negative determination is OWNED BY THIS STEP, not the community-engagement
+    # check. The CE check computes met-vs-not-met and defers finalizing the negative,
+    # so a member later excepted or attested-compliant by a source never accumulates
+    # a superseded not_compliant row (nor its "case.activity_report.denied" audit
+    # line). Exactly one determination is written per member, after all evidence is in.
+    context "when no source produces an outcome and external hours exist" do
+      before do
+        register_one(id: :quiet_feed, outcomes: [])
+        create_external_hourly_activity_for(certification, hours: 40)
+      end
+
+      it "publishes Insufficient with the hours and income payload" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementInsufficient",
+          hash_including(
+            case_id: certification_case.id,
+            hours_data: kind_of(Hash),
+            income_data: kind_of(Hash)
+          )
+        )
+      end
+
+      it "records the not_compliant combined-CE determination, as the CE check used to" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("not_compliant")
+        expect(latest_determination.reasons).to contain_exactly(
+          "hours_reported_insufficient",
+          "income_reported_insufficient"
+        )
+        data = latest_determination.determination_data
+        expect(data["calculation_type"]).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+        expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
+      end
+
+      it "records exactly one determination" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change { Determination.unscope(:order).where(subject_id: certification.id).count }.by(1)
+      end
+
+      it "writes the denied audit line here rather than at the CE check" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change {
+          Strata::AuditLine.where(
+            subject: certification,
+            actor_type: described_class.name,
+            action: "case.activity_report.denied"
+          ).count
+        }.by(1)
+      end
+
+      it "leaves the case open" do
+        described_class.determine(certification_case)
+
+        expect(certification_case.reload).to be_open
+      end
+    end
+
+    context "when no source produces an outcome and there are no external hours" do
+      before do
+        register_one(id: :quiet_feed, outcomes: [])
+      end
+
+      it "publishes ActionRequired" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementActionRequired",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+
+      it "records the not_compliant combined-CE determination" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("not_compliant")
+        expect(latest_determination.determination_data["satisfied_by"])
+          .to eq(Determination::SATISFIED_BY_NEITHER)
+      end
+    end
+
+    # Documents a KNOWN GAP, tracked by https://github.com/navapbc/oscer/issues/810: an errored
+    # source is indistinguishable from "no outcome" to the orchestrator, so a member is recorded
+    # non-compliant even though a source that might have excepted them was never reached. Before
+    # this step existed the orchestrator was inert, so the gap had no member-facing consequence;
+    # it does now. Until #810 lands, the failure is at least surfaced in the log rather than
+    # silently indistinguishable from a clean negative.
+    context "when a source errors rather than returning an outcome" do
+      before { register_erroring(id: :flaky_feed) }
+
+      it "still records non-compliance for the member (the #810 gap, pinned deliberately)" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination.outcome).to eq("not_compliant")
+      end
+
+      it "logs a warning naming the failed source and its error code" do
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.determine(certification_case)
+
+        expect(Rails.logger).to have_received(:warn).with(
+          a_string_matching(/flaky_feed=read_timeout/)
+        )
+      end
+    end
+
+    context "when every source produces an outcome-free success" do
+      before { register_one(id: :quiet_feed, outcomes: []) }
+
+      it "does not log a source-failure warning" do
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.determine(certification_case)
+
+        expect(Rails.logger).not_to have_received(:warn)
+      end
+    end
+
+    context "when no order-bearing sources are registered" do
+      before { stub_registry([]) }
+
+      # Production-parity case: with both demo mocks disabled the registry has no
+      # order-bearing sources, so this step records and publishes exactly what the
+      # community-engagement check did before Phase C.
+      it "records the negative determination and publishes ActionRequired" do
+        expect do
+          described_class.determine(certification_case)
+        end.to change { Determination.unscope(:order).where(subject_id: certification.id).count }.by(1)
+
+        expect(latest_determination.outcome).to eq("not_compliant")
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementActionRequired",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+    end
+
+    context "with the real MockEmergencyCounty registered" do
+      before do
+        stub_registry(
+          [
+            registry_entry(
+              id: :mock_emergency_county,
+              adapter_class: "Verification::Adapters::MockEmergencyCounty",
+              order: 10
+            )
+          ]
+        )
+      end
+
+      context "when the member's va_icn ends in an even digit" do
+        let(:va_icn) { "1012861229V078998" }
+
+        it "records an excepted determination sourced to the mock" do
+          described_class.determine(certification_case)
+
+          expect(latest_determination.outcome).to eq("excepted")
+          expect(latest_determination.source).to eq("mock_emergency_county")
+        end
+      end
+
+      context "when the member's va_icn ends in an odd digit" do
+        let(:va_icn) { "1012861229V078999" }
+
+        it "records the negative determination and routes the member to report activities" do
+          described_class.determine(certification_case)
+
+          expect(latest_determination.outcome).to eq("not_compliant")
+          expect(Strata::EventManager).to have_received(:publish).with(
+            "DeterminedCommunityEngagementActionRequired",
+            hash_including(case_id: certification_case.id)
+          )
+        end
+      end
+    end
+
+    context "with the real MockCommunityEngagement registered" do
+      before do
+        stub_registry(
+          [
+            registry_entry(
+              id: :mock_community_engagement,
+              adapter_class: "Verification::Adapters::MockCommunityEngagement",
+              order: 20
+            )
+          ]
+        )
+      end
+
+      # Keys off the email, not the va_icn, so it stays orthogonal to every va_icn-keyed
+      # source and cannot be starved by one at an earlier pipeline stage.
+      context "when the member's email carries the CE trigger" do
+        let(:account_email) { ce_trigger_email }
+
+        it "records a source-attested compliant determination" do
+          described_class.determine(certification_case)
+
+          expect(latest_determination.outcome).to eq("compliant")
+          expect(latest_determination.determination_data["calculation_type"])
+            .to eq(Determination::CALCULATION_TYPE_DATA_SOURCE_CE)
+          expect(latest_determination.source).to eq("mock_community_engagement")
+        end
+      end
+
+      context "when the member's email does not carry the CE trigger" do
+        let(:account_email) { "member@example.com" }
+
+        it "attests nothing, so the negative determination is recorded" do
+          described_class.determine(certification_case)
+
+          expect(latest_determination.outcome).to eq("not_compliant")
+        end
+      end
+
+      context "when the member has no email at all" do
+        let(:account_email) { nil }
+
+        it "skips the source, so the negative determination is recorded" do
+          described_class.determine(certification_case)
+
+          expect(latest_determination.outcome).to eq("not_compliant")
+        end
+      end
+    end
+  end
+end

--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -113,6 +113,34 @@ RSpec.describe MemberDashboardComplianceService do
       end
     end
 
+    # A community-engagement determination attested by an outbound data source
+    # (OSCER-805). income_summary_visible? allow-lists the types it surfaces, so this
+    # new type falls through to hidden. Pinned here so the behavior is a chosen
+    # default rather than an accident of the allow-list — if product wants these
+    # members to see income progress, add the constant at
+    # member_dashboard_compliance_service.rb and flip this example.
+    context "when latest determination is data_source_ce" do
+      before do
+        create_external_income_for(certification:, gross_income: 100)
+        create(:determination,
+               subject: certification,
+               outcome: "compliant",
+               decision_method: "automated",
+               reasons: [ "hours_reported_compliant" ],
+               determination_data: {
+                 "calculation_type" => Determination::CALCULATION_TYPE_DATA_SOURCE_CE,
+                 "data_source" => "workforce_feed"
+               })
+      end
+
+      let(:member_status) { MemberStatusService.determine(certification) }
+
+      it "hides income summary for a source-attested determination" do
+        expect(read_model.show_income_summary).to be false
+        expect(read_model.ce_calculation_type).to eq(Determination::CALCULATION_TYPE_DATA_SOURCE_CE)
+      end
+    end
+
     context "when latest determination is hours_based" do
       before do
         create(:determination,

--- a/reporting-app/spec/services/verification_data_sources_loader_spec.rb
+++ b/reporting-app/spec/services/verification_data_sources_loader_spec.rb
@@ -279,7 +279,8 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
     end
   end
 
-  # These pin an uncategorized order-bearing outcome to a boot failure, not a determination-time one.
+  # These pin an uncategorized order-bearing outcome to a boot failure rather than the silent
+  # mid-determination stall described on validate_non_exclusion_outcome_categories!.
   describe "order-bearing outcome categorization" do
     def entry_for(outcomes, order:)
       klass = Class.new(Verification::DataSource) do

--- a/reporting-app/spec/support/certification_cascade_helpers.rb
+++ b/reporting-app/spec/support/certification_cascade_helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Settles the determination cascade that runs when a certification factory commits, so a
+# factory-created case lands on report_activities instead of closing itself compliant.
+#
+# Both stubs are required: since OSCER-805 the community-engagement check's not-met branch only
+# publishes the internal routing event, and the trailing step owns the member-facing negative.
+# Stubbing either alone leaves the bootstrap case mid-cascade.
+module CertificationCascadeHelpers
+  def stub_cascade_to_report_activities
+    allow(CommunityEngagementCheckService).to receive(:determine) do |kase|
+      Strata::EventManager.publish("DeterminedCommunityEngagementNotMet", {
+        case_id: kase.id,
+        certification_id: kase.certification_id
+      })
+    end
+
+    allow(DataSourceCheckService).to receive(:determine) do |kase|
+      Strata::EventManager.publish("DeterminedCommunityEngagementActionRequired", {
+        case_id: kase.id,
+        certification_id: kase.certification_id
+      })
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CertificationCascadeHelpers
+end

--- a/reporting-app/spec/support/determination_helpers.rb
+++ b/reporting-app/spec/support/determination_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# The most recent determination for a subject. Determination carries a default_scope order, so
+# reads unscope it before ordering by created_at. Extracted from identical defs previously repeated
+# in certification_case_spec (twice), community_engagement_check_service_spec and
+# data_source_check_service_spec.
+module DeterminationHelpers
+  def latest_determination_for(certification_id)
+    Determination.unscope(:order).where(subject_id: certification_id).order(created_at: :desc).first
+  end
+end
+
+RSpec.configure do |config|
+  config.include DeterminationHelpers
+end

--- a/reporting-app/spec/support/verification/registry_helpers.rb
+++ b/reporting-app/spec/support/verification/registry_helpers.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Stubs Rails.application.config.verification_data_sources, the booted data source registry.
-# Extracted from data_source_orchestrator_spec so any spec exercising the pass can stub the
-# registry the same way.
+# Extracted from identical defs previously repeated in data_source_orchestrator_spec and
+# data_source_check_service_spec.
 module VerificationRegistryHelpers
   def stub_registry(entries)
     allow(Rails.application.config).to receive(:verification_data_sources).and_return(entries)


### PR DESCRIPTION
## Ticket

Part of #805

Last of four in a stack: #823, #828, #829, this. Review in that order; each merge retargets this one
automatically.

The orchestrator engine, result object and first mock shipped in #812. This is the wiring that makes
them load-bearing.

## Changes

Flow:

- Add `verification_data_source_check` as a trailing determination step, running
  `Verification::DataSourceOrchestrator` over the registry's order-bearing sources
  (`DataSourceCheckService`).
- Re-point the community-engagement check's not-met branch into that step via a new
  `DeterminedCommunityEngagementNotMet` event, which has no `NotificationsEventListener` subscription.
- Move the negative determination and the `Insufficient` / `ActionRequired` split out of
  `CommunityEngagementCheckService` and into the new step.

Determinations:

- Add `CertificationCase#record_data_source_ce_determination` and
  `Determination::CALCULATION_TYPE_DATA_SOURCE_CE` for source-attested community engagement, rather
  than reusing `record_external_ce_combined_assessment`, whose value object serializes an in-hand hours
  and income assessment a source does not report.
- Dispatch on #823's outcome categories to pick the determination an emitted outcome calls for, raising
  `UnsupportedOutcomeError` on an uncategorized one.
- Record **one** reason code for an exception and **all** of them for community engagement. Each follows
  its own determination shape's precedent: `ExclusionDeterminationService` and
  `ExceptionDeterminationService` both take the first match, while
  `external_ce_combined_reason_codes` records both codes when both tracks pass. Whichever key the
  source emitted first wins.

Specs:

- Add `certification_business_process_reachability_spec`, which drives the real cascade through the real
  registry with nothing in the determination path stubbed and asserts over the live registry that every
  enabled order-bearing source is creditable, so a future source that starves an existing one fails
  there.
- Move `latest_determination_for` and the cascade bootstrap stub into `spec/support/`.

## Context for reviewers

**Sequencing.** In-hand checks run first (exclusion, exception, community engagement, all against data
already in OSCER), then the outbound pass, then exactly one determination once all the evidence is in.
That is why the negative moved here: recording non-compliance at the community-engagement check and then
letting a source except the member would leave a superseded `not_compliant` row and a false
`case.activity_report.denied` audit line. Plugging in a real source should be registration only, giving
it an `order` and declaring its outcomes.

**Where it sits.** #732 configures the order and conditions under which external sources are called:
contract #754, VA adapter #755, registry #756, exclusion-path consultation #808, API provenance #811,
ordering engine #812. Nothing consumed #812 until now.

**Open seams.** Proven against mocks only, since no real non-exclusion source exists, which is why #805
is scoped orchestrator-only. Cross-source aggregation stays deferred until a concrete source defines it.
No `ExternalException.enabled?` gate on the exception path: a deployment owns both its sources and its
`external_exceptions.yml`, so one that disables an exception would not ship a source attesting it. Note
that `mock_emergency_county` does emit an optional exception today, so the OSCER-shipped mocks are the
one way to construct that mismatch by config alone.

**Error handling still needs a ticket**, narrower than it looked. #810's acceptance criterion is still
`TBD` in the issue, but the design question was answered in `#tss-oscer` on 2026-07-27: continue through
the remaining sources marking the failed one as errored, and distinguish "checked everything, found no
compliance" from "checked everything but one source errored, so this is not comprehensive". Today an
errored source yields a member-facing `not_compliant` indistinguishable from a clean negative, evidenced
only by `log_failed_attempts`. Unreachable while every registered source is an in-memory mock that
cannot raise. Two gaps remain unticketed and share one root cause, that this trailing step has no error
boundary: an undeclared error propagates into Strata's `rescue Exception` and strands the case, and an
order-bearing hybrid source stalls the same silent way.

## Testing

- Suite green: 3163 examples, 0 failures. 96.76% line, 84.22% branch.
- RuboCop clean across 577 files.
- Ran in development against the shipped config, driving certifications through the real cascade from
  creation and inspecting the resulting case step and determination row. All five documented paths
  behaved as the registry describes, each writing exactly one determination:

  | `va_icn` last char | email has `ce-met` | Result |
  |---|---|---|
  | 0, 3, 6, 9 | any | `excluded` (mock_drug_treatment) |
  | 1, 5, 7 | any | `excepted` (mock_drug_treatment) |
  | 2, 4, 8 | any | `excepted` (mock_emergency_county) |
  | not a digit, or absent | no | `not_compliant`, routed to `report_activities` |
  | not a digit, or absent | yes | `compliant` (mock_community_engagement) |

- That walkthrough is what surfaced an unreachable community-engagement branch; the matrix was
  re-verified after the fix.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->