### PR TITLE
Register the community-engagement mock data source

### DIFF
--- a/reporting-app/app/services/verification/adapters/mock_community_engagement.rb
+++ b/reporting-app/app/services/verification/adapters/mock_community_engagement.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Verification
+  module Adapters
+    # Mock data source for the community-engagement half of the ordered non-exclusion pass
+    # (OSCER-805). Attests the requirement is met rather than reporting hours, and declares no
+    # exclusion outcome, so only the orchestrator consults it.
+    #
+    # Keys off the member's email, NOT va_icn, and must stay that way: MockDrugTreatment runs at the
+    # earlier exclusion step and ends the case for 7 of 10 va_icn last digits, leaving only even ones,
+    # which are MockEmergencyCounty's — a va_icn-keyed trigger here would be starved before it ran.
+    # Email is as inert as va_icn (no determination path reads it); the substring idiom follows
+    # Auth::MockAdapter ("unconfirmed").
+    #
+    # A real source must NOT copy this: email describes the member and also joins them to their
+    # certification (Certification.find_by_member_email), so one member-influenceable attribute both
+    # selects the record and drives a favorable outcome. Fine synthetically, never for real.
+    class MockCommunityEngagement < Verification::DataSource
+      SOURCE = "mock_community_engagement"
+      OUTCOME_CE_MET = :hours_reported_compliant
+      TRIGGER_EMAIL_SUBSTRING = "ce-met"
+
+      def self.declared_outcomes
+        [ OUTCOME_CE_MET ]
+      end
+
+      protected
+
+      def precondition_met?(certification)
+        certification.member_email.present?
+      end
+
+      def perform(certification:)
+        success_result(
+          outcomes: outcomes_for(certification.member_email),
+          audit_data: { source: SOURCE }
+        )
+      end
+
+      private
+
+      def outcomes_for(email)
+        email.downcase.include?(TRIGGER_EMAIL_SUBSTRING) ? [ OUTCOME_CE_MET ] : []
+      end
+    end
+  end
+end

--- a/reporting-app/config/custom/verification_data_sources.yml
+++ b/reporting-app/config/custom/verification_data_sources.yml
@@ -80,3 +80,11 @@ mock_emergency_county:
   enabled: true
   adapter_class: "Verification::Adapters::MockEmergencyCounty"
   order: 10
+
+# The community-engagement half of the same pass: attests the requirement is met rather
+# than reporting hours. Ordered after mock_emergency_county so the exception source is
+# consulted first. Keys off the member's email, not va_icn — see the adapter for why.
+mock_community_engagement:
+  enabled: true
+  adapter_class: "Verification::Adapters::MockCommunityEngagement"
+  order: 20

--- a/reporting-app/spec/rails_helper.rb
+++ b/reporting-app/spec/rails_helper.rb
@@ -47,6 +47,7 @@ require_relative 'support/feature_flag_helpers'
 require_relative 'support/env_helpers'
 require_relative 'support/yaml_config_helpers'
 require_relative 'support/verification/data_source_shared_examples'
+require_relative 'support/verification/registry_helpers'
 require "strata/testing/api_auth_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/reporting-app/spec/services/verification/adapters/mock_community_engagement_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/mock_community_engagement_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Verification::Adapters::MockCommunityEngagement do
