### PR TITLE
PBI-69965: Add credit hours and enforce verification status in Cert Creation Service

### DIFF
--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -30,7 +30,9 @@ class Certifications::MemberData < ValueObject
     TYPE_HOURLY = "hourly"
     TYPE_INCOME = "income"
     ACTIVITY_TYPES = [ TYPE_HOURLY, TYPE_INCOME ].freeze
-    VERIFICATION_STATUSES = %w[verified self_attested pending].freeze
+    CATEGORY_EDUCATION = "education"
+    VERIFIED = "verified"
+    VERIFICATION_STATUSES = [ VERIFIED, "self_attested", "pending" ].freeze
 
     attribute :type, :string
     attribute :category, :string
@@ -47,7 +49,8 @@ class Certifications::MemberData < ValueObject
 
     validates :type, presence: true, inclusion: { in: ACTIVITY_TYPES }
     validates :category, presence: true, inclusion: { in: ::Activity::ALLOWED_CATEGORIES }
-    validates :hours, presence: true, if: -> { type == TYPE_HOURLY }
+    validates :hours, presence: true, if: -> { type == TYPE_HOURLY && !education_credit_hours? }
+    validates :credit_hours, numericality: { greater_than: 0 }, allow_nil: true
     validates :gross_income, presence: true,
                              numericality: { greater_than: 0 },
                              if: -> { type == TYPE_INCOME }
@@ -57,7 +60,18 @@ class Certifications::MemberData < ValueObject
               if: -> { type == TYPE_INCOME }
     validates :period_start, presence: true
     validates :period_end, presence: true
-    validates :verification_status, inclusion: { in: VERIFICATION_STATUSES }, allow_nil: true
+    validates :verification_status, presence: true, inclusion: { in: VERIFICATION_STATUSES }
+
+    # Only verified activities count toward a certification.
+    def verified?
+      verification_status == VERIFIED
+    end
+
+    # Education activities may report credit hours in place of clock hours;
+    # Certifications::CreationService converts them.
+    def education_credit_hours?
+      category == CATEGORY_EDUCATION && credit_hours.present?
+    end
   end
 
   class PayrollAccount < ValueObject

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -55,7 +55,7 @@ class Certifications::MemberData < ValueObject
     validates :category, presence: true, inclusion: { in: ::Activity::ALLOWED_CATEGORIES }
     validates :hours, presence: true, if: -> { type == TYPE_HOURLY && !education_credit_hours? }
     validates :credit_hours, numericality: { greater_than: 0 }, allow_nil: true
-    validates :credit_hours, absence: true, unless: -> { category == CATEGORY_EDUCATION }
+    validates :credit_hours, absence: true, unless: -> { type == TYPE_HOURLY && category == CATEGORY_EDUCATION }
     validates :gross_income, presence: true,
                              numericality: { greater_than: 0 },
                              if: -> { type == TYPE_INCOME }

--- a/reporting-app/app/models/certifications/member_data.rb
+++ b/reporting-app/app/models/certifications/member_data.rb
@@ -34,6 +34,10 @@ class Certifications::MemberData < ValueObject
     VERIFIED = "verified"
     VERIFICATION_STATUSES = [ VERIFIED, "self_attested", "pending" ].freeze
 
+    # One credit hour is 12.99 clock hours per month (3 hours per week over a 4.33 week month)
+    # per the Federal Register.
+    CREDIT_HOURS_MULTIPLIER = BigDecimal("12.99")
+
     attribute :type, :string
     attribute :category, :string
     attribute :hours, :decimal
@@ -51,6 +55,7 @@ class Certifications::MemberData < ValueObject
     validates :category, presence: true, inclusion: { in: ::Activity::ALLOWED_CATEGORIES }
     validates :hours, presence: true, if: -> { type == TYPE_HOURLY && !education_credit_hours? }
     validates :credit_hours, numericality: { greater_than: 0 }, allow_nil: true
+    validates :credit_hours, absence: true, unless: -> { category == CATEGORY_EDUCATION }
     validates :gross_income, presence: true,
                              numericality: { greater_than: 0 },
                              if: -> { type == TYPE_INCOME }
@@ -67,10 +72,16 @@ class Certifications::MemberData < ValueObject
       verification_status == VERIFIED
     end
 
-    # Education activities may report credit hours in place of clock hours;
-    # Certifications::CreationService converts them.
+    # Education activities may report credit hours in place of clock hours.
     def education_credit_hours?
       category == CATEGORY_EDUCATION && credit_hours.present?
+    end
+
+    # Reported hours, or their credit-hour equivalent when hours were omitted.
+    def clock_hours
+      return hours if hours.present?
+
+      credit_hours * CREDIT_HOURS_MULTIPLIER if education_credit_hours?
     end
   end
 

--- a/reporting-app/app/services/certifications/creation_service.rb
+++ b/reporting-app/app/services/certifications/creation_service.rb
@@ -5,10 +5,6 @@
 class Certifications::CreationService
   attr_reader :create_request, :certification
 
