### PR TITLE
PBI-69962: Prevent duplicate certification requests via the API

### DIFF
--- a/reporting-app/app/controllers/api/certifications_controller.rb
+++ b/reporting-app/app/controllers/api/certifications_controller.rb
@@ -36,6 +36,7 @@ class Api::CertificationsController < ApiController
   # @request_body_example Without explicit months and due date [Reference:#/components/schemas/CertificationCreateRequestBody/examples/without_explicit_months_that_can_be_certified_and_due_date]
   # @request_body_example Certification type [Reference:#/components/schemas/CertificationCreateRequestBody/examples/certification_type]
   # @response Created Certification.(201) [Reference:#/components/schemas/CertificationResponseBody]
+  # @response Existing Certification returned for a duplicate request.(200) [Reference:#/components/schemas/CertificationResponseBody]
   # @response Accepted(202) []
   # @response User error.(400) [Reference:#/components/schemas/ErrorResponseBody]
   # @response User error.(422) [Reference:#/components/schemas/ErrorResponseBody]
@@ -49,6 +50,17 @@ class Api::CertificationsController < ApiController
     # Build certification from request
     certification = create_request.to_certification
     authorize certification
+
+    # Idempotency: if a certification already exists for this duplicate key,
+    # return its status instead of creating another row.
+    existing = Certification.find_duplicate(
+      member_id: certification.member_id,
+      case_number: certification.case_number,
+      application_date: certification.application_date
+    )
+    if existing
+      return render_data(Api::Certifications::Response.from_certification(existing))
+    end
 
     begin
       service = Certifications::CreationService.new(certification)

--- a/reporting-app/app/models/api/certifications/create_request.rb
+++ b/reporting-app/app/models/api/certifications/create_request.rb
@@ -3,6 +3,7 @@
 class Api::Certifications::CreateRequest < ValueObject
   attribute :member_id, :string
   attribute :case_number, :string
+  attribute :application_date, :date
 
   attribute :certification_requirements, Api::Certifications::RequirementsOrParamsInput.to_type
   attribute :member_data, Certifications::MemberData.to_type

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -60,6 +60,17 @@ class Certification < ApplicationRecord
     ).where("certification_requirements->>'certification_date' = ?", certification_date.to_s).exists?
   end
 
+  # Find an existing certification matching the API duplicate key
+  # (member_id + case_number + application_date). Used to make
+  # POST /api/certifications idempotent for state-system integrations.
+  # Returns nil if any key component is blank so unrelated records with
+  # missing values are never treated as duplicates.
+  def self.find_duplicate(member_id:, case_number:, application_date:)
+    return nil if member_id.blank? || case_number.blank? || application_date.blank?
+
+    where(member_id:, case_number:, application_date:).order(:created_at).first
+  end
+
   # Find certifications created via batch upload
   def self.from_batch_upload(batch_upload_id)
     joins("INNER JOIN certification_origins ON certifications.id = certification_origins.certification_id")

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -63,10 +63,11 @@ class Certification < ApplicationRecord
   # Find an existing certification matching the API duplicate key
   # (member_id + case_number + application_date). Used to make
   # POST /api/certifications idempotent for state-system integrations.
-  # A blank application_date matches other rows that also have a blank
-  # application_date. member_id and case_number are required.
+  # Returns nil if any key component is blank so unrelated records with
+  # missing values are never treated as duplicates. application_date will
+  # be required on create in a follow-up; keep this guard until then.
   def self.find_duplicate(member_id:, case_number:, application_date:)
-    return nil if member_id.blank? || case_number.blank?
+    return nil if member_id.blank? || case_number.blank? || application_date.blank?
 
     where(member_id:, case_number:, application_date:).order(:created_at).first
   end

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -63,10 +63,10 @@ class Certification < ApplicationRecord
   # Find an existing certification matching the API duplicate key
   # (member_id + case_number + application_date). Used to make
   # POST /api/certifications idempotent for state-system integrations.
-  # Returns nil if any key component is blank so unrelated records with
-  # missing values are never treated as duplicates.
+  # A blank application_date matches other rows that also have a blank
+  # application_date. member_id and case_number are required.
   def self.find_duplicate(member_id:, case_number:, application_date:)