+  subject(:result) { described_class.new.call(certification: certification) }
+
+  let(:certification) do
+    build(:certification, member_data: build(:certification_member_data, **member_data_attrs))
+  end
+  let(:member_data_attrs) { { account_email: account_email } }
+  let(:trigger) { described_class::TRIGGER_EMAIL_SUBSTRING }
+
+  describe ".declared_outcomes" do
+    let(:account_email) { nil }
+
+    it "declares the hours-met community-engagement outcome key" do
+      expect(described_class.declared_outcomes).to contain_exactly(:hours_reported_compliant)
+    end
+
+    it "declares only Determination reason-code mapping keys" do
+      expect(described_class.declared_outcomes).to all(be_in(Determination::REASON_CODE_MAPPING.keys))
+    end
+
+    it "declares only non-exclusion (order-bearing) outcome keys" do
+      expect(described_class.declared_outcomes).to all(satisfy { |key| Exclusion.find(key).nil? })
+    end
+  end
+
+  describe "#call" do
+    context "when the member has no email" do
+      let(:account_email) { nil }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the email is a blank string" do
+      let(:account_email) { "" }
+
+      it_behaves_like "a skipped verification result"
+    end
+
+    context "when the email does not contain the trigger" do
+      let(:account_email) { "member@example.com" }
+
+      it_behaves_like "a successful verification result"
+
+      it "returns no result (empty outcomes)" do
+        expect(result.outcomes).to eq([])
+      end
+
+      it "tags the audit data with the source" do
+        expect(result.audit_data[:source]).to eq("mock_community_engagement")
+      end
+    end
+
+    context "when the email contains the trigger" do
+      let(:account_email) { "member+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com" }
+
+      it_behaves_like "a successful verification result"
+
+      it "attests the community-engagement requirement is met" do
+        expect(result.outcomes).to eq([ :hours_reported_compliant ])
+      end
+
+      it "tags the audit data with the source" do
+        expect(result.audit_data[:source]).to eq("mock_community_engagement")
+      end
+    end
+
+    context "when the trigger appears in the local part in mixed case" do
+      let(:account_email) { "Member.CE-Met@Example.com" }
+
+      it "matches case-insensitively so a capitalized demo email still fires" do
+        expect(result.outcomes).to eq([ :hours_reported_compliant ])
+      end
+    end
+
+    context "when the trigger is present only on the contact email" do
+      let(:member_data_attrs) { { contact: { email: "contact+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com" } } }
+
+      it "reads through Certification#member_email so either email field works" do
+        expect(result.outcomes).to eq([ :hours_reported_compliant ])
+      end
+    end
+  end
+
+  # The defect this replaces: the previous design keyed off va_icn parity, which made
+  # the demonstrated branch depend on what OTHER va_icn-keyed sources did at earlier
+  # pipeline stages. Orthogonality is the invariant now, so assert it directly.
+  describe "orthogonality to va_icn" do
+    (0..9).each do |digit|
+      it "emits the CE outcome regardless of va_icn last digit #{digit}" do
+        cert = build(:certification, member_data: build(
+          :certification_member_data,
+          va_icn: "10000000#{digit}",
+          account_email: "member+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com"
+        ))
+
+        expect(described_class.new.call(certification: cert).outcomes).to eq([ :hours_reported_compliant ])
+      end
+    end
+
+    it "emits no outcome for a triggerless email regardless of an odd va_icn" do
+      cert = build(:certification, member_data: build(
+        :certification_member_data, va_icn: "1000000007", account_email: "member@example.com"
+      ))
+
+      expect(described_class.new.call(certification: cert).outcomes).to eq([])
+    end
+  end
+end

--- a/reporting-app/spec/services/verification/adapters/mock_community_engagement_spec.rb
+++ b/reporting-app/spec/services/verification/adapters/mock_community_engagement_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Verification::Adapters::MockCommunityEngagement do
     end
 
     context "when the email contains the trigger" do
-      let(:account_email) { "member+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com" }
+      let(:account_email) { "member+#{trigger}@example.com" }
 
       it_behaves_like "a successful verification result"
 
@@ -68,16 +68,16 @@ RSpec.describe Verification::Adapters::MockCommunityEngagement do
       end
     end
 
-    context "when the trigger appears in the local part in mixed case" do
-      let(:account_email) { "Member.CE-Met@Example.com" }
+    context "when the trigger appears in the local part in a different case" do
+      let(:account_email) { "Member.#{trigger.upcase}@Example.com" }
 
-      it "matches case-insensitively so a capitalized demo email still fires" do
+      it "matches case-insensitively so a demo email typed in any case still fires" do
         expect(result.outcomes).to eq([ :hours_reported_compliant ])
       end
     end
 
     context "when the trigger is present only on the contact email" do
-      let(:member_data_attrs) { { contact: { email: "contact+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com" } } }
+      let(:member_data_attrs) { { contact: { email: "contact+#{trigger}@example.com" } } }
 
       it "reads through Certification#member_email so either email field works" do
         expect(result.outcomes).to eq([ :hours_reported_compliant ])
