### PR TITLE
PBI-69889: Independent client and staff UI theming hooks

### DIFF
--- a/docs/how-to-guides/branding.md
+++ b/docs/how-to-guides/branding.md
@@ -4,9 +4,35 @@ This guide explains how to customize the look and feel of the OSCER user experie
 
 ## Cascading Style Sheets (CSS)
 
-OSCER uses the cssbundling-rails gem to bundle its stylesheets. For simple changes, add CSS styles to `app/assets/stylesheets/_overrides.scss`, and these styles will automatically be used.
+OSCER uses the cssbundling-rails gem to bundle its stylesheets. Branding cascades
+after USWDS, so your rules win. Three SCSS hooks let you scope a change to one
+surface or both:
 
-To override all styles; for example, to change USWDS default colors; build a custom stylesheet by updating `app/assets/stylesheets/custom.scss`. You will also need to override the application_base layout template to link to this "custom" stylesheet rather than OSCER's "application" stylesheet. To use the "custom" stylesheet, copy `app/views/layouts/application_base.html.erb` to `app/views/overrides/layouts/application_base.html.erb` and update the "stylesheet_link_tag" to use "custom" instead of "application".
+| Hook | Applies to | Builds into | Loaded by |
+|---|---|---|---|
+| `app/assets/stylesheets/_overrides.scss` | **Both** client and staff | `application.css` | every layout |
+| `app/assets/stylesheets/_client_overrides.scss` | **Client only** (member-facing) | `client.css` | `layouts/application_base` (after `application`) |
+| `app/assets/stylesheets/_staff_overrides.scss` | **Staff only** | `staff.css` | `layouts/oscer_staff` (after `application`, via `:head`) |
+
+Use the narrowest hook that expresses the change: a client-only restyle goes in
+`_client_overrides.scss`, staff-only in `_staff_overrides.scss`, and genuinely
+app-wide branding (shared brand color, logo) in `_overrides.scss`.
+
+To override all styles; for example, to change USWDS default colors; build a
+custom stylesheet by updating `app/assets/stylesheets/custom.scss`. You will
+also need to override the application_base layout template to link to this
+"custom" stylesheet rather than OSCER's "application" stylesheet. To use the
+"custom" stylesheet, copy `app/views/layouts/application_base.html.erb` to
+`app/views/overrides/layouts/application_base.html.erb` and update the
+shared `stylesheet_link_tag` to use `"custom"` instead of `"application"`.
+
+**Keep the `stylesheet_link_tag "client"` that follows it** so client-only
+hooks in `_client_overrides.scss` still apply. If you override the staff layout
+(`layouts/oscer_staff` or `layouts/strata/staff`), **keep loading `staff.css`
+after the shared/custom bundle** (via `:head` or an explicit link) so
+staff-only hooks still apply. Note: `custom.scss` is a **shared** full-reskin
+hatch across both surfaces unless you maintain separate layout overrides and
+keep those surface bundles linked.
 
 ## Views
 
@@ -23,5 +49,6 @@ For example, to remove the demo notice from the member emails, you would create 
 
 ## Best Practices
 
-- Add new files instead of modifying OSCER core files. Feel free to modify `app/assets/stylesheets/_overrides.scss` and `app/assets/stylesheets/custom.scss`, but add new files in the `app/views/overrides` and `app/assets/stylesheets` directories to brand your implementation of OSCER.
-- When overriding a template, try to keep it as close as possible to the OSCER core version. Only change what you need to get the look and feel you want. Some parts of the template that seem extraneous might be necessary for the proper user experience.
+- Add new files instead of modifying OSCER core files. Feel free to modify the SCSS hooks (`_overrides.scss`, `_client_overrides.scss`, `_staff_overrides.scss`, and `custom.scss`), but add new files in the `app/views/overrides` and `app/assets/stylesheets` directories to brand your implementation of OSCER.
+- Prefer surface-scoped hooks (`_client_overrides.scss` / `_staff_overrides.scss`) over `_overrides.scss` when a change should not affect both UIs.
+- When overriding a template, try to keep it as close as possible to the OSCER core version. Only change what you need to get the look and feel you want. Some parts of the template that seem extraneous might be necessary for the proper user experience — including the `client` / `staff` stylesheet links described above.

--- a/reporting-app/CUSTOMIZATION.md
+++ b/reporting-app/CUSTOMIZATION.md
@@ -97,10 +97,24 @@ en:
 See [`config/locales/overrides/README.md`](config/locales/overrides/README.md)
 for layout conventions.
 