-    return nil if member_id.blank? || case_number.blank? || application_date.blank?
+    return nil if member_id.blank? || case_number.blank?
 
     where(member_id:, case_number:, application_date:).order(:created_at).first
   end

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -752,67 +752,73 @@ components:
       required:
       - status
   responses:
-    92b867c7bd7710a190d49f556523432e:
+    7c87ef12f746372bf77667e95b18eafa:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    84de618d106cfb28cb206e386b02308b:
+    caf1be1c08b49c98b7e45e6be580e278:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    16d508648743b65df08644f70d98f653:
+    21ab1046c7d707036d76c87abc919b78:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    f254a5555e78e1eb8959045c99f6bc05:
+    6c394101a508d3f54c451c5c16b74201:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    47caa76d260b12b1202ff7a40f810ffe:
+    0b9cd4248c2ed0eb661b97a29888e52b:
+      description: Existing Certification returned for a duplicate request.
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/CertificationResponseBody"
+    d9254880ce9c4fadca6e4a36f00907bf:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    6896680c4d444791570b1ca22a8caea4:
+    f24c4be5ebb1dccb9143c084e6f5091f:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    5741b9b03a686f8044536adad009d864:
+    d408b7ec60dee040c5c5456624203b8f:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    bb4cae093af9929cfa7dc58d58aa8ef3:
+    f0872d47563a65056c767d8379cb28f1:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    77dc4daafcdf5907bdbed4bd69410c25:
+    7031fe4d0ae796b7d011b83321ef724b:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    45892ef2d6d8cac7e489dd65c55158c5:
+    e715643f357b06ad82f0771c5bba5aab:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    51dfcfc07c920f9d9f37a09083494608:
+    304ca6c4b26f6bb5b722b14c65510ab6:
       description: Response
       content:
         application/json:
@@ -844,7 +850,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    d3b71db4b808315111933b8eb20bdd27:
+    52da7d76af32690d4c5666a7dab71890:
       description: The Certification data.
       content:
         application/json:
@@ -937,11 +943,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/92b867c7bd7710a190d49f556523432e"
+          "$ref": "#/components/responses/7c87ef12f746372bf77667e95b18eafa"
         '202':
-          "$ref": "#/components/responses/84de618d106cfb28cb206e386b02308b"
+          "$ref": "#/components/responses/caf1be1c08b49c98b7e45e6be580e278"
         '404':
-          "$ref": "#/components/responses/16d508648743b65df08644f70d98f653"
+          "$ref": "#/components/responses/21ab1046c7d707036d76c87abc919b78"
       security:
       - hmac: []
       deprecated: false
@@ -955,16 +961,18 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/d3b71db4b808315111933b8eb20bdd27"
+        "$ref": "#/components/requestBodies/52da7d76af32690d4c5666a7dab71890"
       responses:
         '201':
-          "$ref": "#/components/responses/f254a5555e78e1eb8959045c99f6bc05"
+          "$ref": "#/components/responses/6c394101a508d3f54c451c5c16b74201"
+        '200':
+          "$ref": "#/components/responses/0b9cd4248c2ed0eb661b97a29888e52b"
         '202':
-          "$ref": "#/components/responses/47caa76d260b12b1202ff7a40f810ffe"
+          "$ref": "#/components/responses/d9254880ce9c4fadca6e4a36f00907bf"
         '400':
-          "$ref": "#/components/responses/6896680c4d444791570b1ca22a8caea4"
+          "$ref": "#/components/responses/f24c4be5ebb1dccb9143c084e6f5091f"
         '422':
-          "$ref": "#/components/responses/5741b9b03a686f8044536adad009d864"
+          "$ref": "#/components/responses/d408b7ec60dee040c5c5456624203b8f"
       security:
       - hmac: []
       deprecated: false
@@ -979,9 +987,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/bb4cae093af9929cfa7dc58d58aa8ef3"
+          "$ref": "#/components/responses/f0872d47563a65056c767d8379cb28f1"
         '404':
-          "$ref": "#/components/responses/77dc4daafcdf5907bdbed4bd69410c25"
+          "$ref": "#/components/responses/7031fe4d0ae796b7d011b83321ef724b"
       security:
       - hmac: []
       deprecated: false