@@ -94,7 +94,7 @@ RSpec.describe Verification::Adapters::MockCommunityEngagement do
         cert = build(:certification, member_data: build(
           :certification_member_data,
           va_icn: "10000000#{digit}",
-          account_email: "member+#{described_class::TRIGGER_EMAIL_SUBSTRING}@example.com"
+          account_email: "member+#{trigger}@example.com"
         ))
 
         expect(described_class.new.call(certification: cert).outcomes).to eq([ :hours_reported_compliant ])

--- a/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
+++ b/reporting-app/spec/services/verification/data_source_orchestrator_spec.rb
@@ -25,13 +25,7 @@ RSpec.describe Verification::DataSourceOrchestrator do
     const_name
   end
 
-  def registry_entry(id:, adapter_class:, order:, enabled: true)
-    { id: id, enabled: enabled, adapter_class: adapter_class, order: order }
-  end
-
-  def stub_registry(entries)
-    allow(Rails.application.config).to receive(:verification_data_sources).and_return(entries)
-  end
+  # stub_registry / registry_entry come from VerificationRegistryHelpers.
 
   def success(outcomes:, audit_data: {})
     Verification::DataSourceResult.success(outcomes: outcomes, audit_data: audit_data)
@@ -171,39 +165,78 @@ RSpec.describe Verification::DataSourceOrchestrator do
   end
 
   # Exercises the ACTUAL booted Rails.application.config.verification_data_sources
-  # rather than a stubbed registry, so Phase B's registration in
-  # config/custom/verification_data_sources.yml is proven end-to-end. The only
-  # order-bearing source shipped there is mock_emergency_county (mock_drug_treatment
-  # is order: nil and belongs to the exclusion path, so it is never in this pass).
+  # rather than a stubbed registry, so the registration in
+  # config/custom/verification_data_sources.yml is proven end-to-end.
   describe "against the real registered configuration" do
     let(:certification) do
-      build(:certification, member_data: build(:certification_member_data, va_icn: va_icn))
+      build(:certification, member_data: build(
+        :certification_member_data, va_icn: va_icn, account_email: account_email
+      ))
+    end
+    let(:va_icn) { "1012861229V078998" }
+    # Non-triggering by default; mock_community_engagement keys off the email, not the ICN.
+    let(:account_email) { "member@example.com" }
+    let(:ce_trigger_email) { "member+#{Verification::Adapters::MockCommunityEngagement::TRIGGER_EMAIL_SUBSTRING}@example.com" }
+
+    # The shipped config ENABLES both demo mocks: no real non-exclusion source exists yet, so
+    # they are what exercises this pass end to end in the test deployments. Both are
+    # order-bearing; mock_drug_treatment is order: nil and belongs to the exclusion path, so it
+    # is never part of this pass regardless.
+    it "registers exactly the two demo mocks as the order-bearing pass, in order" do
+      enabled_order_bearing = Rails.application.config.verification_data_sources
+        .select { |e| e[:enabled] && !e[:order].nil? }
+        .sort_by { |e| e[:order] }
+
+      expect(enabled_order_bearing.map { |e| e[:id] })
+        .to eq([ :mock_emergency_county, :mock_community_engagement ])
     end
 
-    context "when the registered mock emits a matched outcome (even ICN last digit)" do
-      let(:va_icn) { "1012861229V078998" }
+    describe "the shipped demo mocks" do
+      context "when the ICN's last digit is even" do
+        let(:va_icn) { "1012861229V078998" }
 
-      it "is satisfied by mock_emergency_county with the emergency-county outcome" do
-        expect(evaluate).to have_attributes(satisfied: true, source_id: :mock_emergency_county)
-        expect(evaluate.result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+        it "is satisfied by mock_emergency_county (order 10) with the exception outcome" do
+          expect(evaluate).to have_attributes(satisfied: true, source_id: :mock_emergency_county)
+          expect(evaluate.result.outcomes).to eq([ :resides_in_declared_emergency_county ])
+        end
       end
-    end
 
-    context "when the registered mock returns no result (odd ICN last digit)" do
-      let(:va_icn) { "1012861229V078999" }
+      context "when the email carries the CE trigger and the ICN's last digit is not even" do
+        let(:va_icn) { "1012861229V078999" }
+        let(:account_email) { ce_trigger_email }
 
-      it "is not satisfied but records the attempt" do
-        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
-        expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :mock_emergency_county ])
+        # emergency-county returns no result for an odd digit, so the pass continues past it
+        # to the community-engagement mock at order 20.
+        it "falls through to mock_community_engagement with the CE-met outcome" do
+          expect(evaluate).to have_attributes(satisfied: true, source_id: :mock_community_engagement)
+          expect(evaluate.result.outcomes).to eq([ :hours_reported_compliant ])
+          expect(evaluate.attempted.map { |a| a[:source_id] })
+            .to eq([ :mock_emergency_county, :mock_community_engagement ])
+        end
       end