-  # One credit hour is 12.99 clock hours per month (3 hours per week over a 4.33 week month)
-  # per the Federal Register.
-  CREDIT_HOURS_MULTIPLIER = BigDecimal("12.99")
-
   def initialize(certification)
     @certification = certification
   end
@@ -52,16 +48,10 @@ class Certifications::CreationService
     hourly_activities.each do |activity_data|
       next unless activity_data.verified?
 
-      hours = if activity_data.hours.nil? && activity_data.education_credit_hours?
-                activity_data.credit_hours * CREDIT_HOURS_MULTIPLIER
-      else
-                activity_data.hours
-      end
-
       ExternalHourlyActivityService.create_entry(
         member_id: certification.member_id,
         category: activity_data.category,
-        hours: hours,
+        hours: activity_data.clock_hours,
         period_start: activity_data.period_start,
         period_end: activity_data.period_end,
         source_type: ExternalHourlyActivity::SOURCE_TYPES[:api],

--- a/reporting-app/app/services/certifications/creation_service.rb
+++ b/reporting-app/app/services/certifications/creation_service.rb
@@ -5,6 +5,10 @@
 class Certifications::CreationService
   attr_reader :create_request, :certification
 
+  # One credit hour is 12.99 clock hours per month (3 hours per week over a 4.33 week month)
+  # per the Federal Register.
+  CREDIT_HOURS_MULTIPLIER = BigDecimal("12.99")
+
   def initialize(certification)
     @certification = certification
   end
@@ -46,10 +50,18 @@ class Certifications::CreationService
     hourly_activities = certification.member_data.activities.select { |a| a.type == "hourly" }
 
     hourly_activities.each do |activity_data|
-      result = ExternalHourlyActivityService.create_entry(
+      next unless activity_data.verified?
+
+      hours = if activity_data.hours.nil? && activity_data.education_credit_hours?
+                activity_data.credit_hours * CREDIT_HOURS_MULTIPLIER
+      else
+                activity_data.hours
+      end
+
+      ExternalHourlyActivityService.create_entry(
         member_id: certification.member_id,
         category: activity_data.category,
-        hours: activity_data.hours,
+        hours: hours,
         period_start: activity_data.period_start,
         period_end: activity_data.period_end,
         source_type: ExternalHourlyActivity::SOURCE_TYPES[:api],
@@ -64,7 +76,9 @@ class Certifications::CreationService
     income_activities = certification.member_data.activities.select { |a| a.type == "income" }
 
     income_activities.each do |activity_data|
-      result = ExternalIncomeActivityService.create_entry(
+      next unless activity_data.verified?
+
+      ExternalIncomeActivityService.create_entry(
         member_id: certification.member_id,
         category: activity_data.category,
         gross_income: activity_data.gross_income,
@@ -73,7 +87,7 @@ class Certifications::CreationService
         source_type: activity_data.source,
         source_id: nil,
         reported_at: activity_data.reported_at || Time.current,
-        employer: activity_data.employer,
+        employer: activity_data.employer || activity_data.name,
         recalculate_income_compliance: false
       )
     end

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -85,6 +85,15 @@
                     "period_end": "2025-09-30",
                     "employer": "Community Center",
                     "verification_status": "verified"
+                  },
+                  {
+                    "type": "hourly",
+                    "category": "education",
+                    "credit_hours": "9",
+                    "period_start": "2025-09-01",
+                    "period_end": "2025-09-30",
+                    "name": "State University",
+                    "verification_status": "verified"
                   }
                 ],
                 "date_of_birth": "1980-01-01",
@@ -405,22 +414,16 @@
             "enum": ["employment", "community_service", "education", "unearned"],
             "description": "The category of activity"
           },
-          "oneOf": [
-            {
-	      "hours": {
-		"type": "string",
-		"format": "decimal",
-		"description": "Number of hours for the activity"
-              }
-	    },
-            {
-	      "credit_hours": {
-		"type": "string",
-		"format": "decimal",
-		"description": "Number of credit hours for the educational activity"
-              }
-	    }
-	  ],
+          "hours": {
+            "type": ["string", "null"],
+            "format": "decimal",
+            "description": "Number of hours for the activity; required unless the activity is an education activity reporting credit_hours"
+          },
+          "credit_hours": {
+            "type": ["string", "null"],
+            "format": "decimal",
+            "description": "Number of credit hours for an education activity, converted to hours on intake. Ignored when hours is also supplied"
+          },
           "period_start": {
             "type": "string",
             "format": "date",
@@ -435,18 +438,35 @@
             "type": ["string", "null"],
             "description": "Employer or organization associated with the activity"
           },
-          "verification_status": {
+          "name": {
             "type": ["string", "null"],
-            "enum": ["verified", "self_attested", "pending", null],
-            "description": "Verification status of the activity"
+            "description": "Name of the school or organization associated with the activity, where employer does not apply"
+          },
+          "verification_status": {
+            "type": "string",
+            "enum": ["verified", "self_attested", "pending"],
+            "description": "Verification status of the activity; only verified activities count toward the certification"
           }
         },
         "required": [
           "type",
           "category",
-          "hours",
           "period_start",
-          "period_end"
+          "period_end",
+          "verification_status"
+        ],
+        "anyOf": [
+          {
+            "required": ["hours"]
+          },
+          {
+            "properties": {
+              "category": {
+                "const": "education"
+              }
+            },
+            "required": ["credit_hours"]
+          }
         ]
       },
       "CertificationMemberDataIncomeActivity": {
@@ -492,10 +512,14 @@
             "type": ["string", "null"],
             "description": "Employer or organization associated with the activity"
           },