@@ -1016,9 +1024,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/45892ef2d6d8cac7e489dd65c55158c5"
+          "$ref": "#/components/responses/e715643f357b06ad82f0771c5bba5aab"
         '503':
-          "$ref": "#/components/responses/51dfcfc07c920f9d9f37a09083494608"
+          "$ref": "#/components/responses/304ca6c4b26f6bb5b722b14c65510ab6"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -107,6 +107,59 @@ RSpec.describe Certification, type: :model do
     end
   end
 
+  describe '.find_duplicate' do
+    let(:application_date) { Date.new(2025, 3, 1) }
+    let!(:certification) do
+      create(:certification,
+        member_id: "M123",
+        case_number: "C-123",
+        application_date: application_date
+      )
+    end
+
+    it 'returns the matching certification for the full compound key' do
+      result = described_class.find_duplicate(
+        member_id: "M123",
+        case_number: "C-123",
+        application_date: application_date
+      )
+
+      expect(result).to eq(certification)
+    end
+
+    it 'returns nil when the application_date does not match' do
+      result = described_class.find_duplicate(
+        member_id: "M123",
+        case_number: "C-123",
+        application_date: application_date + 1
+      )
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when member_id does not match' do
+      result = described_class.find_duplicate(
+        member_id: "M000",
+        case_number: "C-123",
+        application_date: application_date
+      )
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when any key component is blank' do
+      expect(
+        described_class.find_duplicate(member_id: "M123", case_number: "C-123", application_date: nil)
+      ).to be_nil
+      expect(
+        described_class.find_duplicate(member_id: nil, case_number: "C-123", application_date: application_date)
+      ).to be_nil
+      expect(
+        described_class.find_duplicate(member_id: "M123", case_number: "", application_date: application_date)
+      ).to be_nil
+    end
+  end
+
   describe '.from_batch_upload' do
     let(:user) { create(:user) }
     let(:batch_upload) { create(:certification_batch_upload, uploader: user) }

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -147,10 +147,33 @@ RSpec.describe Certification, type: :model do
       expect(result).to be_nil
     end
 
-    it 'returns nil when any key component is blank' do
-      expect(
-        described_class.find_duplicate(member_id: "M123", case_number: "C-123", application_date: nil)
-      ).to be_nil
+    it 'returns the matching certification when both application_dates are blank' do
+      blank_date_cert = create(:certification,
+        member_id: "M456",
+        case_number: "C-456",
+        application_date: nil
+      )
+
+      result = described_class.find_duplicate(
+        member_id: "M456",
+        case_number: "C-456",
+        application_date: nil
+      )
+
+      expect(result).to eq(blank_date_cert)
+    end
+
+    it 'does not treat a blank application_date as a match for a dated certification' do
+      result = described_class.find_duplicate(
+        member_id: "M123",
+        case_number: "C-123",
+        application_date: nil
+      )
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when member_id or case_number is blank' do
       expect(
         described_class.find_duplicate(member_id: nil, case_number: "C-123", application_date: application_date)
       ).to be_nil

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -147,33 +147,10 @@ RSpec.describe Certification, type: :model do
       expect(result).to be_nil
     end
 