-    end
 
-    context "when the member has no ICN (precondition not met)" do
-      let(:va_icn) { nil }
+      # The two shipped mocks read DIFFERENT fields, so an even digit reaches
+      # mock_emergency_county first and stop-on-first ends the pass there — the CE trigger
+      # in the email is never consulted. Locks in the precedence rather than leaving it to
+      # registry order alone.
+      context "when the email carries the CE trigger but the ICN's last digit is even" do
+        let(:va_icn) { "1012861229V078998" }
+        let(:account_email) { ce_trigger_email }
 
-      it "is not satisfied; the source is attempted and skipped" do
-        expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
-        expect(evaluate.attempted.map { |a| a[:result].status }).to eq(%i[skipped])
+        it "stops at mock_emergency_county (order 10) without attempting the CE source" do
+          expect(evaluate).to have_attributes(satisfied: true, source_id: :mock_emergency_county)
+          expect(evaluate.attempted.map { |a| a[:source_id] }).to eq([ :mock_emergency_county ])
+        end
+      end
+
+      context "when the member has neither an ICN nor an email (preconditions not met)" do
+        let(:va_icn) { nil }
+        let(:account_email) { nil }
+
+        it "is not satisfied; every order-bearing source is attempted and skipped" do
+          expect(evaluate).to have_attributes(satisfied: false, source_id: nil)
+          expect(evaluate.attempted.map { |a| a[:result].status }).to all(eq(:skipped))
+        end
       end
     end
   end

--- a/reporting-app/spec/services/verification_data_sources_loader_spec.rb
+++ b/reporting-app/spec/services/verification_data_sources_loader_spec.rb
@@ -334,20 +334,38 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       entries = described_class.transform(merged)
 
       expect(entries.map { |e| e[:id] })
-        .to include(:mock_drug_treatment, :mock_emergency_county)
+        .to include(:mock_drug_treatment, :mock_emergency_county, :mock_community_engagement)
       expect { described_class.validate_registry!(entries) }.not_to raise_error
     end
 
-    it "registers mock_emergency_county as an enabled order-bearing non-exclusion source" do
+    # Both orchestrator mocks ship enabled and order-bearing (Integer order, so they join the
+    # orchestrator's pass). No real non-exclusion source exists yet, so they are what exercises
+    # the trailing verification_data_source_check step in the test deployments.
+    [
+      [ :mock_emergency_county, "Verification::Adapters::MockEmergencyCounty" ],
+      [ :mock_community_engagement, "Verification::Adapters::MockCommunityEngagement" ]
+    ].each do |id, adapter_class|
+      it "registers #{id} as an enabled order-bearing non-exclusion source" do
+        override_path = Rails.root.join("config/custom/verification_data_sources.yml")
+        overrides = described_class.safe_load_optional(override_path)
+        entries = described_class.transform(described_class.merge_with_defaults(overrides))
+
+        entry = entries.find { |e| e[:id] == id }
+        expect(entry[:adapter_class]).to eq(adapter_class)
+        # An Integer order (not nil) is what makes it part of the orchestrator's pass.
+        expect(entry[:order]).to be_an(Integer)
+        expect(entry[:enabled]).to be(true)
+      end
+    end
+
+    it "orders the exception mock ahead of the community-engagement mock" do
       override_path = Rails.root.join("config/custom/verification_data_sources.yml")
       overrides = described_class.safe_load_optional(override_path)
       entries = described_class.transform(described_class.merge_with_defaults(overrides))
 