-          "verification_status": {
+          "name": {
             "type": ["string", "null"],
-            "enum": ["verified", "self_attested", "pending", null],
-            "description": "Verification status of the activity"
+            "description": "Name of the school or organization associated with the activity, where employer does not apply. Recorded as the employer when employer is not supplied"
+          },
+          "verification_status": {
+            "type": "string",
+            "enum": ["verified", "self_attested", "pending"],
+            "description": "Verification status of the activity; only verified activities count toward the certification"
           }
         },
         "required": [
@@ -504,7 +528,8 @@
           "gross_income",
           "period_start",
           "period_end",
-          "source"
+          "source",
+          "verification_status"
         ]
       },
       "CertificationMemberDataActivity": {

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -422,7 +422,7 @@
           "credit_hours": {
             "type": ["string", "null"],
             "format": "decimal",
-            "description": "Number of credit hours for an education activity, converted to hours on intake. Ignored when hours is also supplied"
+            "description": "Number of credit hours for an education activity, converted to hours on intake. Permitted only on education activities, and ignored when hours is also supplied"
           },
           "period_start": {
             "type": "string",

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -384,7 +384,8 @@ components:
           - 'null'
           format: decimal
           description: Number of credit hours for an education activity, converted
-            to hours on intake. Ignored when hours is also supplied
+            to hours on intake. Permitted only on education activities, and ignored
+            when hours is also supplied
         period_start:
           type: string
           format: date
@@ -751,67 +752,67 @@ components:
       required:
       - status
   responses:
-    8a67e8795d7b68df469d13960f900a12:
+    92b867c7bd7710a190d49f556523432e:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    bb8ebe02c5a13c5f3fee9b1b6bd94995:
+    84de618d106cfb28cb206e386b02308b:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    14f17426af7f517602ea2904180603d5:
+    16d508648743b65df08644f70d98f653:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    8a385ec51a9b465a697c8031bff2a306:
+    f254a5555e78e1eb8959045c99f6bc05:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    95b103ab34bc3a42c7b3eb5487410b04:
+    47caa76d260b12b1202ff7a40f810ffe:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    e907db1a91604a13bf78e218a4967b0e:
+    6896680c4d444791570b1ca22a8caea4:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    14b3906b8c85fa9a94b3c87820c3b0ed:
+    5741b9b03a686f8044536adad009d864:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    b45d644e50b607748a23209511064432:
+    bb4cae093af9929cfa7dc58d58aa8ef3:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    488ce1ccd2323108344283b4eee11de1:
+    77dc4daafcdf5907bdbed4bd69410c25:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    2013f53af0d2b2b7532a51aedfc4b113:
+    45892ef2d6d8cac7e489dd65c55158c5:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    178285d956368b41d7421c5441f7bf34:
+    51dfcfc07c920f9d9f37a09083494608:
       description: Response
       content:
         application/json:
@@ -843,7 +844,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    4da63c7b9c9f62b82cd3e4e505771b2c:
+    d3b71db4b808315111933b8eb20bdd27:
       description: The Certification data.
       content:
         application/json:
@@ -936,11 +937,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/8a67e8795d7b68df469d13960f900a12"
+          "$ref": "#/components/responses/92b867c7bd7710a190d49f556523432e"
         '202':
-          "$ref": "#/components/responses/bb8ebe02c5a13c5f3fee9b1b6bd94995"
+          "$ref": "#/components/responses/84de618d106cfb28cb206e386b02308b"
         '404':
-          "$ref": "#/components/responses/14f17426af7f517602ea2904180603d5"
+          "$ref": "#/components/responses/16d508648743b65df08644f70d98f653"
       security:
       - hmac: []
       deprecated: false
@@ -954,16 +955,16 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/4da63c7b9c9f62b82cd3e4e505771b2c"
+        "$ref": "#/components/requestBodies/d3b71db4b808315111933b8eb20bdd27"
       responses:
         '201':
-          "$ref": "#/components/responses/8a385ec51a9b465a697c8031bff2a306"
+          "$ref": "#/components/responses/f254a5555e78e1eb8959045c99f6bc05"
         '202':
-          "$ref": "#/components/responses/95b103ab34bc3a42c7b3eb5487410b04"
+          "$ref": "#/components/responses/47caa76d260b12b1202ff7a40f810ffe"
         '400':
-          "$ref": "#/components/responses/e907db1a91604a13bf78e218a4967b0e"
+          "$ref": "#/components/responses/6896680c4d444791570b1ca22a8caea4"
         '422':
-          "$ref": "#/components/responses/14b3906b8c85fa9a94b3c87820c3b0ed"
+          "$ref": "#/components/responses/5741b9b03a686f8044536adad009d864"
       security:
       - hmac: []
       deprecated: false
@@ -978,9 +979,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/b45d644e50b607748a23209511064432"
+          "$ref": "#/components/responses/bb4cae093af9929cfa7dc58d58aa8ef3"
         '404':
-          "$ref": "#/components/responses/488ce1ccd2323108344283b4eee11de1"
+          "$ref": "#/components/responses/77dc4daafcdf5907bdbed4bd69410c25"
       security:
       - hmac: []
       deprecated: false
@@ -1015,9 +1016,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/2013f53af0d2b2b7532a51aedfc4b113"
+          "$ref": "#/components/responses/45892ef2d6d8cac7e489dd65c55158c5"
         '503':
-          "$ref": "#/components/responses/178285d956368b41d7421c5441f7bf34"
+          "$ref": "#/components/responses/51dfcfc07c920f9d9f37a09083494608"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -72,6 +72,13 @@ components:
                 period_end: '2025-09-30'
                 employer: Community Center
                 verification_status: verified
+              - type: hourly
+                category: education
+                credit_hours: '9'
+                period_start: '2025-09-01'
+                period_end: '2025-09-30'
+                name: State University
+                verification_status: verified
               date_of_birth: '1980-01-01'
               race_ethnicity: Hispanic
               pregnancy_status: false
@@ -364,15 +371,20 @@ components:
           - education
           - unearned
           description: The category of activity
-        oneOf:
-        - hours:
-            type: string
-            format: decimal
-            description: Number of hours for the activity
-        - credit_hours:
-            type: string
-            format: decimal
-            description: Number of credit hours for the educational activity
+        hours:
+          type:
+          - string
+          - 'null'
+          format: decimal
+          description: Number of hours for the activity; required unless the activity
+            is an education activity reporting credit_hours
+        credit_hours:
+          type:
+          - string
+          - 'null'
+          format: decimal
+          description: Number of credit hours for an education activity, converted
+            to hours on intake. Ignored when hours is also supplied
         period_start:
           type: string
           format: date
@@ -386,22 +398,34 @@ components:
           - string
           - 'null'
           description: Employer or organization associated with the activity
-        verification_status:
+        name:
           type:
           - string
           - 'null'
+          description: Name of the school or organization associated with the activity,
+            where employer does not apply
+        verification_status:
+          type: string
           enum:
           - verified
           - self_attested
           - pending
-          -
-          description: Verification status of the activity
+          description: Verification status of the activity; only verified activities
+            count toward the certification
       required:
       - type
       - category
-      - hours
       - period_start
       - period_end
+      - verification_status
+      anyOf:
+      - required:
+        - hours
+      - properties:
+          category:
+            const: education
+        required:
+        - credit_hours
     CertificationMemberDataIncomeActivity:
       type: object
       description: Income-based community engagement activity
@@ -447,16 +471,21 @@ components:
           - string
           - 'null'
           description: Employer or organization associated with the activity
-        verification_status:
+        name:
           type:
           - string
           - 'null'
+          description: Name of the school or organization associated with the activity,
+            where employer does not apply. Recorded as the employer when employer
+            is not supplied
+        verification_status:
+          type: string
           enum:
           - verified
           - self_attested
           - pending
-          -
-          description: Verification status of the activity
+          description: Verification status of the activity; only verified activities
+            count toward the certification
       required:
       - type
       - category
@@ -464,6 +493,7 @@ components:
       - period_start
       - period_end
       - source
+      - verification_status
     CertificationMemberDataActivity:
       oneOf:
       - "$ref": "#/components/schemas/CertificationMemberDataHourlyActivity"
@@ -721,67 +751,67 @@ components:
       required:
       - status
   responses:
-    eed80766c4e7638604355de711286cd1:
+    8a67e8795d7b68df469d13960f900a12:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    aa4e7eb889f98373dfd78e6608895b17:
+    bb8ebe02c5a13c5f3fee9b1b6bd94995:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    d4d03d0242e6f29275bab7e96c8f9d78:
+    14f17426af7f517602ea2904180603d5:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    97c1c43d73d325b22ed61e20992b3b69:
+    8a385ec51a9b465a697c8031bff2a306:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    '090e751cce74d60b12094cb20365132d':
+    95b103ab34bc3a42c7b3eb5487410b04:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    ef385539c18c5109da1050ae9954577d:
+    e907db1a91604a13bf78e218a4967b0e:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    a73160450ba6b1d88f90787cb2645869:
+    14b3906b8c85fa9a94b3c87820c3b0ed:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    508e983ec0f7e2fb34f5498de98106c1:
+    b45d644e50b607748a23209511064432:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    8322b8e1650193a41f4254fe2edc0ec7:
+    488ce1ccd2323108344283b4eee11de1:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    27d17ea1573ae6ccb888f55bf3172c37:
+    2013f53af0d2b2b7532a51aedfc4b113:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    e40161e7e1ed2b2c81b7c23b00a9597e:
+    178285d956368b41d7421c5441f7bf34:
       description: Response
       content:
         application/json:
@@ -813,7 +843,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    27b0db527c903c3959ca8869c5d3fcaa:
+    4da63c7b9c9f62b82cd3e4e505771b2c:
       description: The Certification data.
       content:
         application/json:
@@ -906,11 +936,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/eed80766c4e7638604355de711286cd1"
+          "$ref": "#/components/responses/8a67e8795d7b68df469d13960f900a12"
         '202':
-          "$ref": "#/components/responses/aa4e7eb889f98373dfd78e6608895b17"
+          "$ref": "#/components/responses/bb8ebe02c5a13c5f3fee9b1b6bd94995"
         '404':
-          "$ref": "#/components/responses/d4d03d0242e6f29275bab7e96c8f9d78"
+          "$ref": "#/components/responses/14f17426af7f517602ea2904180603d5"
       security:
       - hmac: []
       deprecated: false
@@ -924,16 +954,16 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/27b0db527c903c3959ca8869c5d3fcaa"
+        "$ref": "#/components/requestBodies/4da63c7b9c9f62b82cd3e4e505771b2c"
       responses:
         '201':
-          "$ref": "#/components/responses/97c1c43d73d325b22ed61e20992b3b69"
+          "$ref": "#/components/responses/8a385ec51a9b465a697c8031bff2a306"
         '202':
-          "$ref": "#/components/responses/090e751cce74d60b12094cb20365132d"
+          "$ref": "#/components/responses/95b103ab34bc3a42c7b3eb5487410b04"
         '400':
-          "$ref": "#/components/responses/ef385539c18c5109da1050ae9954577d"
+          "$ref": "#/components/responses/e907db1a91604a13bf78e218a4967b0e"
         '422':
-          "$ref": "#/components/responses/a73160450ba6b1d88f90787cb2645869"
+          "$ref": "#/components/responses/14b3906b8c85fa9a94b3c87820c3b0ed"
       security:
       - hmac: []
       deprecated: false
@@ -948,9 +978,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/508e983ec0f7e2fb34f5498de98106c1"
+          "$ref": "#/components/responses/b45d644e50b607748a23209511064432"
         '404':
-          "$ref": "#/components/responses/8322b8e1650193a41f4254fe2edc0ec7"
+          "$ref": "#/components/responses/488ce1ccd2323108344283b4eee11de1"
       security:
       - hmac: []
       deprecated: false
@@ -985,9 +1015,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/27d17ea1573ae6ccb888f55bf3172c37"
+          "$ref": "#/components/responses/2013f53af0d2b2b7532a51aedfc4b113"
         '503':
-          "$ref": "#/components/responses/e40161e7e1ed2b2c81b7c23b00a9597e"
+          "$ref": "#/components/responses/178285d956368b41d7421c5441f7bf34"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -140,7 +140,8 @@ FactoryBot.define do
             "period_start": cert_date.beginning_of_month,
             "period_end": cert_date.end_of_month,
             "source": "api",
-            "employer": "Acme Corp"
+            "employer": "Acme Corp",
+            "verification_status": "verified"
           }
         ]
       }

