### PR TITLE
Extract the shared in-hand community-engagement assessment

### DIFF
--- a/reporting-app/app/services/community_engagement_check_service.rb
+++ b/reporting-app/app/services/community_engagement_check_service.rb
@@ -6,43 +6,54 @@
 # see NotificationsEventListener).
 class CommunityEngagementCheckService
   include Strata::VirtualActor
+
+  # The in-hand assessment: both aggregates and their per-track verdicts. Extracted from #determine
+  # so a second step can reuse the derivation instead of repeating it, where the two could drift.
+  Assessment = Struct.new(:hours_data, :income_data, :hours_ok, :income_ok, keyword_init: true) do
+    def met?
+      hours_ok || income_ok
+    end
+  end
+
   class << self
     # @param kase [CertificationCase]
     def determine(kase)
       certification = Certification.find(kase.certification_id)
-      hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(
-        certification
-      )
-      income_data = IncomeComplianceDeterminationService.aggregate_income_for_certification(
-        certification
-      )
-
-      hours_ok = hours_compliant?(hours_data)
-      income_ok = IncomeComplianceDeterminationService.compliant_for_total_income?(income_data[:total_income])
+      assessment = assess(certification)
 
       kase.record_external_ce_combined_assessment(
         actor: self,
         certification: certification,
-        hours_data: hours_data,
-        income_data: income_data,
-        hours_ok: hours_ok,
-        income_ok: income_ok
+        hours_data: assessment.hours_data,
+        income_data: assessment.income_data,
+        hours_ok: assessment.hours_ok,
+        income_ok: assessment.income_ok
       )
 
       publish_workflow_events(
         kase: kase,
         certification: certification,
+        hours_data: assessment.hours_data,
+        income_data: assessment.income_data,
+        either_track_compliant: assessment.met?
+      )
+    end
+
+    # @param certification [Certification]
+    # @return [Assessment]
+    def assess(certification)
+      hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(certification)
+      income_data = IncomeComplianceDeterminationService.aggregate_income_for_certification(certification)
+
+      Assessment.new(
         hours_data: hours_data,
         income_data: income_data,
-        either_track_compliant: hours_ok || income_ok
+        hours_ok: HoursComplianceDeterminationService.compliant_for_total_hours?(hours_data[:total_hours]),
+        income_ok: IncomeComplianceDeterminationService.compliant_for_total_income?(income_data[:total_income])
       )
     end
 
     private
-
-    def hours_compliant?(hours_data)
-      HoursComplianceDeterminationService.compliant_for_total_hours?(hours_data[:total_hours])
-    end
 
     def publish_workflow_events(kase:, certification:, hours_data:, income_data:, either_track_compliant:)
       payload_base = {

--- a/reporting-app/spec/services/community_engagement_check_service_spec.rb
+++ b/reporting-app/spec/services/community_engagement_check_service_spec.rb
@@ -38,27 +38,46 @@ RSpec.describe CommunityEngagementCheckService do
   # .assess is the derivation .determine used to inline. It is public so a second step can reuse it
   # rather than re-deriving the same four values and risking a different verdict.
   describe ".assess" do
-    it "returns both aggregates and their per-track verdicts" do
-      create_external_hourly_activity_for(certification, hours: 85)
+    let(:over_hours) { HoursComplianceDeterminationService::TARGET_HOURS + 5 }
+    let(:under_hours) { HoursComplianceDeterminationService::TARGET_HOURS / 2 }
+    let(:over_income) { IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY + 20 }
+    let(:under_income) { IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2 }
+
+    it "returns both aggregates and their per-track verdicts when only hours pass" do
+      create_external_hourly_activity_for(certification, hours: over_hours)
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.hours_data[:total_hours]).to eq(over_hours)
+      expect(assessment.income_data[:total_income]).to be_zero
+      expect(assessment.hours_ok).to be(true)
+      expect(assessment.income_ok).to be(false)
+      expect(assessment.met?).to be(true)
+    end
+
+    # met? is hours_ok || income_ok; without this the income side is never exercised.
+    it "reports met? when only the income track passes" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: over_income)
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.income_data[:total_income]).to eq(over_income)
+      expect(assessment.hours_ok).to be(false)
+      expect(assessment.income_ok).to be(true)
+      expect(assessment.met?).to be(true)
+    end
+
+    # Both tracks carry below-threshold data, so a verdict derived from presence rather than amount
+    # fails here instead of passing on an empty aggregate.
+    it "reports met? false when neither track passes" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: under_income)
 
       assessment = described_class.assess(certification)
 
       expect(assessment.hours_data[:total_hours]).to be_positive