-    it 'returns the matching certification when both application_dates are blank' do
-      blank_date_cert = create(:certification,
-        member_id: "M456",
-        case_number: "C-456",
-        application_date: nil
-      )
-
-      result = described_class.find_duplicate(
-        member_id: "M456",
-        case_number: "C-456",
-        application_date: nil
-      )
-
-      expect(result).to eq(blank_date_cert)
-    end
-
-    it 'does not treat a blank application_date as a match for a dated certification' do
-      result = described_class.find_duplicate(
-        member_id: "M123",
-        case_number: "C-123",
-        application_date: nil
-      )
-
-      expect(result).to be_nil
-    end
-
-    it 'returns nil when member_id or case_number is blank' do
+    it 'returns nil when any key component is blank' do
+      expect(
+        described_class.find_duplicate(member_id: "M123", case_number: "C-123", application_date: nil)
+      ).to be_nil
       expect(
         described_class.find_duplicate(member_id: nil, case_number: "C-123", application_date: application_date)
       ).to be_nil

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "/api/certifications", type: :request do
   let(:valid_json_request_attributes) {
     {
       member_id: "foobar",
+      application_date: "2025-10-16",
       member_data: {
         account_email: member_user.email,
         name: {
@@ -621,6 +622,38 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
+      it "returns the existing certification's outcome status" do
+        allow(Strata::EventManager).to receive(:publish)
+
+        post api_certifications_url,
+             params: duplicate_attributes,
+             headers: auth_headers(duplicate_attributes),
+             as: :json
+        expect(response).to have_http_status(:created)
+        existing_id = response.parsed_body[:id]
+
+        create(:determination,
+               subject: Certification.find(existing_id),
+               outcome: "compliant",
+               decision_method: "automated",
+               reasons: [ "hours_reported_compliant" ])
+
+        expect {
+          post api_certifications_url,
+               params: duplicate_attributes,
+               headers: auth_headers(duplicate_attributes),
+               as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:id]).to eq(existing_id)
+        expect(response.parsed_body[:outcome]).to include(
+          "status" => "compliant",
+          "reason" => "hours_reported_compliant"
+        )
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
       it "returns the existing certification even when respond-async is requested" do
         post api_certifications_url,
              params: duplicate_attributes,
@@ -659,23 +692,48 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
-      it "creates a new certification when no application_date is provided" do
-        params = valid_json_request_attributes.merge(member_id: "no-app-date", case_number: "C-NAD")
+      it "returns the existing certification when both requests omit application_date" do
+        params = valid_json_request_attributes.except(:application_date).merge(
+          member_id: "no-app-date",
+          case_number: "C-NAD"
+        )
 
         post api_certifications_url,
              params: params,
              headers: auth_headers(params),
              as: :json
         expect(response).to have_http_status(:created)
+        existing_id = response.parsed_body[:id]
 
         expect {
           post api_certifications_url,
                params: params,
                headers: auth_headers(params),
                as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:id]).to eq(existing_id)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "creates a new certification when a dated request is replayed without application_date" do
+        post api_certifications_url,
+             params: duplicate_attributes,
+             headers: auth_headers(duplicate_attributes),
+             as: :json
+        expect(response).to have_http_status(:created)
+
+        undated_attributes = duplicate_attributes.except(:application_date)
+        expect {
+          post api_certifications_url,
+               params: undated_attributes,
+               headers: auth_headers(undated_attributes),
+               as: :json
         }.to change(Certification, :count).by(1)
 
         expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
     end
 

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -590,6 +590,95 @@ RSpec.describe "/api/certifications", type: :request do
       end
     end
 
+    context "when a duplicate request is submitted" do
+      let(:application_date) { Date.new(2025, 10, 16) }
+      let(:duplicate_attributes) {
+        valid_json_request_attributes.merge(
+          member_id: "dup-member",
+          case_number: "C-DUP-1",
+          application_date: application_date.to_s
+        )
+      }
+
+      it "returns the existing certification instead of creating another" do
+        post api_certifications_url,
+             params: duplicate_attributes,
+             headers: auth_headers(duplicate_attributes),
+             as: :json
+        expect(response).to have_http_status(:created)
+        existing_id = response.parsed_body[:id]
+        expect(Certification.find(existing_id).application_date).to eq(application_date)
+
+        expect {
+          post api_certifications_url,
+               params: duplicate_attributes,
+               headers: auth_headers(duplicate_attributes),
+               as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:id]).to eq(existing_id)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "returns the existing certification even when respond-async is requested" do
+        post api_certifications_url,
+             params: duplicate_attributes,
+             headers: auth_headers(duplicate_attributes),
+             as: :json
+        existing_id = response.parsed_body[:id]
+
+        expect {
+          post api_certifications_url,
+               params: duplicate_attributes,
+               headers: auth_headers(duplicate_attributes).merge({ 'prefer': 'respond-async' }),
+               as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:id]).to eq(existing_id)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "creates a new certification when the application_date differs" do
+        post api_certifications_url,
+             params: duplicate_attributes,
+             headers: auth_headers(duplicate_attributes),
+             as: :json
+        expect(response).to have_http_status(:created)
+
+        differing_attributes = duplicate_attributes.merge(application_date: (application_date + 1).to_s)
+        expect {
+          post api_certifications_url,
+               params: differing_attributes,
+               headers: auth_headers(differing_attributes),
+               as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "creates a new certification when no application_date is provided" do
+        params = valid_json_request_attributes.merge(member_id: "no-app-date", case_number: "C-NAD")
+
+        post api_certifications_url,
+             params: params,
+             headers: auth_headers(params),
+             as: :json
+        expect(response).to have_http_status(:created)
+
+        expect {
+          post api_certifications_url,
+               params: params,
+               headers: auth_headers(params),
+               as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
     context "with invalid parameters" do
       it "does not create a new Certification and renders response" do
         params = invalid_request_attributes

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -692,7 +692,7 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
-      it "returns the existing certification when both requests omit application_date" do
+      it "creates a new certification when no application_date is provided" do
         params = valid_json_request_attributes.except(:application_date).merge(
           member_id: "no-app-date",
           case_number: "C-NAD"
@@ -703,17 +703,15 @@ RSpec.describe "/api/certifications", type: :request do
              headers: auth_headers(params),
              as: :json
         expect(response).to have_http_status(:created)
-        existing_id = response.parsed_body[:id]
 
         expect {
           post api_certifications_url,
                params: params,
                headers: auth_headers(params),
                as: :json
-        }.not_to change(Certification, :count)
+        }.to change(Certification, :count).by(1)
 
-        expect(response).to have_http_status(:ok)
-        expect(response.parsed_body[:id]).to eq(existing_id)
+        expect(response).to have_http_status(:created)
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 


### PR DESCRIPTION
## Ticket

PBI-69962 — Prevent duplicate certification requests from being created in OSCER via the API

## Changes

- Persist `application_date` from `POST /api/certifications` via `Api::Certifications::CreateRequest`
- Add `Certification.find_duplicate` keyed on `member_id` + `case_number` + `application_date`
- In `Api::CertificationsController#create`, return the existing certification as `200` with `Api::Certifications::Response` instead of creating another row
- Skip the duplicate check when `member_id`, `case_number`, or `application_date` is blank (blank dates are not treated as matches)
- Document the `200` duplicate response in the generated OpenAPI spec
- Request/model specs for replay, outcome status on the existing cert, `respond-async`, differing date, and omitted date

## Context for reviewers

- App-level lookup only — no unique DB index on this branch. Concurrent overlapping POSTs can still both insert.
- `application_date` is not required on create yet. The blank guard is in place so missing dates never match; requiring the field can be a follow-up.
- OpenAPI still documents `application_date` as optional/nullable.
- Unique-index work (if any) lives separately and is out of scope here.

## Testing

- From `reporting-app/`: `make test args='spec/requests/api/certifications_spec.rb spec/models/certification_spec.rb'`
- 60 examples passed (SimpleCov `exit 2` is expected on a partial suite)

## Local testing

Setup
```
export API_SECRET_KEY='your-local-secret'   # same value the app has

BODY='{
  "member_id": "dup-curl-1",
  "case_number": "C-DUP-1",
  "application_date": "2025-10-16",
  "member_data": {
    "name": { "first": "John", "last": "Doe" }
  },
  "certification_requirements": {
    "certification_date": "2025-10-16",
    "number_of_months_to_certify": 1,
    "lookback_period": 3,
    "due_period_days": 30
  }
}'

post_cert() {
  local payload="$1"
  local extra_header="${2:-}"
  SIG=$(printf '%s' "$payload" | openssl dgst -sha256 -hmac "$API_SECRET_KEY" -binary | base64)
  curl -sS -D /tmp/cert-headers -o /tmp/cert-body \
    -X POST http://localhost:3000/api/certifications \
    -H "Content-Type: application/json" \
    -H "Authorization: HMAC sig=$SIG" \
    ${extra_header:+-H "$extra_header"} \
    -d "$payload"
  echo "HTTP $(awk 'NR==1{print $2}' /tmp/cert-headers)"
  cat /tmp/cert-body | python3 -m json.tool
}
```

Calls and returns
```
post_cert "$BODY"          # 201, note id
post_cert "$BODY"          # 200, same id, no new row
```

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->