--- a/reporting-app/spec/models/certifications/member_data_spec.rb
+++ b/reporting-app/spec/models/certifications/member_data_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Certifications::MemberData do
+  describe Certifications::MemberData::Activity do
+    describe "credit_hours validation" do
+      subject(:activity) do
+        described_class.new(
+          type: "hourly",
+          category: category,
+          hours: 40,
+          credit_hours: 9,
+          period_start: Date.new(2025, 12, 1),
+          period_end: Date.new(2025, 12, 31),
+          verification_status: "verified"
+        )
+      end
+
+      context "when the activity is an education activity" do
+        let(:category) { "education" }
+
+        it "is valid" do
+          expect(activity).to be_valid
+        end
+      end
+
+      context "when the activity is not an education activity" do
+        let(:category) { "employment" }
+
+        it "is invalid" do
+          expect(activity).not_to be_valid
+          expect(activity.errors).to be_of_kind(:credit_hours, :present)
+        end
+      end
+    end
+
+    describe "#clock_hours" do
+      subject(:activity) do
+        described_class.new(
+          type: "hourly",
+          category: category,
+          hours: hours,
+          credit_hours: credit_hours
+        )
+      end
+
+      let(:category) { "education" }
+      let(:hours) { nil }
+      let(:credit_hours) { nil }
+
+      context "when hours are reported" do
+        let(:category) { "employment" }
+        let(:hours) { 40 }
+
+        it "returns the reported hours" do
+          expect(activity.clock_hours).to eq(40)
+        end
+      end
+
+      context "when an education activity reports credit hours instead of hours" do
+        let(:credit_hours) { 9 }
+
+        it "converts credit hours at 12.99 clock hours each" do
+          expect(activity.clock_hours).to eq(9 * described_class::CREDIT_HOURS_MULTIPLIER)
+        end
+      end
+
+      context "when an education activity reports both hours and credit hours" do
+        let(:hours) { 25 }
+        let(:credit_hours) { 9 }
+
+        it "prefers the reported hours" do
+          expect(activity.clock_hours).to eq(25)
+        end
+      end
+
+      context "when a non-education activity reports credit hours without hours" do
+        let(:category) { "employment" }
+        let(:credit_hours) { 9 }
+
+        it "returns nil rather than converting" do
+          expect(activity.clock_hours).to be_nil
+        end
+      end
+
+      context "when neither hours nor credit hours are reported" do
+        it "returns nil" do
+          expect(activity.clock_hours).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -318,6 +318,40 @@ RSpec.describe "/api/certifications", type: :request do
         expect(activity.source_id).to be_nil
       end
 