-      entry = entries.find { |e| e[:id] == :mock_emergency_county }
-      expect(entry[:adapter_class]).to eq("Verification::Adapters::MockEmergencyCounty")
-      # An Integer order (not nil) is what makes it part of the orchestrator's pass.
-      expect(entry[:order]).to be_an(Integer)
-      expect(entry[:enabled]).to be(true)
+      order_bearing = entries.select { |e| !e[:order].nil? }.sort_by { |e| e[:order] }
+      expect(order_bearing.map { |e| e[:id] })
+        .to eq([ :mock_emergency_county, :mock_community_engagement ])
     end
   end
 
@@ -373,6 +391,18 @@ RSpec.describe VerificationDataSourcesLoader, type: :service do
       expect(mock[:enabled]).to be(true)
       expect(Verification::Adapters::MockEmergencyCounty.declared_outcomes)
         .to eq([ :resides_in_declared_emergency_county ])
+    end
+
+    it "wires mock_community_engagement order-bearing and enabled, after emergency_county" do
+      sources = Rails.application.config.verification_data_sources
+
+      emergency = sources.find { |s| s[:id] == :mock_emergency_county }
+      mock = sources.find { |s| s[:id] == :mock_community_engagement }
+      expect(mock[:adapter_class]).to eq("Verification::Adapters::MockCommunityEngagement")
+      expect(mock[:order]).to be > emergency[:order]
+      expect(mock[:enabled]).to be(true)
+      expect(Verification::Adapters::MockCommunityEngagement.declared_outcomes)
+        .to eq([ :hours_reported_compliant ])
     end
   end
 end

--- a/reporting-app/spec/support/verification/registry_helpers.rb
+++ b/reporting-app/spec/support/verification/registry_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Stubs Rails.application.config.verification_data_sources, the booted data source registry.
+# Extracted from data_source_orchestrator_spec so any spec exercising the pass can stub the
+# registry the same way.
+module VerificationRegistryHelpers
+  def stub_registry(entries)
+    allow(Rails.application.config).to receive(:verification_data_sources).and_return(entries)
+  end
+
+  def registry_entry(id:, adapter_class:, order: 10, enabled: true)
+    { id: id, enabled: enabled, adapter_class: adapter_class, order: order }
+  end
+end
+
+RSpec.configure do |config|
+  config.include VerificationRegistryHelpers
+end


### PR DESCRIPTION
## Ticket

Part of #805

Third of four in a stack: #823, #828, this, #822. Lands inert; #822 is the consumer.

## Changes

- Add `Verification::Adapters::MockCommunityEngagement`, which attests community engagement when the
  member's email contains `ce-met`.
- Register it in the deployment-owned `config/custom/verification_data_sources.yml` at `order: 20`,
  behind `mock_emergency_county` at `order: 10`.
- Extract `stub_registry` / `registry_entry` into `VerificationRegistryHelpers`, now that a second spec
  stubs the booted registry.
- Update `data_source_orchestrator_spec`'s real-registry cases for a second order-bearing source.

## Context for reviewers

Inert, the same staging #812 used for `MockEmergencyCounty`: `DataSourceOrchestrator` still has no
consumers. The adapter declares no exclusion outcome, so `ExclusionDeterminationService` drops it
(`best_declared_priority` is nil) and only the orchestrator's pass will ever consult it.

The trigger is email rather than `va_icn` because `MockDrugTreatment` runs at the earlier exclusion step
and terminates the case for seven of ten `va_icn` last digits, leaving only even ones, which are
`MockEmergencyCounty`'s. A `va_icn`-keyed trigger here would be starved before it ran. Email is safe
because no determination path reads it, and the substring idiom follows `Auth::MockAdapter`'s
"unconfirmed"/"mfa". A real source must not copy it, and the adapter says so: email both describes the
member and joins them to their certification (`Certification.find_by_member_email`), so a single
member-influenceable attribute would select the record and drive a favourable outcome.

The orchestrator spec churns because a third order-bearing source changes the `attempted` list its
real-registry cases assert. The two mocks read different member fields, so an even-digit `va_icn` must
stop at `order: 10` without consulting the CE source; that precedence is now pinned by a spec rather
than left implicit in registry order.

## Testing

- Suite green on this branch alone: 3107 examples, 0 failures. 96.73% line, 84.14% branch.
- RuboCop clean across 572 files.
- Registration proven against the real booted registry rather than a stub: the loader spec asserts both
  mocks are enabled, order-bearing, and ordered emergency-county first.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->