### PR TITLE
PBI-69962: Add unique index for certification API duplicate key

### DIFF
--- a/reporting-app/db/migrate/20260810164108_add_unique_index_on_certifications_duplicate_key.rb
+++ b/reporting-app/db/migrate/20260810164108_add_unique_index_on_certifications_duplicate_key.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnCertificationsDuplicateKey < ActiveRecord::Migration[8.0]
+  def change
+    # Enforces API idempotency key used by Certification.find_duplicate /
+    # POST /api/certifications. Partial index so rows missing any key
+    # component (NULL) are not treated as duplicates — matching app-level
+    # blank? guards. Postgres UNIQUE already allows multiple NULLs; the
+    # WHERE clause makes that intent explicit.
+    add_index :certifications,
+      [ :member_id, :case_number, :application_date ],
+      unique: true,
+      where: "member_id IS NOT NULL AND case_number IS NOT NULL AND application_date IS NOT NULL",
+      name: "index_certifications_on_member_case_application_date"
+  end
+end

--- a/reporting-app/db/schema.rb
+++ b/reporting-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_29_133636) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_10_164108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -144,6 +144,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_29_133636) do
     t.date "application_date"
     t.jsonb "household_data"
     t.index ["case_number"], name: "index_certifications_on_case_number"
+    t.index ["member_id", "case_number", "application_date"], name: "index_certifications_on_member_case_application_date", unique: true, where: "((member_id IS NOT NULL) AND (case_number IS NOT NULL) AND (application_date IS NOT NULL))"
     t.index ["member_id"], name: "index_certifications_on_member_id"
   end
 


### PR DESCRIPTION
## Ticket

PBI-69962 — Prevent duplicate certification requests from being created in OSCER via the API

## Changes

- Add partial unique index `index_certifications_on_member_case_application_date` on `(member_id, case_number, application_date)` where all three are `NOT NULL`
- Update `schema.rb` to version `2026_08_10_164108`

## Context for reviewers

- Migration-only PR (no application code). App-level idempotency / `RecordNotUnique` handling should land in a follow-up stacked on this branch or after merge.
- Partial unique index intentionally excludes rows missing any key component, matching `Certification.find_duplicate` blank guards.
- If existing environments already have duplicate non-null triples, migrate will fail until those rows are cleaned up.

## Testing

- Locally: from `reporting-app/`, `make db-migrate` — migration applied successfully.
- Verify index in `db/schema.rb` / `\d certifications` in `make db-console` if desired.

Made with [Cursor](https://cursor.com)

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->