+      it "creates ExternalHourlyActivity records for education activities reporting credit hours" do
+        member_data = build(:certification_member_data,
+          :with_full_name,
+          :with_account_email,
+          activities: [
+            {
+              "type" => "hourly",
+              "category" => "education",
+              "credit_hours" => 9,
+              "period_start" => certification_date.beginning_of_month,
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
+            }
+          ]
+        )
+        params = valid_json_request_attributes.merge({
+          member_id: member_id,
+          member_data: member_data.as_json
+        })
+
+        expect {
+          post api_certifications_url,
+            params: params,
+            headers: auth_headers(params),
+            as: :json
+        }.to change(ExternalHourlyActivity, :count).from(0).to(1)
+
+        expect(response).to have_http_status(:created)
+
+        activity = ExternalHourlyActivity.last
+        expect(activity.category).to eq("education")
+        expect(activity.hours).to eq(9 * Certifications::CreationService::CREDIT_HOURS_MULTIPLIER)
+      end
+
       it "creates ExternalIncomeActivity records for income activities and not ExternalHourlyActivity" do
         member_data = build(:certification_member_data,
           :with_full_name,
@@ -330,7 +364,8 @@ RSpec.describe "/api/certifications", type: :request do
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
               "source" => "api",
-              "employer" => "Acme Corp"
+              "employer" => "Acme Corp",
+              "verification_status" => "verified"
             }
           ]
         )
