### PR TITLE
update markdown links

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -8,6 +8,18 @@
     },
     {
       "pattern": "127.0.0.1"
+    },
+    {
+      "pattern": "www.cbpp.org" // cloudflare blocks
+    },
+    {
+      "pattern": "medium.com" // cloudflare blocks
+    },
+    {
+      "pattern": "copilot-instructions.md" // in infra template documentation
+    },
+    {
+      "pattern": "strata-service-document-ai" // private
     }
   ],
   "replacementPatterns": [

--- a/docs/decisions/infra/2022-10-01-use-markdown-architectural-decision-records.md
+++ b/docs/decisions/infra/2022-10-01-use-markdown-architectural-decision-records.md
@@ -19,7 +19,7 @@ Chosen option: "MADR 2.1.2", because
 
 - Implicit assumptions should be made explicit.
   Design documentation is important to enable people to understand the decisions later on.
-  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+  See also [A rational design process: How and why to fake it](https://ieeexplore.ieee.org/document/6312940b).
 - The MADR format is lean and fits our development style.
 - The MADR structure is comprehensible and facilitates usage & maintenance.
 - The MADR project is vivid.

--- a/docs/how-to-guides/batch-upload-instructions.md
+++ b/docs/how-to-guides/batch-upload-instructions.md
@@ -47,7 +47,7 @@ Processing begins automatically when a file is uploaded — there is no manual "
 
 ### Template and Example CSV
 
-- [Download CSV template](/certification_batch_upload_template.csv) — also available on the upload page
+- [Download CSV template](/reporting-app/public/certification_batch_upload_template.csv) — also available on the upload page
 - [Download sample CSV with test data](/docs/assets/test_data.csv)
 
 > **Note:** If you want to receive email notifications, change the emails in the sample CSV to real email addresses.

--- a/docs/how-to-guides/getting-started.md
+++ b/docs/how-to-guides/getting-started.md
@@ -56,7 +56,7 @@ OSCER is designed to be cloud-agnostic. We provide infrastructure templates for 
 **AWS Deployment:**
 
 - **Reference implementation** using our [AWS infrastructure template](https://github.com/navapbc/template-infra)
-- See our [AWS implementation as a reference.](docs/infra/)
+- See our [AWS implementation as a reference.](/docs/infra/)
 
 **Azure Deployment:**
 

--- a/docs/infra/add-application.md
+++ b/docs/infra/add-application.md
@@ -8,7 +8,7 @@ Create a new directory for your application in the root of the repository. The a
 
 ## 2. Add infrastructure code for the new application
 
-[Use the platform CLI to add a new application to the repository](https://github.com/navapbc/platform-cli/blob/main/docs/adding-an-app.md)
+[Use the platform CLI to add a new application to the repository](https://github.com/navapbc/platform-cli/blob/main/docs/guides/adding-an-app.md)
 
 ## 3. Set up the application infrastructure
 

--- a/docs/infra/sms-notifications.md
+++ b/docs/infra/sms-notifications.md
@@ -327,7 +327,7 @@ Following [AWS End User Messaging SMS Best Practices](https://docs.aws.amazon.co
 
 ### Support Resources
 
-- [AWS End User Messaging SMS Developer Guide](https://docs.aws.amazon.com/sms-voice/latest/)
+- [AWS End User Messaging SMS User Guide](https://docs.aws.amazon.com/sms-voice/latest/userguide/what-is-sms-mms.html)
 - [Phone Number Registration Troubleshooting](https://docs.aws.amazon.com/sms-voice/latest/userguide/registrations-troubleshoot.html)
 - [SMS Delivery Best Practices](https://docs.aws.amazon.com/sms-voice/latest/userguide/best-practices.html)
 

--- a/docs/infra/temporary-environments-and-out-of-band-resources.md
+++ b/docs/infra/temporary-environments-and-out-of-band-resources.md
@@ -8,7 +8,7 @@ Temporary environments are short-lived infrastructure instances used for testing
 
 - **PR environments** — created automatically when a pull request is opened and destroyed when it's merged or closed. See [Pull Request Environments](./pull-request-environments.md).
 - **Workspace-based environments** — created manually using Terraform workspaces for isolated development and testing. See [Develop and Test Infrastructure in Isolation Using Workspaces](./develop-and-test-infrastructure-in-isolation-using-workspaces.md).
-- **CI end-to-end environments** — created and torn down by [`template-only-ci-infra.yml`](/.github/workflows/template-only-ci-infra.yml) to test creating a new project from scratch, deploying infrastructure (tests live in `infra/test/`), and tearing it all down.
+- **CI end-to-end environments** — created and torn down by [`template-only-ci-infra.yml`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/template-only-ci-infra.yml) to test creating a new project from scratch, deploying infrastructure (tests live in `infra/test/`), and tearing it all down.
 
 All three types need to handle the fact that some resources can't simply be `terraform apply`'d into existence and `terraform destroy`'d away.
 


### PR DESCRIPTION
## Ticket

Resolves #840

## Changes

Markdown files with bad links either updated or links added to ignore.

## Context for reviewers

Our markdown lint checker flagged 10 links as dead. These were not caught in pull requests, because PRs only check changed files.

- Two are external and behind cloudflare, which blocks them
- One is imported in the infrastructure template, so its link does not match
- One is to a private repository
- 6 were updated

## Testing

CI passes.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->