-      expect(assessment.income_data).to have_key(:total_income)
-      expect(assessment.hours_ok).to be(true)
-      expect(assessment.income_ok).to be(false)
-    end
-
-    it "reports met? when either track passes" do
-      create_external_hourly_activity_for(certification, hours: 85)
-
-      expect(described_class.assess(certification).met?).to be(true)
-    end
-
-    it "reports met? false when neither track passes" do
-      create_external_hourly_activity_for(certification, hours: 1)
-
-      assessment = described_class.assess(certification)
+      expect(assessment.income_data[:total_income]).to be_positive
       expect(assessment.hours_ok).to be(false)
       expect(assessment.income_ok).to be(false)
       expect(assessment.met?).to be(false)

--- a/reporting-app/spec/services/community_engagement_check_service_spec.rb
+++ b/reporting-app/spec/services/community_engagement_check_service_spec.rb
@@ -35,6 +35,36 @@ RSpec.describe CommunityEngagementCheckService do
     Determination.unscope(:order).where(subject_id: certification_id).order(created_at: :desc).first
   end
 
+  # .assess is the derivation .determine used to inline. It is public so a second step can reuse it
+  # rather than re-deriving the same four values and risking a different verdict.
+  describe ".assess" do
+    it "returns both aggregates and their per-track verdicts" do
+      create_external_hourly_activity_for(certification, hours: 85)
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.hours_data[:total_hours]).to be_positive
+      expect(assessment.income_data).to have_key(:total_income)
+      expect(assessment.hours_ok).to be(true)
+      expect(assessment.income_ok).to be(false)
+    end
+
+    it "reports met? when either track passes" do
+      create_external_hourly_activity_for(certification, hours: 85)
+
+      expect(described_class.assess(certification).met?).to be(true)
+    end
+
+    it "reports met? false when neither track passes" do
+      create_external_hourly_activity_for(certification, hours: 1)
+
+      assessment = described_class.assess(certification)
+      expect(assessment.hours_ok).to be(false)
+      expect(assessment.income_ok).to be(false)
+      expect(assessment.met?).to be(false)
+    end
+  end
+
   describe ".determine" do
     context "when hours meet target (hours-only pass)" do
       before do


### PR DESCRIPTION
## Ticket

Part of #805

Second of four in a stack: #823, this, #829, #822. A pure refactor, split out so it can be verified as
a no-op on its own.

## Changes

- Extract the in-hand community-engagement derivation from `CommunityEngagementCheckService#determine`
  into a public `.assess`, returning an `Assessment` struct: both aggregates, both per-track verdicts,
  and `#met?`.
- Fold the private `hours_compliant?` wrapper into `.assess`.
- Add a direct `.assess` spec covering hours-only, income-only and neither, so `met?` is exercised
  through both sides of its disjunction rather than only the hours track.

## Context for reviewers

The trailing data-source step in #822 has to recompute this assessment when no source produced an
outcome, because Strata hands a `system_process` only the case and never the triggering event.
Deriving the same four values in both steps would let them disagree about the same certification, so
the derivation lives in one place.

Split from #822 because the extraction and the behavioural change that consumes it are hard to review
together: the diff shows a rewritten method body with no easy way to tell which lines moved and which
changed behaviour. Reviewed alone the evidence is simple, since every pre-existing example passes with
the spec file unmodified. `.determine` still records the combined determination and still publishes all
three community-engagement events; #822 changes that.

## Testing

- Suite green on this branch alone: 3054 examples, 0 failures. 96.72% line, 84.05% branch. Branch
  coverage is unchanged from #823, as expected for a refactor over already-covered paths.
- RuboCop clean across 569 files.
- The 16 pre-existing `community_engagement_check_service_spec` examples pass with no edits to the spec
  file, which is the substance of the no-op claim. Three new examples cover `.assess` and `#met?`.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->