@@ -368,7 +403,8 @@ RSpec.describe "/api/certifications", type: :request do
               "category" => "employment",
               "hours" => 40,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             },
             {
               "type" => "income",
@@ -376,7 +412,8 @@ RSpec.describe "/api/certifications", type: :request do
               "gross_income" => 580,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             }
           ]
         )
@@ -410,7 +447,8 @@ RSpec.describe "/api/certifications", type: :request do
               "category" => "employment",
               "hours" => 40,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             }
           ]
         )
@@ -443,7 +481,8 @@ RSpec.describe "/api/certifications", type: :request do
               "category" => "employment",
               "hours" => -10, # Invalid: negative hours
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             }
           ]
         )
@@ -476,7 +515,8 @@ RSpec.describe "/api/certifications", type: :request do
               "gross_income" => 500,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             },
             {
               "type" => "income",
@@ -484,7 +524,8 @@ RSpec.describe "/api/certifications", type: :request do
               "gross_income" => 500,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             }
           ]
         )
@@ -515,14 +556,16 @@ RSpec.describe "/api/certifications", type: :request do
               "category" => "employment",
               "hours" => 40,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             },
             {
               "type" => "hourly",
               "category" => "community_service",
               "hours" => 10,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             }
           ]
         )
@@ -612,6 +655,80 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
+      it "invalid activities - credit hours outside the education category" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "employment",
+                "credit_hours": 9, # only education activities may report credit hours instead of hours
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s,
+                "verification_status" => "verified"
+              }
+            ]
+          }
+        })
+        post api_certifications_url,
+             params: params,
+             headers: auth_headers(params),
+             as: :json
+
+        expect(response).to be_client_error
+        expect(response.content_type).to match(a_string_including("application/json"))
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "invalid activities - credit hours not greater than zero" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "education",
+                "credit_hours": 0,
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s,
+                "verification_status": "verified"
+              }
+            ]
+          }
+        })
+        post api_certifications_url,
+             params: params,
+             headers: auth_headers(params),
+             as: :json
+
+        expect(response).to be_client_error
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "member_data.activities[0].credit_hours"))
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "invalid activities - missing verification_status" do
+        params = valid_json_request_attributes.merge({
+          member_data: {
+            activities: [
+              {
+                "type": "hourly",
+                "category": "employment",
+                "hours": 20,
+                "period_start": Date.today.to_s,
+                "period_end": Date.today.to_s
+              }
+            ]
+          }
+        })
+        post api_certifications_url,
+             params: params,
+             headers: auth_headers(params),
+             as: :json
+
+        expect(response).to be_client_error
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "member_data.activities[0].verification_status"))
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
       it "invalid activities - invalid verification_status" do
         params = valid_json_request_attributes.merge({
           member_data: {
@@ -670,7 +787,8 @@ RSpec.describe "/api/certifications", type: :request do
                 "category": "invalid_category",
                 "hours": 20,
                 "period_start": Date.today.to_s,
-                "period_end": Date.today.to_s
+                "period_end": Date.today.to_s,
+                "verification_status" => "verified"
               }
             ]
           }