-**Visual theming.** Add styles to `app/assets/stylesheets/_overrides.scss`
-(cascades after USWDS, so it wins) for most branding: colors, fonts, logo,
-spacing. Use `app/assets/stylesheets/custom.scss` only when you need to replace
-the whole stylesheet. Full how-to (CSS, view, and mailer branding):
+**Visual theming.** Branding cascades after USWDS, so your rules win. Three
+SCSS hooks let you scope a change to one surface or both:
+
+| Hook | Applies to | Builds into | Loaded by |
+|---|---|---|---|
+| `app/assets/stylesheets/_overrides.scss` | **Both** client and staff | `application.css` | every layout |
+| `app/assets/stylesheets/_client_overrides.scss` | **Client only** (member-facing) | `client.css` | `layouts/application_base` |
+| `app/assets/stylesheets/_staff_overrides.scss` | **Staff only** | `staff.css` | `layouts/oscer_staff` |
+
+Both `client.css` and `staff.css` load *after* the shared `application.css`, so
+a surface hook always wins over a shared rule for that surface. Use the
+narrowest hook that expresses the change: this is what guarantees a client-only
+restyle can't bleed into the staff UI and vice versa. Reserve `_overrides.scss`
+for branding that is genuinely app-wide (a shared brand color, the logo).
+
+Use `app/assets/stylesheets/custom.scss` only when you need to replace the whole
+stylesheet; note this full-reskin hatch is currently **shared** across both
+surfaces. Full how-to (CSS, view, and mailer branding):
 [`docs/how-to-guides/branding.md`](https://github.com/navapbc/oscer/blob/main/docs/how-to-guides/branding.md).
 
 ## Extension points
@@ -186,7 +200,8 @@ New models exposed to controllers also need a Pundit policy
 
 | I want to… | Mechanism | Where |
 |---|---|---|
-| Change logo, colors, fonts | Locales + branding | `app/assets/stylesheets/_overrides.scss` (or `custom.scss`) |
+| Change logo, colors, fonts (both surfaces) | Locales + branding | `app/assets/stylesheets/_overrides.scss` (or `custom.scss`) |
+| Restyle only the client UI / only the staff UI | Locales + branding | `_client_overrides.scss` / `_staff_overrides.scss` |
 | Rename the program / change member-facing copy | Locales + branding | `config/locales/overrides/` |
 | Override an email template | Branding / extension points | `branding.md` (mailer view) or `app/views/overrides/member_mailer/` |
 | Adjust the exemption list | Config | `config/custom/exemption_types.yml` |
@@ -209,8 +224,9 @@ categories of files determine whether that stays clean:
    `config/locales/overrides/`. These are new files OSCER never ships, so a sync
    never overwrites them. Always clean.
 2. **Deployment-owned config and branding hooks**: `config/custom/*.yml` and
-   the SCSS hooks (`_overrides.scss`, `custom.scss`). OSCER ships these as empty
-   or starter files and rarely edits them, so your edits survive a sync in
+   the SCSS hooks (`_overrides.scss`, `_client_overrides.scss`,
+   `_staff_overrides.scss`, `custom.scss`). OSCER ships these as empty or
+   starter files and rarely edits them, so your edits survive a sync in
    practice. If a future upstream change does touch one, you re-apply your edit
    the next time you sync.
 3. **OSCER-owned files everywhere else**: base views, models, services, and the

--- a/reporting-app/app/assets/config/manifest.js
+++ b/reporting-app/app/assets/config/manifest.js
@@ -16,4 +16,6 @@
 // Compiled CSS and JS
 //= link_tree ../builds
 //= link application.css
+//= link client.css
+//= link staff.css
 //= link custom.css

--- a/reporting-app/app/assets/stylesheets/_client_overrides.scss
+++ b/reporting-app/app/assets/stylesheets/_client_overrides.scss
@@ -1,0 +1,12 @@
+// =========================================================
+// CLIENT-ONLY overrides — builds into "client.css", loaded
+// only by the member/client-facing layout (application_base).
+//
+// Styles placed here affect the client UI and NOT the staff UI.
+// For branding that should apply to BOTH surfaces, use
+// ./_overrides.scss instead. For staff-only styling, use
+// ./_staff_overrides.scss.
+//
+// To use USWDS functions/mixins/tokens (color(), units(), etc.)
+// add `@use "uswds-core" as *;` as the first line below.
+// =========================================================

--- a/reporting-app/app/assets/stylesheets/_staff_overrides.scss
+++ b/reporting-app/app/assets/stylesheets/_staff_overrides.scss
@@ -1,0 +1,12 @@
+// =========================================================
+// STAFF-ONLY overrides — builds into "staff.css", loaded
+// only by the staff-facing layout (oscer_staff / strata staff).
+//
+// Styles placed here affect the staff UI and NOT the client UI.
+// For branding that should apply to BOTH surfaces, use
+// ./_overrides.scss instead. For client-only styling, use
+// ./_client_overrides.scss.
+//
+// To use USWDS functions/mixins/tokens (color(), units(), etc.)
+// add `@use "uswds-core" as *;` as the first line below.
+// =========================================================

--- a/reporting-app/app/assets/stylesheets/client.scss
+++ b/reporting-app/app/assets/stylesheets/client.scss
@@ -1,0 +1,9 @@
+// =========================================================
+// Client-surface stylesheet entry point — builds into
+// "client.css". Loaded by application_base.html.erb AFTER
+// the shared "application" bundle, so its rules win the
+// cascade for the client/member UI only.
+//
+// Put client-only styles in ./_client_overrides.scss.
+// =========================================================
+@forward "client_overrides";

--- a/reporting-app/app/assets/stylesheets/custom.scss
+++ b/reporting-app/app/assets/stylesheets/custom.scss
@@ -1,4 +1,8 @@
 // =========================================================
 // Custom base scss file builds to "custom.css"
 // Use when ./_overrides.scss is not enough.
+// This full-reskin hatch is shared by client and staff unless
+// you override each layout and keep surface bundles (client.css /
+// staff.css) linked after it. Prefer _client_overrides.scss /
+// _staff_overrides.scss for surface-scoped branding.
 // =========================================================

--- a/reporting-app/app/assets/stylesheets/staff.scss
+++ b/reporting-app/app/assets/stylesheets/staff.scss
@@ -1,0 +1,9 @@
+// =========================================================
+// Staff-surface stylesheet entry point — builds into
+// "staff.css". Loaded by oscer_staff.html.erb AFTER the
+// shared "application" bundle, so its rules win the cascade
+// for the staff UI only.
+//
+// Put staff-only styles in ./_staff_overrides.scss.
+// =========================================================
+@forward "staff_overrides";

--- a/reporting-app/app/views/layouts/application_base.html.erb
+++ b/reporting-app/app/views/layouts/application_base.html.erb
@@ -12,6 +12,9 @@
     <%= favicon_link_tag asset_path('@uswds/uswds/dist/img/us_flag_small.png') %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%# Client-surface overrides; loaded after "application" so they win the
+        cascade for the client UI only (staff UI loads "staff" instead). %>
+    <%= stylesheet_link_tag "client", "data-turbo-track": "reload" %>
     <%= yield :head %>
 
     <%= javascript_importmap_tags %>

--- a/reporting-app/app/views/layouts/oscer_staff.html.erb
+++ b/reporting-app/app/views/layouts/oscer_staff.html.erb
@@ -1,4 +1,8 @@
 <% content_for :head do %>
+  <%# Staff-surface overrides; the strata staff layout renders :head after its
+      "application" link, so these win the cascade for the staff UI only
+      (client UI loads "client" instead). %>
+  <%= stylesheet_link_tag "staff", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 <% end %>
 <%= render template: "layouts/strata/staff" %>

--- a/reporting-app/package.json
+++ b/reporting-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css ./app/assets/stylesheets/custom.scss:./app/assets/builds/custom.css --load-path=node_modules --load-path=node_modules/@uswds/uswds/packages",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css ./app/assets/stylesheets/client.scss:./app/assets/builds/client.css ./app/assets/stylesheets/staff.scss:./app/assets/builds/staff.css ./app/assets/stylesheets/custom.scss:./app/assets/builds/custom.css --load-path=node_modules --load-path=node_modules/@uswds/uswds/packages",
     "postinstall": "mkdir -p vendor/javascript && sed '1s/^\\xEF\\xBB\\xBF//' node_modules/pdfjs-dist/build/pdf.min.mjs > vendor/javascript/pdfjs-dist.js && sed '1s/^\\xEF\\xBB\\xBF//' node_modules/pdfjs-dist/build/pdf.worker.min.mjs > vendor/javascript/pdfjs-dist-worker.js"
   },
   "dependencies": {

--- a/reporting-app/spec/requests/theming_isolation_spec.rb
+++ b/reporting-app/spec/requests/theming_isolation_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Proves the client and staff surfaces load independent stylesheet bundles
+# (Azure DevOps PBI 69889 / SS-69889). A client-only override lives in
+# "client.css" and a staff-only override in "staff.css"; each surface loads
+# exactly one of them, on top of the shared "application" bundle. This is the
+# structural guarantee that a styling change scoped to one surface cannot
+# affect the other.
+RSpec.describe "Client/staff theming isolation", type: :request do
+  include Warden::Test::Helpers
+
+  after { Warden.test_reset! }
+
+  # Normalize a stylesheet href to its logical bundle name, dropping the
+  # sprockets digest and extension: "/assets/client-abc123.css" -> "client".
+  def linked_bundles(body)
+    Nokogiri::HTML(body)
+      .css('link[rel="stylesheet"]')
+      .map { |link| File.basename(link["href"].to_s).sub(/(-[0-9a-f]+)?\.css.*\z/, "") }
+  end
+
+  describe "the client (member-facing) surface" do
+    let(:member_data) { build(:certification_member_data, :with_account_email) }
+    let(:user) { create(:user, email: member_data.account_email) }
+
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+      create(:certification, member_data: member_data)
+      login_as user
+    end
+
+    it "loads the shared and client bundles but not the staff bundle" do
+      get "/dashboard"
+
+      expect(response).to be_successful
+      bundles = linked_bundles(response.body)
+      expect(bundles).to include("application", "client")
+      expect(bundles).not_to include("staff")
+      expect(bundles.index("application")).to be < bundles.index("client")
+    end
+  end
+
+  describe "the staff-facing surface" do
+    before { login_as create(:user, :as_admin) }
+
+    it "loads the shared and staff bundles but not the client bundle" do
+      get "/staff/users"
+
+      expect(response).to be_successful
+      bundles = linked_bundles(response.body)
+      expect(bundles).to include("application", "staff")
+      expect(bundles).not_to include("client")
+      expect(bundles.index("application")).to be < bundles.index("staff")
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves [Azure DevOps PBI 69889](https://dev.azure.com/akhealth/Dpa/_boards/board/t/SapphireSquad/Backlog%20items?workitem=69889) (SS-69889)

## Changes

- Add surface-scoped stylesheet packs `client.css` and `staff.css`, built from `client.scss` / `staff.scss` and empty hooks `_client_overrides.scss` / `_staff_overrides.scss`.
- Load `client` after `application` in `layouts/application_base`; load `staff` after `application` via `:head` in `layouts/oscer_staff`.
- Wire packs into `package.json` `build:css` and `app/assets/config/manifest.js`.
- Document the three-hook model (`_overrides` shared, client/staff surface hooks) in `CUSTOMIZATION.md` and `docs/how-to-guides/branding.md`; note the shared `custom.scss` full-reskin caveat.
- Add request spec `spec/requests/theming_isolation_spec.rb` asserting each surface loads the shared + its own pack (not the other), with correct cascade order.

## Context for reviewers

OSCER client and staff UIs previously could not be themed independently; branding lived in a single app-level stylesheet path (see prior art [#522](https://github.com/navapbc/oscer/pull/522), demo theme [#498](https://github.com/navapbc/oscer/pull/498), ARIES theme [akhr1#6](https://github.com/navapbc/akhr1/pull/6)).

This PR adds **structural** isolation via additive CSS packs rather than dual full USWDS themes.

> **Known limitation (intentional for this slice):** `_overrides.scss` and `custom.scss` remain **shared** across client and staff. Independence for day-to-day branding is provided by `_client_overrides.scss` / `_staff_overrides.scss`. A full `custom.scss` reskin still couples both surfaces unless implementers override each layout and keep the surface bundles linked. Acceptable for now; follow-up if we need independent full-reskin hatches.

SSO redirect (`layouts/sso`) and Lookbook still load only `application` by design in this slice.

## Testing

### Automated

From `reporting-app/`:

- `make lint` — clean
- `make test args='spec/requests/theming_isolation_spec.rb'` — **2 examples, 0 failures** (SimpleCov may exit non-zero on single-file runs; ignore for this check)

The isolation spec asserts:

- Member `/dashboard` loads `application` + `client`, not `staff`, with `application` before `client`
- Admin `/staff/users` loads `application` + `staff`, not `client`, with `application` before `staff`

### Manual isolation smoke (for screenshots)

Temporary distinctive rules (revert override files after capturing; do not leave demo CSS in the branch):

1. In `_client_overrides.scss`, e.g. red body outline / red `.usa-button`
2. In `_staff_overrides.scss`, e.g. green body outline / green `.usa-button`
3. Rebuild CSS: with `make start-native` the Procfile `css` watcher runs `npm run build:css -- --watch`; otherwise `cd reporting-app && npm run build:css`
4. Member login → `/dashboard` — client theme only
5. Admin login → `/staff/users` (or `/staff`) — staff theme only
6. Optional: put a rule only in `_overrides.scss` and confirm it appears on **both** surfaces (documents the shared-hook limitation)

### Screenshots

<img width="530" height="246" alt="Screenshot 2026-08-06 at 11 21 01 AM" src="https://github.com/user-attachments/assets/0e1aa33b-1857-4a6a-9352-c421905e8468" />
<img width="523" height="309" alt="Screenshot 2026-08-06 at 11 21 13 AM" src="https://github.com/user-attachments/assets/b63ac18e-d876-4afe-9cb0-33a55c40492b" />
<img width="560" height="361" alt="Screenshot 2026-08-06 at 11 21 55 AM" src="https://github.com/user-attachments/assets/c5aa2500-f098-4a7a-874b-08b8c144884f" />


<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->