### PR TITLE
Enforce the verification data source outcome contract

### DIFF
--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -66,7 +66,11 @@ class Determination < Strata::Determination
   API_SOURCE = "api"
   MEMBER_SOURCE = "member"
 
-  REASON_CODE_MAPPING = {
+  # REASON_CODE_MAPPING below merges these groups into the flat lookup every caller uses. A new code
+  # goes in one group and nowhere else; its category follows from where it is defined.
+
+  # Recorded as +:excluded+.
+  EXCLUSION_REASON_CODES = {
     age_under_19: "age_under_19_excluded",
     age_over_65: "age_over_65_excluded",
     is_pregnant: "pregnancy_excluded",
@@ -77,19 +81,13 @@ class Determination < Strata::Determination
     tanf_snap_work: "tanf_snap_work_excluded",
     drug_treatment: "drug_treatment_excluded",
     inmate: "inmate_excluded",
-    income_reported_compliant: "income_reported_compliant",
-    income_reported_insufficient: "income_reported_insufficient",
-    hours_reported_compliant: "hours_reported_compliant",
-    hours_reported_insufficient: "hours_reported_insufficient",
-    exemption_request_compliant: "exemption_request_compliant",
-    is_veteran_with_disability: "veteran_disability_excluded",
-    denial_response_convincing: "denial_response_convincing",
-    denial_response_not_convincing: "denial_response_not_convincing",
-    # External-exception reason codes (see ExceptionDeterminationService). "Excepted" is a
-    # distinct outcome from "excluded"/"exempt" — do not conflate the three.
-    #
-    # Mandatory exceptions migrated from the exclusion ruleset carry the exclusion's reason code with
-    # "excluded" replaced by "excepted" (e.g. pregnancy_excluded -> pregnancy_excepted).
+    is_veteran_with_disability: "veteran_disability_excluded"
+  }.freeze
+
+  # Recorded as +:excepted+ (see ExceptionDeterminationService). Distinct from "excluded"/"exempt" — do
+  # not conflate the three. Exceptions migrated from the exclusion ruleset reuse its reason code with
+  # "excluded" replaced by "excepted".
+  EXCEPTION_REASON_CODES = {
     was_pregnant: "pregnancy_excepted",
     was_former_foster_care: "was_former_foster_care",
     was_caretaker: "caretaker_excepted",
@@ -103,39 +101,51 @@ class Determination < Strata::Determination
     participating_in_other_program: "other_program_excepted"
   }.freeze
 
-  # REASON_CODE_MAPPING is one flat namespace; these lists partition its non-exclusion keys so a
-  # consumer can tell which determination an outcome calls for. VerificationDataSourcesLoader
-  # boot-validates the partition against every order-bearing source's declared outcomes.
+  # A community-engagement track reached its threshold. Recorded as +:compliant+.
+  CE_MET_REASON_CODES = {
+    hours_reported_compliant: "hours_reported_compliant",
+    income_reported_compliant: "income_reported_compliant"
+  }.freeze
 
-  # Attests a non-exclusion exception applies. Recorded as +:excepted+.
-  EXCEPTION_OUTCOME_KEYS = %i[
-    was_pregnant
-    was_former_foster_care
-    was_caretaker
-    was_in_drug_treatment
-    was_inmate
-    age_was_under_19
-    receiving_inpatient_medical_care
-    resides_in_declared_emergency_county
-    resides_in_high_unemployment_county
-    traveling_for_medical_care
-    participating_in_other_program
+  # Neither community-engagement track reached its threshold. Recorded as +:not_compliant+.
+  CE_INSUFFICIENT_REASON_CODES = {
+    hours_reported_insufficient: "hours_reported_insufficient",
+    income_reported_insufficient: "income_reported_insufficient"
+  }.freeze
+
+  # An approved exemption request. Recorded as +:exempt+.
+  EXEMPTION_REQUEST_REASON_CODES = {
+    exemption_request_compliant: "exemption_request_compliant"
+  }.freeze
+
+  # A staff reviewer's verdict on a member's response to a denial.
+  DENIAL_RESPONSE_REASON_CODES = {
+    denial_response_convincing: "denial_response_convincing",
+    denial_response_not_convincing: "denial_response_not_convincing"
+  }.freeze
+
+  REASON_CODE_GROUPS = [
+    EXCLUSION_REASON_CODES,
+    EXCEPTION_REASON_CODES,
+    CE_MET_REASON_CODES,
+    CE_INSUFFICIENT_REASON_CODES,
+    EXEMPTION_REQUEST_REASON_CODES,
+    DENIAL_RESPONSE_REASON_CODES
   ].freeze
 
-  # Attests the CE requirement is met. Recorded as +:compliant+.
-  CE_OUTCOME_KEYS = %i[
-    hours_reported_compliant
-    income_reported_compliant
-  ].freeze
+  # A key defined in two groups is silently overwritten here; determination_spec catches that with a
+  # size check.
+  REASON_CODE_MAPPING = REASON_CODE_GROUPS.reduce(:merge).freeze
 
+  # Which determination a non-exclusion outcome calls for. VerificationDataSourcesLoader
+  # boot-validates every order-bearing source's declared outcomes against this partition.
+  EXCEPTION_OUTCOME_KEYS = EXCEPTION_REASON_CODES.keys.freeze
+  CE_OUTCOME_KEYS = CE_MET_REASON_CODES.keys.freeze
   NON_EXCLUSION_OUTCOME_KEYS = (EXCEPTION_OUTCOME_KEYS + CE_OUTCOME_KEYS).freeze
 
-  # Reasons recorded when a staff reviewer approves or denies a member's denial response.
-  DENIAL_RESPONSE_REASONS = REASON_CODE_MAPPING.values_at(
-    :denial_response_convincing,
-    :denial_response_not_convincing
-  ).freeze
+  DENIAL_RESPONSE_REASONS = DENIAL_RESPONSE_REASON_CODES.values.freeze
 
+  # Spans groups on purpose: three exclusion conditions also stand as exemption reasons.
   EXEMPTION_REASONS = REASON_CODE_MAPPING.values_at(
     :is_pregnant,
     :is_american_indian_or_alaska_native,

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -103,6 +103,33 @@ class Determination < Strata::Determination
     participating_in_other_program: "other_program_excepted"
   }.freeze
 
+  # REASON_CODE_MAPPING is one flat namespace; these lists partition its non-exclusion keys so a
+  # consumer can tell which determination an outcome calls for. VerificationDataSourcesLoader
+  # boot-validates the partition against every order-bearing source's declared outcomes.
+
+  # Attests a non-exclusion exception applies. Recorded as +:excepted+.
+  EXCEPTION_OUTCOME_KEYS = %i[
+    was_pregnant
+    was_former_foster_care
+    was_caretaker
+    was_in_drug_treatment
+    was_inmate
+    age_was_under_19
+    receiving_inpatient_medical_care
+    resides_in_declared_emergency_county
+    resides_in_high_unemployment_county
+    traveling_for_medical_care
+    participating_in_other_program
+  ].freeze
+
+  # Attests the CE requirement is met. Recorded as +:compliant+.
+  CE_OUTCOME_KEYS = %i[
+    hours_reported_compliant
+    income_reported_compliant
+  ].freeze
+
+  NON_EXCLUSION_OUTCOME_KEYS = (EXCEPTION_OUTCOME_KEYS + CE_OUTCOME_KEYS).freeze
+
   # Reasons recorded when a staff reviewer approves or denies a member's denial response.
   DENIAL_RESPONSE_REASONS = REASON_CODE_MAPPING.values_at(
     :denial_response_convincing,

--- a/reporting-app/app/services/verification_data_sources_loader.rb
+++ b/reporting-app/app/services/verification_data_sources_loader.rb
@@ -70,6 +70,7 @@ module VerificationDataSourcesLoader
       klass = validate_adapter_class!(entry)
       outcomes = fetch_declared_outcomes!(entry, klass)
       validate_outcome_ids!(entry, outcomes, valid_outcomes)
+      validate_non_exclusion_outcome_categories!(entry, outcomes)
     end
   end
 
@@ -170,5 +171,24 @@ module VerificationDataSourcesLoader
     raise ConfigurationError,
       "verification_data_sources.#{entry[:id]}: .declared_outcomes references unknown id(s) #{unknown.map(&:to_s)}; " \
       "valid ids are Determination::REASON_CODE_MAPPING keys (#{valid_outcomes.map(&:to_s).sort})"
+  end
+
+  # The non-exclusion pass records an outcome by CATEGORY (exception → :excepted, CE → :compliant),
+  # so an uncategorized outcome clears validate_outcome_ids! and fails only at determination time.
+  # Exclusion keys stay permitted: a hybrid source is registrable by design, its exclusion outcomes
+  # ranked by Exclusion.priority_order. Exclusion-only sources (order: nil) never enter the pass.
+  def validate_non_exclusion_outcome_categories!(entry, outcomes)
+    return if entry[:order].nil?
+
+    uncategorized = outcomes.reject do |outcome|
+      Determination::NON_EXCLUSION_OUTCOME_KEYS.include?(outcome) || Exclusion.find(outcome).present?
+    end
+    return if uncategorized.empty?
+
+    raise ConfigurationError,
+      "verification_data_sources.#{entry[:id]}: order-bearing source declares uncategorized " \
+      "outcome(s) #{uncategorized.map(&:to_s)}; an order-bearing source joins the non-exclusion " \
+      "pass, so each declared outcome must be an exclusion id, or be in " \
+      "Determination::EXCEPTION_OUTCOME_KEYS or Determination::CE_OUTCOME_KEYS"
   end
 end

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -309,6 +309,43 @@ RSpec.describe Determination, type: :model do
     end
   end
 
+  # VerificationDataSourcesLoader boot-validates against these, so the count canary below turns
+  # "added an exception check without categorizing it" into a test failure here rather than a boot
+  # error on the first deployment that registers a source declaring it.
+  describe 'non-exclusion outcome categories' do
+    it 'references only real REASON_CODE_MAPPING keys' do
+      expect(described_class::NON_EXCLUSION_OUTCOME_KEYS)
+        .to all(be_in(described_class::REASON_CODE_MAPPING.keys))
+    end
+
+    it 'keeps the exception and community-engagement categories disjoint' do
+      overlap = described_class::EXCEPTION_OUTCOME_KEYS & described_class::CE_OUTCOME_KEYS
+      expect(overlap).to be_empty
+    end
+
+    # ExceptionDeterminationService produces every exception reason code, so its checks bound the set.
+    it 'covers every exception reason code ExceptionDeterminationService can produce' do
+      in_hand_exception_codes = described_class::EXCEPTION_OUTCOME_KEYS
+        .map { |key| described_class::REASON_CODE_MAPPING.fetch(key) }
+
+      expect(in_hand_exception_codes).to include(
+        'pregnancy_excepted',
+        'was_former_foster_care',
+        'caretaker_excepted',
+        'drug_treatment_excepted',
+        'inmate_excepted',
+        'age_under_19_excepted',
+        'inpatient_medical_care_excepted',
+        'declared_emergency_county_excepted',
+        'high_unemployment_county_excepted',
+        'medical_travel_excepted',
+        'other_program_excepted'
+      )
+      expect(described_class::EXCEPTION_OUTCOME_KEYS.count)
+        .to eq(ExceptionDeterminationService::EXCEPTION_CHECKS.count)
+    end
+  end
+
   describe '#source' do
     it 'returns the matched verification data source when one was recorded' do
       determination = build(:determination, decision_method: 'automated',

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -309,38 +309,30 @@ RSpec.describe Determination, type: :model do
     end
   end
 
-  # VerificationDataSourcesLoader boot-validates against these, so the count canary below turns
-  # "added an exception check without categorizing it" into a test failure here rather than a boot
-  # error on the first deployment that registers a source declaring it.
-  describe 'non-exclusion outcome categories' do
-    it 'references only real REASON_CODE_MAPPING keys' do
-      expect(described_class::NON_EXCLUSION_OUTCOME_KEYS)
-        .to all(be_in(described_class::REASON_CODE_MAPPING.keys))
+  # Grouping makes a code's category structural, so every way it can go wrong is now silent.
+  describe 'reason code groups' do
+    it 'defines every reason code in exactly one group' do
+      expect(described_class::REASON_CODE_MAPPING.size)
+        .to eq(described_class::REASON_CODE_GROUPS.sum(&:size))
     end
 
-    it 'keeps the exception and community-engagement categories disjoint' do
-      overlap = described_class::EXCEPTION_OUTCOME_KEYS & described_class::CE_OUTCOME_KEYS
+    # A met code filed under CE_INSUFFICIENT_REASON_CODES, or the reverse, records :compliant for a
+    # member who reached neither threshold.
+    it 'keeps the community-engagement met and insufficient codes distinguishable' do
+      expect(described_class::CE_MET_REASON_CODES.values).to all(end_with('_compliant'))
+      expect(described_class::CE_INSUFFICIENT_REASON_CODES.values).to all(end_with('_insufficient'))
+    end
+
+    # An exclusion key here lets an order-bearing source emit an exclusion into a pass with no
+    # determination shape for one.
+    it 'keeps exclusion keys out of the non-exclusion partition' do
+      overlap = described_class::NON_EXCLUSION_OUTCOME_KEYS & described_class::EXCLUSION_REASON_CODES.keys
       expect(overlap).to be_empty
     end
 
-    # ExceptionDeterminationService produces every exception reason code, so its checks bound the set.
-    it 'covers every exception reason code ExceptionDeterminationService can produce' do
-      in_hand_exception_codes = described_class::EXCEPTION_OUTCOME_KEYS
-        .map { |key| described_class::REASON_CODE_MAPPING.fetch(key) }
-
-      expect(in_hand_exception_codes).to include(
-        'pregnancy_excepted',
-        'was_former_foster_care',
-        'caretaker_excepted',
-        'drug_treatment_excepted',
-        'inmate_excepted',
-        'age_under_19_excepted',
-        'inpatient_medical_care_excepted',
-        'declared_emergency_county_excepted',
-        'high_unemployment_county_excepted',
-        'medical_travel_excepted',
-        'other_program_excepted'
-      )
+    # Its checks bound the set, so a twelfth check with no reason code fails here rather than at boot
+    # on the first deployment that registers a source declaring it.
+    it 'keeps one exception reason code per ExceptionDeterminationService check' do
       expect(described_class::EXCEPTION_OUTCOME_KEYS.count)
         .to eq(ExceptionDeterminationService::EXCEPTION_CHECKS.count)
     end

--- a/reporting-app/spec/services/verification_data_sources_loader_spec.rb
+++ b/reporting-app/spec/services/verification_data_sources_loader_spec.rb
@@ -279,6 +279,53 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
     end
   end
 
+  # These pin an uncategorized order-bearing outcome to a boot failure, not a determination-time one.
+  describe "order-bearing outcome categorization" do
+    def entry_for(outcomes, order:)
+      klass = Class.new(Verification::DataSource) do
+        define_singleton_method(:declared_outcomes) { outcomes }
+      end
+      stub_const("CategorizationTestSource", klass)
+      [ { id: :probe, enabled: true, adapter_class: "CategorizationTestSource", order: order } ]
+    end
+
+    it "rejects an order-bearing source declaring a known but uncategorized outcome" do
+      # A real REASON_CODE_MAPPING key, so validate_outcome_ids! passes; just uncategorized.
+      entries = entry_for([ :exemption_request_compliant ], order: 10)
+
+      expect { described_class.validate_registry!(entries) }.to raise_error(
+        described_class::ConfigurationError,
+        /uncategorized outcome\(s\) \["exemption_request_compliant"\]/
+      )
+    end
+
+    it "accepts an order-bearing source declaring an exception outcome" do
+      entries = entry_for([ :resides_in_declared_emergency_county ], order: 10)
+
+      expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+
+    it "accepts an order-bearing source declaring a community-engagement outcome" do
+      entries = entry_for([ :hours_reported_compliant ], order: 10)
+
+      expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+
+    # ExclusionDeterminationService ranks by Exclusion.priority_order, not by category.
+    it "does not category-check an exclusion-only source (order: nil)" do
+      entries = entry_for([ :is_veteran_with_disability ], order: nil)
+
+      expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+
+    # A hybrid stays registrable; the Exclusion registry categorizes its exclusion outcomes.
+    it "permits an exclusion outcome on an order-bearing source" do
+      entries = entry_for([ :resides_in_declared_emergency_county, :is_veteran_with_disability ], order: 10)
+
+      expect { described_class.validate_registry!(entries) }.not_to raise_error
+    end
+  end
+
   describe "full pipeline against the shipped defaults + override file" do
     it "loads, merges, transforms, and passes registry validation" do
       override_path = Rails.root.join("config/custom/verification_data_sources.yml")
@@ -286,20 +333,21 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       merged = described_class.merge_with_defaults(overrides)
       entries = described_class.transform(merged)
 
-      expect(entries.map { |e| e[:id] }).to include(:mock_drug_treatment, :mock_emergency_county)
+      expect(entries.map { |e| e[:id] })
+        .to include(:mock_drug_treatment, :mock_emergency_county)
       expect { described_class.validate_registry!(entries) }.not_to raise_error
     end
 
-    it "registers mock_emergency_county as an order-bearing non-exclusion source" do
+    it "registers mock_emergency_county as an enabled order-bearing non-exclusion source" do
       override_path = Rails.root.join("config/custom/verification_data_sources.yml")
       overrides = described_class.safe_load_optional(override_path)
       entries = described_class.transform(described_class.merge_with_defaults(overrides))
 
       entry = entries.find { |e| e[:id] == :mock_emergency_county }
-      expect(entry[:enabled]).to be(true)
       expect(entry[:adapter_class]).to eq("Verification::Adapters::MockEmergencyCounty")
       # An Integer order (not nil) is what makes it part of the orchestrator's pass.
       expect(entry[:order]).to be_an(Integer)
+      expect(entry[:enabled]).to be(true)
     end
   end
 
@@ -316,13 +364,13 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
         .to eq([ :drug_treatment, :was_in_drug_treatment ])
     end
 
-    it "wires mock_emergency_county with an Integer order for the orchestrator pass" do
+    it "wires mock_emergency_county order-bearing and enabled" do
       sources = Rails.application.config.verification_data_sources
 
       mock = sources.find { |s| s[:id] == :mock_emergency_county }
-      expect(mock[:enabled]).to be(true)
       expect(mock[:adapter_class]).to eq("Verification::Adapters::MockEmergencyCounty")
       expect(mock[:order]).to be_an(Integer)
+      expect(mock[:enabled]).to be(true)
       expect(Verification::Adapters::MockEmergencyCounty.declared_outcomes)
         .to eq([ :resides_in_declared_emergency_county ])
     end


### PR DESCRIPTION
## Ticket

Part of #805

First of four in a stack: this, #828, #829, #822. Lands inert; #822 is the consumer.

## Changes

- Split `Determination::REASON_CODE_MAPPING` into six groups named for the outcome that records them
  (exclusion, exception, CE met, CE insufficient, exemption request, denial response), and build the
  flat lookup by merging them, so every existing caller is untouched.
- Derive `EXCEPTION_OUTCOME_KEYS`, `CE_OUTCOME_KEYS`, `NON_EXCLUSION_OUTCOME_KEYS` and
  `DENIAL_RESPONSE_REASONS` from their groups rather than restating their keys.
- Boot-validate in `VerificationDataSourcesLoader` that an order-bearing source declares only
  categorized outcomes. Exclusion keys stay permitted; `order: nil` sources are skipped.
- Add four `determination_spec` guards: the merged size equals the sum of the groups, CE met and
  insufficient codes stay distinguishable, no exclusion key reaches the non-exclusion partition, and
  the exception group's size matches `ExceptionDeterminationService::EXCEPTION_CHECKS`.

## Context for reviewers

`REASON_CODE_MAPPING` spans exclusion, exception, community-engagement, exemption and denial-response
codes in one namespace, and nothing said which category an emitted outcome falls in. Grouping it by
recording outcome makes a code's category follow from where it is defined, so a consumer can pick a
determination shape without a separate list of keys to keep in step. `EXEMPTION_REASONS` stays a
`values_at` view because it deliberately spans groups: three exclusion conditions also stand as
exemption reasons.

Boot validation rather than a spec, because an uncategorized outcome is a real `REASON_CODE_MAPPING`
key: it clears the existing `validate_outcome_ids!` check and fails only at determination time, inside
Strata's `rescue Exception` plus a log, stranding the case with no determination, notification or staff
task. `config/custom/verification_data_sources.yml` is also deployment-owned, so a registration our CI
never sees can introduce one.

The four guards cover what grouping makes silent. `reduce(:merge)` keeps the last value for a key
defined twice, so the size check catches a duplicate the merge would swallow. A code filed under the
wrong group preserves the total, so the suffix and exclusion-key guards cover mis-categorization. The
consequential cases are a CE insufficient code recorded as `:compliant`, and an exclusion key reaching
a pass with no determination shape for one. The exception group cannot be derived from
`EXCEPTION_CHECKS`, which holds check method names (`pregnancy`, `medical_travel`) rather than outcome
keys (`was_pregnant`, `traveling_for_medical_care`), so a size assertion is the available link.

This does not change the exclusion path: the boot check returns early for `order: nil` sources, which
is how exclusion-only sources are registered.

## Testing

- Suite green on this branch alone: 3052 examples, 0 failures. 96.72% line, 84.05% branch.
- RuboCop clean across 569 files.
- Boot validation exercised against the real registry (the loader spec loads the shipped config and
  asserts it passes), plus a stubbed source declaring `:exemption_request_compliant`, a real key in no
  category, rejected at boot.
- Each new guard confirmed to fail on the mis-categorization it describes, not just to pass today.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->