@@ -693,7 +811,8 @@ RSpec.describe "/api/certifications", type: :request do
                 "type": "income",
                 "category": "employment",
                 "period_start": Date.today.to_s,
-                "period_end": Date.today.to_s
+                "period_end": Date.today.to_s,
+                "verification_status" => "verified"
               }
             ]
           }

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe "/api/certifications", type: :request do
 
         activity = ExternalHourlyActivity.last
         expect(activity.category).to eq("education")
-        expect(activity.hours).to eq(9 * Certifications::CreationService::CREDIT_HOURS_MULTIPLIER)
+        expect(activity.hours).to eq(9 * Certifications::MemberData::Activity::CREDIT_HOURS_MULTIPLIER)
       end
 
       it "creates ExternalIncomeActivity records for income activities and not ExternalHourlyActivity" do
@@ -677,6 +677,7 @@ RSpec.describe "/api/certifications", type: :request do
 
         expect(response).to be_client_error
         expect(response.content_type).to match(a_string_including("application/json"))
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "member_data.activities[0].credit_hours"))
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 

--- a/reporting-app/spec/services/certifications/creation_service_spec.rb
+++ b/reporting-app/spec/services/certifications/creation_service_spec.rb
@@ -116,27 +116,13 @@ RSpec.describe Certifications::CreationService, type: :service do
 
           activity = ExternalHourlyActivity.last
           expect(activity.category).to eq("education")
-          expect(activity.hours).to eq(credit_hours * Certifications::CreationService::CREDIT_HOURS_MULTIPLIER)
+          expect(activity.hours).to eq(
+            credit_hours * Certifications::MemberData::Activity::CREDIT_HOURS_MULTIPLIER
+          )
         end
       end
 
-      context "when education category and credit hours and hours" do
-        let(:category) { "education" }
-        let(:credit_hours) { 9 }
-        let(:hours) { 25 }
-
-        it "ignores credit hours" do
-          expect {
-            service.call
-          }.to change(ExternalHourlyActivity, :count).from(0).to(1)
-
-          activity = ExternalHourlyActivity.last
-          expect(activity.category).to eq("education")
-          expect(activity.hours).to eq(hours)
-        end
-      end
-
-      context "when employment category and credit hours and nil hours" do
+      context "when employment category and nil hours" do
         let(:category) { "employment" }
         let(:hours) { nil }
 

--- a/reporting-app/spec/services/certifications/creation_service_spec.rb
+++ b/reporting-app/spec/services/certifications/creation_service_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Certifications::CreationService, type: :service do
 
   describe "#call" do
     context "with hourly activities" do
+      let(:verification_status) { "verified" }
+      let(:category) { "employment" }
+      let(:hours) { 40 }
+      let(:credit_hours) { nil }
       let(:member_data) do
         build(:certification_member_data,
           :with_full_name,
@@ -31,12 +35,13 @@ RSpec.describe Certifications::CreationService, type: :service do
           activities: [
             {
               "type" => "hourly",
-              "category" => "employment",
-              "hours" => 40,
+              "category" => category,
+              "hours" => hours,
+              "credit_hours" => credit_hours,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "employer" => "Acme Corp",
-              "verification_status" => "verified"
+              "name" => "Acme Corp",
+              "verification_status" => verification_status
             }
           ]
         )
@@ -88,6 +93,57 @@ RSpec.describe Certifications::CreationService, type: :service do
         activity = ExternalHourlyActivity.last
         expect(activity).not_to respond_to(:verification_status)
       end
+
+      context "when verification status is not verified" do
+        let(:verification_status) { "self_attested" }
+
+        it "does not create ExternalHourlyActivity" do
+          expect {
+            service.call
+          }.not_to change(ExternalHourlyActivity, :count)
+        end
+      end
+
+      context "when education category and credit hours" do
+        let(:credit_hours) { 9 }
+        let(:category) { "education" }
+        let(:hours) { nil }
+
+        it "counts education hours at 13 to 1" do
+          expect {
+            service.call
+          }.to change(ExternalHourlyActivity, :count).from(0).to(1)
+
+          activity = ExternalHourlyActivity.last
+          expect(activity.category).to eq("education")
+          expect(activity.hours).to eq(credit_hours * Certifications::CreationService::CREDIT_HOURS_MULTIPLIER)
+        end
+      end
+
+      context "when education category and credit hours and hours" do
+        let(:category) { "education" }
+        let(:credit_hours) { 9 }
+        let(:hours) { 25 }
+
+        it "ignores credit hours" do
+          expect {
+            service.call
+          }.to change(ExternalHourlyActivity, :count).from(0).to(1)
+
+          activity = ExternalHourlyActivity.last
+          expect(activity.category).to eq("education")
+          expect(activity.hours).to eq(hours)
+        end
+      end
+
+      context "when employment category and credit hours and nil hours" do
+        let(:category) { "employment" }
+        let(:hours) { nil }
+
+        it "raises ActiveRecord::RecordInvalid" do
+          expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
     end
 
     context "with multiple hourly activities" do
@@ -101,14 +157,16 @@ RSpec.describe Certifications::CreationService, type: :service do
               "category" => "employment",
               "hours" => 40,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             },
             {
               "type" => "hourly",
               "category" => "community_service",
               "hours" => 10,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             }
           ]
         )
@@ -126,6 +184,7 @@ RSpec.describe Certifications::CreationService, type: :service do
     end
 
     context "with income activities" do
+      let(:verification_status) { "verified" }
       let(:member_data) do
         build(:certification_member_data,
           :with_full_name,
@@ -138,7 +197,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
               "source" => "api",
-              "employer" => "Acme Corp"
+              "name" => "Acme Corp",
+              "verification_status" => verification_status
             }
           ]
         )
@@ -168,6 +228,16 @@ RSpec.describe Certifications::CreationService, type: :service do
           service.call
         }.to change(Certification, :count).from(0).to(1)
       end
+
+      context "when verification status is not verified" do
+        let(:verification_status) { "pending" }
+
+        it "does not create ExternalIncomeActivity" do
+          expect {
+            service.call
+          }.not_to change(ExternalIncomeActivity, :count)
+        end
+      end
     end
 
     context "with mixed hourly and income activities" do
@@ -181,7 +251,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "category" => "employment",
               "hours" => 40,
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             },
             {
               "type" => "income",
@@ -189,7 +260,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "gross_income" => 580,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             }
           ]
         )
@@ -265,7 +337,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "category" => "employment",
               "hours" => -10, # Invalid: negative hours
               "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month
+              "period_end" => certification_date.end_of_month,
+              "verification_status" => "verified"
             }
           ]
         )
@@ -293,7 +366,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "gross_income" => 500,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             },
             {
               "type" => "income",
@@ -301,7 +375,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "gross_income" => 500,
               "period_start" => certification_date.beginning_of_month,
               "period_end" => certification_date.end_of_month,
-              "source" => "api"
+              "source" => "api",
+              "verification_status" => "verified"
             }
           ]
         )


### PR DESCRIPTION
## Ticket

Resolves PBI-69965

## Changes

- `Certifications::CreationService` only creates `ExternalHourlyActivity` and `ExternalIncomeActivity` records for activities whose verification status is `verified`.
- Education activities may report `credit_hours` in place of `hours`. `Certifications::CreationService` converts them at intake using `CREDIT_HOURS_MULTIPLIER` (12.99 clock hours per credit hour, per the Federal Register).
- `Certifications::MemberData::Activity` requires `verification_status`, requires `hours` only when the activity is not an education activity reporting credit hours, and validates `credit_hours` as greater than zero.
- `Certifications::CreationService` falls back to an activity's `name` when `employer` is absent on income activities.
- OpenAPI spec: `hours` and `credit_hours` are now declared properties with an `anyOf` rule covering the either/or, `verification_status` is required and non-nullable, and `name` is documented alongside `employer`.

## Context for reviewers

`verification_status` moving from optional to required is a breaking change for any client that omits it. Without it, activities would be silently discarded and the request would still return `201`, so it fails loudly instead.

`CREDIT_HOURS_MULTIPLIER` is a `BigDecimal` rather than a float — `credit_hours` is a decimal attribute, and a float multiplier would push the result through binary floating point.

Two known gaps to address in follow-up tickets:

- **Duplicate detection.** `ExternalHourlyActivityService.duplicate_entry?` keys on `(member_id, category, hours, period_start, period_end)`. Two entries with the same hours are rejected as duplicates, rolling back the whole certification. Unlike income, the distinguishing field, `name`, is neither part of the key nor persisted for hourly activities.
- **Multi-month activity periods.** The credit-hours multiplier is monthly, so a period spanning more than one month is credited a single month. This needs handling across all activities, not just credit hours.

## Testing

Request specs cover the new API behavior end to end: an education activity reporting only `credit_hours` is accepted and stored as the converted hours, and requests are rejected when `credit_hours` appears outside the education category, when `credit_hours` is not greater than zero, and when `verification_status` is missing or invalid. Service specs cover activities being skipped when not verified, `hours` taking precedence when both values are supplied, and a non-education category with no hours failing.

```
make test    # 3340 examples, 0 failures — line 96.77%, branch 84.17%
make lint    # 569 files inspected, no offenses detected
```

Manual test with demo ("Partially met income requirement" and "Fully met work hours requirement") worked as expected.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->