### PR TITLE
PBI-70650: Move lookback back a month

### DIFF
--- a/e2e/reporting-app/tests/docAiUploadFlow.spec.ts
+++ b/e2e/reporting-app/tests/docAiUploadFlow.spec.ts
@@ -15,11 +15,10 @@ test('member can upload a payslip via DocAI and land on activity review', async 
   const password = 'testPassword';
   const fixturePath = path.join(__dirname, '../fixtures/paystub_test_feb_2026_paydate.pdf');
 
-  // 1. Create a certification case with a February 2026 certification date so the
-  //    reporting period shown on ChooseMonthsPage is "February 2026", matching
-  //    the pay date on the fixture paystub.
+  // 1. Create a certification case dated March 2026. The lookback ends the month before, so the
+  //    reporting period is "February 2026", matching the pay date on the fixture paystub.
   const certPage = await new CertificationRequestPage(page).go();
-  await certPage.fillAndSubmit(email, '02/28/2026');
+  await certPage.fillAndSubmit(email, '03/15/2026');
 
   // 2. Register account + verify email
   const accountCreationFlow = new AccountCreationFlow(page, emailService);

--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -40,8 +40,9 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
     })
   end
 
+  # Excludes the certification month, which is still in progress.
   def months_that_can_be_certified
-    lookback_period.times.map { |i| certification_date.beginning_of_month << i }
+    lookback_period.times.map { |i| certification_date.beginning_of_month << (i + 1) }
   end
 
   private

--- a/reporting-app/app/models/certifications/requirements.rb
+++ b/reporting-app/app/models/certifications/requirements.rb
@@ -13,12 +13,6 @@ class Certifications::Requirements < ValueObject
   attribute :certification_type, :enum, options: CERTIFICATION_TYPE_OPTIONS
   validates :certification_type, inclusion: { in: CERTIFICATION_TYPE_OPTIONS, message: "is not a valid option" }, allow_blank: true
 
-  # TODO: could do something like
-  # "lookback": {
-  #   "start": requirement_params.certification_date.beginning_of_month << requirement_params.lookback_period,
-  #   "end": requirement_params.certification_date.beginning_of_month << 1
-  # },
-  # but a list of the months feels potentially more usable, alt name "months_to_consider"?
   attribute :months_that_can_be_certified, :array, of: ActiveModel::Type::Date.new
   attribute :number_of_months_to_certify, :integer, default: 1
   attribute :due_date, :date

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -59,9 +59,9 @@
                 "number_of_months_to_certify": 1,
                 "due_date": "2025-10-26",
                 "months_that_can_be_certified": [
+                  "2025-06-01",
                   "2025-07-01",
-                  "2025-08-01",
-                  "2025-09-01"
+                  "2025-08-01"
                 ]
               },
               "member_data": {
@@ -81,8 +81,8 @@
                     "type": "hourly",
                     "category": "community_service",
                     "hours": "20",
-                    "period_start": "2025-09-01",
-                    "period_end": "2025-09-30",
+                    "period_start": "2025-08-01",
+                    "period_end": "2025-08-31",
                     "employer": "Community Center",
                     "verification_status": "verified"
                   },
@@ -91,8 +91,8 @@
                     "category": "education",
                     "credit_hours": "9",
                     "enrollment_status": "full_time",
-                    "period_start": "2025-09-01",
-                    "period_end": "2025-09-30",
+                    "period_start": "2025-08-01",
+                    "period_end": "2025-08-31",
                     "name": "State University",
                     "verification_status": "verified"
                   }
@@ -798,9 +798,9 @@
           "certification_requirements": {
             "certification_date": "2025-09-26",
             "months_that_can_be_certified": [
+              "2025-06-01",
               "2025-07-01",
-              "2025-08-01",
-              "2025-09-01"
+              "2025-08-01"
             ],
             "number_of_months_to_certify": 1,
             "due_date": "2025-10-26",
@@ -827,8 +827,8 @@
                 "type": "hourly",
                 "category": "community_service",
                 "hours": "80",
-                "period_start": "2025-09-01",
-                "period_end": "2025-09-30",
+                "period_start": "2025-08-01",
+                "period_end": "2025-08-31",
                 "employer": "Community Center",
                 "verification_status": "verified"
               }

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -51,9 +51,9 @@ components:
               number_of_months_to_certify: 1
               due_date: '2025-10-26'
               months_that_can_be_certified:
+              - '2025-06-01'
               - '2025-07-01'
               - '2025-08-01'
-              - '2025-09-01'
             member_data:
               account_email: john@doe.com
               contact:
@@ -68,16 +68,16 @@ components:
               - type: hourly
                 category: community_service
                 hours: '20'
-                period_start: '2025-09-01'
-                period_end: '2025-09-30'
+                period_start: '2025-08-01'
+                period_end: '2025-08-31'
                 employer: Community Center
                 verification_status: verified
               - type: hourly
                 category: education
                 credit_hours: '9'
                 enrollment_status: full_time
-                period_start: '2025-09-01'
-                period_end: '2025-09-30'
+                period_start: '2025-08-01'
+                period_end: '2025-08-31'
                 name: State University
                 verification_status: verified
               date_of_birth: '1980-01-01'
@@ -737,9 +737,9 @@ components:
         certification_requirements:
           certification_date: '2025-09-26'
           months_that_can_be_certified:
+          - '2025-06-01'
           - '2025-07-01'
           - '2025-08-01'
-          - '2025-09-01'
           number_of_months_to_certify: 1
           due_date: '2025-10-26'
           params:
@@ -760,8 +760,8 @@ components:
           - type: hourly
             category: community_service
             hours: '80'
-            period_start: '2025-09-01'
-            period_end: '2025-09-30'
+            period_start: '2025-08-01'
+            period_end: '2025-08-31'
             employer: Community Center
             verification_status: verified
           date_of_birth: '1980-01-01'
@@ -795,73 +795,73 @@ components:
       required:
       - status
   responses:
-    77b9592b378bfa9f37a8424bf24955cc:
+    97b7961e71e50273645f83deb9a36c61:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    87ccaaab551aa9d024f26343cb8099f8:
+    46a16e2accf3afd8af454e34d75b8ff5:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    c6906c6c9f4d833648b5e341cbfd2577:
+    a0cd30798b6f58a5b8383ac34e9b046c:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    19e257c5a603bb56e8fa480fdc871db7:
+    a83413b9d41e58b4134b113b5fbf9796:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    6c9a88c7631125095db78e1fbdf2c203:
+    1ecceed86c18b203880874495cd64043:
       description: Existing Certification returned for a duplicate request.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    5c084620db1afad26fa27720198dd054:
+    9059d8b7005896da239ea7f4a22f0d47:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    240073189eed343e15ff71063ec9d26b:
+    c1dd4c539de38facb9f3e04263c9b3f3:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    a8d4323c1612eff3030eff101b4d3115:
+    ff2485bd417055ab349e909c601c2708:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    26843a11fc653f7a83a5f429d9983197:
+    '080c214d3aa3c1240f1851360f3cf3db':
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    c9bb2496eda87e91f3b13673fb02a43b:
+    26003162718b460a46d1682738e2c795:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    5e3e5feb102cb7990513c05b736d552f:
+    6cca329dabea9581b6ae2f0a3c893e38:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    131ea2b125eefa635d6a9726bb53c2c3:
+    a5bd9a84fef503c6d49680f7838ee7b8:
       description: Response
       content:
         application/json:
@@ -893,7 +893,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    8c862da4c6d88c18f05f0d2ac7893a9e:
+    0cb88fb096fd80d410d5b2e432ff47e1:
       description: The Certification data.
       content:
         application/json:
@@ -986,11 +986,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/77b9592b378bfa9f37a8424bf24955cc"
+          "$ref": "#/components/responses/97b7961e71e50273645f83deb9a36c61"
         '202':
-          "$ref": "#/components/responses/87ccaaab551aa9d024f26343cb8099f8"
+          "$ref": "#/components/responses/46a16e2accf3afd8af454e34d75b8ff5"
         '404':
-          "$ref": "#/components/responses/c6906c6c9f4d833648b5e341cbfd2577"
+          "$ref": "#/components/responses/a0cd30798b6f58a5b8383ac34e9b046c"
       security:
       - hmac: []
       deprecated: false
@@ -1004,18 +1004,18 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/8c862da4c6d88c18f05f0d2ac7893a9e"
+        "$ref": "#/components/requestBodies/0cb88fb096fd80d410d5b2e432ff47e1"
       responses:
         '201':
-          "$ref": "#/components/responses/19e257c5a603bb56e8fa480fdc871db7"
+          "$ref": "#/components/responses/a83413b9d41e58b4134b113b5fbf9796"
         '200':
-          "$ref": "#/components/responses/6c9a88c7631125095db78e1fbdf2c203"
+          "$ref": "#/components/responses/1ecceed86c18b203880874495cd64043"
         '202':
-          "$ref": "#/components/responses/5c084620db1afad26fa27720198dd054"
+          "$ref": "#/components/responses/9059d8b7005896da239ea7f4a22f0d47"
         '400':
-          "$ref": "#/components/responses/240073189eed343e15ff71063ec9d26b"
+          "$ref": "#/components/responses/c1dd4c539de38facb9f3e04263c9b3f3"
         '422':
-          "$ref": "#/components/responses/a8d4323c1612eff3030eff101b4d3115"
+          "$ref": "#/components/responses/ff2485bd417055ab349e909c601c2708"
       security:
       - hmac: []
       deprecated: false
@@ -1030,9 +1030,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/26843a11fc653f7a83a5f429d9983197"
+          "$ref": "#/components/responses/080c214d3aa3c1240f1851360f3cf3db"
         '404':
-          "$ref": "#/components/responses/c9bb2496eda87e91f3b13673fb02a43b"
+          "$ref": "#/components/responses/26003162718b460a46d1682738e2c795"
       security:
       - hmac: []
       deprecated: false
@@ -1067,9 +1067,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/5e3e5feb102cb7990513c05b736d552f"
+          "$ref": "#/components/responses/6cca329dabea9581b6ae2f0a3c893e38"
         '503':
-          "$ref": "#/components/responses/131ea2b125eefa635d6a9726bb53c2c3"
+          "$ref": "#/components/responses/a5bd9a84fef503c6d49680f7838ee7b8"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/factories/certifications/certification_requirements_factory.rb
+++ b/reporting-app/spec/factories/certifications/certification_requirements_factory.rb
@@ -4,11 +4,12 @@ FactoryBot.define do
   factory :certification_certification_requirements, class: Certifications::Requirements do
     certification_date { Faker::Date.forward(days: 30) }
     number_of_months_to_certify { Faker::Number.within(range: 1..3) }
+    # Mirrors Certifications::RequirementParams#months_that_can_be_certified.
     months_that_can_be_certified do
       Faker::Number.between(
         from: number_of_months_to_certify,
         to: number_of_months_to_certify + 3
-      ).times.map { |i| certification_date.beginning_of_month << i }
+      ).times.map { |i| certification_date.beginning_of_month << (i + 1) }
     end
     due_date { Faker::Date.between(from: 30.days.from_now, to: 60.days.from_now) }
 

--- a/reporting-app/spec/factories/certifications/member_data_factory.rb
+++ b/reporting-app/spec/factories/certifications/member_data_factory.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     transient do
       cert_date { Date.today }
       num_months { 1 }
+      # Reported activity lands in the certifiable months, which end the month before cert_date.
+      latest_certifiable_month { cert_date.beginning_of_month << 1 }
     end
 
     trait :with_full_name do
@@ -46,8 +48,8 @@ FactoryBot.define do
             "type": "hourly",
             "category": "employment",
             "hours": 10,
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "employer": "Acme",
             "verification_status": "verified"
           }
@@ -63,8 +65,8 @@ FactoryBot.define do
             "type": "hourly",
             "category": "employment",
             "hours": 80,
-            "period_start": cert_date.beginning_of_month << i,
-            "period_end": cert_date.end_of_month << i,
+            "period_start": latest_certifiable_month << i,
+            "period_end": latest_certifiable_month.end_of_month << i,
             "employer": "Acme",
             "verification_status": "verified"
           }
@@ -80,8 +82,8 @@ FactoryBot.define do
             "type": "hourly",
             "category": "education",
             "enrollment_status": "half_time",
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "name": "State University",
             "verification_status": "verified"
           }
@@ -97,8 +99,8 @@ FactoryBot.define do
             "type": "hourly",
             "category": "education",
             "enrollment_status": "less_than_half_time",
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "name": "State University",
             "verification_status": "verified"
           }
@@ -119,8 +121,8 @@ FactoryBot.define do
             "type": "income",
             "category": "employment",
             "gross_income": IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2.0,
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "source": "api",
             "employer": "Acme Corp",
             "verification_status": "verified"
@@ -137,8 +139,8 @@ FactoryBot.define do
             "type": "income",
             "category": "employment",
             "gross_income": IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY,
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "source": "api",
             "employer": "Acme Corp",
             "verification_status": "verified"
@@ -154,8 +156,8 @@ FactoryBot.define do
             "type": "hourly",
             "category": "community_service",
             "hours": 20,
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "employer": "Community Center",
             "verification_status": "verified"
           }
@@ -171,8 +173,8 @@ FactoryBot.define do
             "type": "income",
             "category": "employment",
             "gross_income": 620.0,
-            "period_start": cert_date.beginning_of_month,
-            "period_end": cert_date.end_of_month,
+            "period_start": latest_certifiable_month,
+            "period_end": latest_certifiable_month.end_of_month,
             "source": "api",
             "employer": "Acme Corp",
             "verification_status": "verified"

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -161,4 +161,83 @@ RSpec.describe Demo::Certifications::CreateForm do
       end
     end
   end
+
+  # Scenario activities have to land inside the lookback, since that is all the compliance services
+  # count, so the scenarios keep reaching the determinations they name.
+  describe "#to_certification external scenario months" do
+    subject(:activities) { certification.member_data.activities }
+
+    let(:certification) { form.to_certification }
+    let(:form) do
+      described_class.new(
+        certification_date: Date.new(2026, 8, 20),
+        external_scenario: scenario,
+        lookback_period: 3,
+        number_of_months_to_certify: 3
+      )
+    end
+    let(:months) { certification.certification_requirements.months_that_can_be_certified }
+    let(:latest_certifiable_month) { Date.new(2026, 7, 1) }
+
+    shared_examples "activities reported in the certifiable months" do |expected_months_count|
+      it "reports #{expected_months_count} month(s) of activity" do
+        expect(activities.length).to eq expected_months_count
+      end
+
+      it "reports activity only in certifiable months" do
+        expect(activities.map(&:period_start)).to match_array(months.first(expected_months_count))
+        activities.each do |activity|
+          expect(activity.period_end).to eq activity.period_start.end_of_month
+        end
+      end
+
+      it "reports the most recent activity in the month before the certification month" do
+        expect(activities.map(&:period_start).max).to eq latest_certifiable_month
+      end
+    end
+
+    context "when the partially met work hours scenario is selected" do
+      let(:scenario) { "Partially met work hours requirement" }
+
+      it_behaves_like "activities reported in the certifiable months", 1
+    end
+
+    context "when the fully met work hours scenario is selected" do
+      let(:scenario) { "Fully met work hours requirement" }
+
+      it_behaves_like "activities reported in the certifiable months", 3
+    end
+
+    context "when the partially met income scenario is selected" do
+      let(:scenario) { "Partially met income requirement" }
+
+      it_behaves_like "activities reported in the certifiable months", 1
+    end
+
+    context "when the fully met income scenario is selected" do
+      let(:scenario) { "Fully met income requirement" }
+
+      it_behaves_like "activities reported in the certifiable months", 1
+    end
+
+    context "when the half-time education enrollment scenario is selected" do
+      let(:scenario) { "Half-time education enrollment" }
+
+      it_behaves_like "activities reported in the certifiable months", 1
+    end
+
+    context "when the less than half-time education enrollment scenario is selected" do
+      let(:scenario) { "Less than half-time education enrollment" }
+
+      it_behaves_like "activities reported in the certifiable months", 1
+    end
+
+    context "when the age-based exemption scenario is selected" do
+      let(:scenario) { "Meets age-based exemption requirement" }
+
+      it "sets a date of birth that is still under 19 in every certifiable month" do
+        expect(certification.member_data.date_of_birth).to be > months.min - 19.years
+      end
+    end
+  end
 end

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Demo::Certifications::CreateForm do
       )
     end
     let(:months) { certification.certification_requirements.months_that_can_be_certified }
-    let(:latest_certifiable_month) { Date.new(2026, 7, 1) }
+    let(:latest_certifiable_month) { months.max }
 
     shared_examples "activities reported in the certifiable months" do |expected_months_count|
       it "reports #{expected_months_count} month(s) of activity" do

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Certifications::RequirementParams do
+  describe "#months_that_can_be_certified" do
+    subject(:months) { params.months_that_can_be_certified }
+
+    let(:params) do
+      build(
+        :certification_certification_requirement_params,
+        certification_date: Date.new(2026, 8, 20),
+        lookback_period: lookback_period,
+        number_of_months_to_certify: 1,
+        due_period_days: 30
+      )
+    end
+
+    context "with a multi-month lookback" do
+      let(:lookback_period) { 3 }
+
+      it "returns the lookback_period months ending the month before the certification month" do
+        expect(months).to eq [ Date.new(2026, 7, 1), Date.new(2026, 6, 1), Date.new(2026, 5, 1) ]
+      end
+
+      it "excludes the certification month" do
+        expect(months).not_to include Date.new(2026, 8, 1)
+      end
+    end
+
+    context "with a single-month lookback" do
+      let(:lookback_period) { 1 }
+
+      it "returns only the month before the certification month" do
+        expect(months).to eq [ Date.new(2026, 7, 1) ]
+      end
+    end
+
+    context "when the window crosses a year boundary" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date: Date.new(2026, 1, 15),
+          lookback_period: 2,
+          number_of_months_to_certify: 1,
+          due_period_days: 30
+        )
+      end
+
+      it "walks back into the previous year" do
+        expect(months).to eq [ Date.new(2025, 12, 1), Date.new(2025, 11, 1) ]
+      end
+    end
+  end
+
+  describe "#to_requirements" do
+    subject(:requirements) { params.to_requirements }
+
+    let(:params) do
+      build(
+        :certification_certification_requirement_params,
+        certification_date: Date.new(2026, 8, 20),
+        lookback_period: 6,
+        number_of_months_to_certify: 3,
+        due_period_days: 30
+      )
+    end
+
+    it "carries the shifted months" do
+      expect(requirements.months_that_can_be_certified.max).to eq Date.new(2026, 7, 1)
+      expect(requirements.months_that_can_be_certified.min).to eq Date.new(2026, 2, 1)
+    end
+
+    it "produces a continuous lookback period ending the month before the certification month" do
+      lookback = requirements.continuous_lookback_period
+
+      expect(lookback.start).to eq Date.new(2026, 2, 1)
+      expect(lookback.end).to eq Date.new(2026, 7, 1)
+    end
+  end
+end

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Certifications::RequirementParams do
   describe "#months_that_can_be_certified" do
     subject(:months) { params.months_that_can_be_certified }
 
+    let(:certification_date) {  Date.new(2026, 8, 20) }
+    let(:cert_date_start) { certification_date.beginning_of_month }
     let(:params) do
       build(
         :certification_certification_requirement_params,
-        certification_date: Date.new(2026, 8, 20),
+        certification_date:,
         lookback_period: lookback_period,
         number_of_months_to_certify: 1,
         due_period_days: 30
@@ -24,7 +26,7 @@ RSpec.describe Certifications::RequirementParams do
       end
 
       it "excludes the certification month" do
-        expect(months).not_to include Date.new(2026, 8, 1)
+        expect(months).not_to include cert_date_start
       end
     end
 
@@ -32,20 +34,14 @@ RSpec.describe Certifications::RequirementParams do
       let(:lookback_period) { 1 }
 
       it "returns only the month before the certification month" do
-        expect(months).to eq [ Date.new(2026, 7, 1) ]
+        expect(months).to eq [ cert_date_start << 1 ]
       end
     end
 
     context "when the window crosses a year boundary" do
-      let(:params) do
-        build(
-          :certification_certification_requirement_params,
-          certification_date: Date.new(2026, 1, 15),
-          lookback_period: 2,
-          number_of_months_to_certify: 1,
-          due_period_days: 30
-        )
-      end
+      let(:lookback_period) { 2 }
+
+      let(:certification_date) { Date.new(2026, 1, 15) }
 
       it "walks back into the previous year" do
         expect(months).to eq [ Date.new(2025, 12, 1), Date.new(2025, 11, 1) ]
@@ -56,26 +52,31 @@ RSpec.describe Certifications::RequirementParams do
   describe "#to_requirements" do
     subject(:requirements) { params.to_requirements }
 
+    let(:lookback_period) { 6 }
+    let(:certification_date) { Date.new(2026, 8, 20) }
+    let(:expected_start) { (certification_date << lookback_period).beginning_of_month }
+    let(:expected_end) { (certification_date << 1).beginning_of_month }
+
     let(:params) do
       build(
         :certification_certification_requirement_params,
-        certification_date: Date.new(2026, 8, 20),
-        lookback_period: 6,
+        certification_date:,
+        lookback_period:,
         number_of_months_to_certify: 3,
         due_period_days: 30
       )
     end
 
     it "carries the shifted months" do
-      expect(requirements.months_that_can_be_certified.max).to eq Date.new(2026, 7, 1)
-      expect(requirements.months_that_can_be_certified.min).to eq Date.new(2026, 2, 1)
+      expect(requirements.months_that_can_be_certified.min).to eq expected_start
+      expect(requirements.months_that_can_be_certified.max).to eq expected_end
     end
 
     it "produces a continuous lookback period ending the month before the certification month" do
       lookback = requirements.continuous_lookback_period
 
-      expect(lookback.start).to eq Date.new(2026, 2, 1)
-      expect(lookback.end).to eq Date.new(2026, 7, 1)
+      expect(lookback.start).to eq expected_start
+      expect(lookback.end).to eq expected_end
     end
   end
 end

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Certifications::RequirementParams do
 
     let(:lookback_period) { 6 }
     let(:certification_date) { Date.new(2026, 8, 20) }
-    let(:expected_start) { (certification_date << lookback_period).beginning_of_month }
-    let(:expected_end) { (certification_date << 1).beginning_of_month }
+    let(:expected_start) { certification_date.beginning_of_month << lookback_period }
+    let(:expected_end) { certification_date.beginning_of_month << 1 }
 
     let(:params) do
       build(

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Certifications::RequirementParams do
   describe "#months_that_can_be_certified" do
     subject(:months) { params.months_that_can_be_certified }
 
-    let(:certification_date) {  Date.new(2026, 8, 20) }
+    let(:certification_date) { Date.new(2026, 8, 20) }
     let(:cert_date_start) { certification_date.beginning_of_month }
     let(:params) do
       build(

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe "/api/certifications", type: :request do
 
     context "with activities that create ExternalHourlyActivity records" do
       let(:member_id) { "member-789" }
-      let(:certification_date) { Date.new(2025, 12, 25) }
+      let(:latest_certifiable_month) { Date.new(2025, 12, 25) }
 
       it "creates ExternalHourlyActivity records for hourly activities" do
         member_data = build(:certification_member_data,
@@ -289,8 +289,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "employer" => "Acme Corp",
               "verification_status" => "verified"
             }
@@ -328,8 +328,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "education",
               "credit_hours" => 9,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -362,8 +362,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "education",
               "enrollment_status" => "full_time",
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -396,8 +396,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 620,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "employer" => "Acme Corp",
               "verification_status" => "verified"
@@ -422,7 +422,7 @@ RSpec.describe "/api/certifications", type: :request do
 
         expect(ExternalIncomeActivity.pluck(:member_id, :category, :gross_income, :source_type, :period_start, :period_end)).to eq(
           [
-            [ member_id, "employment", 620, "api", certification_date.beginning_of_month, certification_date.end_of_month ]
+            [ member_id, "employment", 620, "api", latest_certifiable_month.beginning_of_month, latest_certifiable_month.end_of_month ]
           ]
         )
         expect(ExternalIncomeActivity.pick(:metadata)).to include("employer" => "Acme Corp")
@@ -437,16 +437,16 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             },
             {
               "type" => "income",
               "category" => "employment",
               "gross_income" => 580,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             }
@@ -481,8 +481,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -515,8 +515,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "employment",
               "hours" => -10, # Invalid: negative hours
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -548,8 +548,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 500,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             },
@@ -557,8 +557,8 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 500,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             }
@@ -590,16 +590,16 @@ RSpec.describe "/api/certifications", type: :request do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             },
             {
               "type" => "hourly",
               "category" => "community_service",
               "hours" => 10,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -627,7 +627,7 @@ RSpec.describe "/api/certifications", type: :request do
 
     context "with household data that creates ExternalIncomeActivity records" do
       let(:member_id) { "member-789" }
-      let(:certification_date) { Date.new(2025, 12, 25) }
+      let(:latest_certifiable_month) { Date.new(2025, 12, 25) }
 
       it "creates ExternalIncomeActivity records for household income and not ExternalHourlyActivity" do
         member_data = build(:certification_member_data,
@@ -648,8 +648,8 @@ RSpec.describe "/api/certifications", type: :request do
               gross_incomes: [
                 {
                   "gross_income" => 620,
-                  "period_start" => certification_date.beginning_of_month,
-                  "period_end" => certification_date.end_of_month
+                  "period_start" => latest_certifiable_month.beginning_of_month,
+                  "period_end" => latest_certifiable_month.end_of_month
                 }
               ]
             }
@@ -674,7 +674,7 @@ RSpec.describe "/api/certifications", type: :request do
 
         expect(ExternalIncomeActivity.pluck(:member_id, :category, :gross_income, :source_type, :period_start, :period_end)).to eq(
           [
-            [ member_id, "household", 620, "api", certification_date.beginning_of_month, certification_date.end_of_month ]
+            [ member_id, "household", 620, "api", latest_certifiable_month.beginning_of_month, latest_certifiable_month.end_of_month ]
           ]
         )
       end

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -174,8 +174,9 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(activity.member_id).to eq(cert.member_id)
         expect(activity.category).to eq("employment")
         expect(activity.hours).to eq(10)
-        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
-        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        certifiable_month = cert.certification_requirements.months_that_can_be_certified.max
+        expect(activity.period_start).to eq(certifiable_month)
+        expect(activity.period_end).to eq(certifiable_month.end_of_month)
         expect(activity.source_type).to eq("api")
         expect(activity.source_id).to be_nil
       end
@@ -254,8 +255,9 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(activity.category).to eq("employment")
         expect(activity.gross_income).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY / 2.0)
         expect(activity.source_type).to eq("api")
-        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
-        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        certifiable_month = cert.certification_requirements.months_that_can_be_certified.max
+        expect(activity.period_start).to eq(certifiable_month)
+        expect(activity.period_end).to eq(certifiable_month.end_of_month)
         expect(activity.source_id).to be_nil
       end
 
@@ -284,8 +286,9 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(activity.category).to eq("employment")
         expect(activity.gross_income).to eq(IncomeComplianceDeterminationService::TARGET_INCOME_MONTHLY)
         expect(activity.source_type).to eq("api")
-        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
-        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        certifiable_month = cert.certification_requirements.months_that_can_be_certified.max
+        expect(activity.period_start).to eq(certifiable_month)
+        expect(activity.period_end).to eq(certifiable_month.end_of_month)
         expect(activity.source_id).to be_nil
       end
 
@@ -308,8 +311,9 @@ RSpec.describe "/demo/certifications", type: :request do
         expect(activity.category).to eq("education")
         expect(activity.enrollment_status).to eq("half_time")
         expect(activity.hours).to be_nil
-        expect(activity.period_start).to eq(cert.certification_requirements.certification_date.beginning_of_month)
-        expect(activity.period_end).to eq(cert.certification_requirements.certification_date.end_of_month)
+        certifiable_month = cert.certification_requirements.months_that_can_be_certified.max
+        expect(activity.period_start).to eq(certifiable_month)
+        expect(activity.period_end).to eq(certifiable_month.end_of_month)
       end
 
       it "creates Certification with 'Less than half-time education enrollment'" do

--- a/reporting-app/spec/services/certifications/creation_service_spec.rb
+++ b/reporting-app/spec/services/certifications/creation_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Certifications::CreationService, type: :service do
   let(:member_id) { "member-123" }
   let(:case_number) { "case-456" }
   let(:certification_date) { Date.new(2025, 12, 25) }
+  let(:latest_certifiable_month) { certification_date << 1 }
   let(:household_data) { {} }
 
   let(:base_params) do
@@ -42,8 +43,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "hours" => hours,
               "credit_hours" => credit_hours,
               "enrollment_status" => enrollment_status,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "name" => "Acme Corp",
               "verification_status" => verification_status
             }
@@ -69,8 +70,8 @@ RSpec.describe Certifications::CreationService, type: :service do
         expect(activity.member_id).to eq(member_id)
         expect(activity.category).to eq("employment")
         expect(activity.hours).to eq(40)
-        expect(activity.period_start).to eq(certification_date.beginning_of_month)
-        expect(activity.period_end).to eq(certification_date.end_of_month)
+        expect(activity.period_start).to eq(latest_certifiable_month.beginning_of_month)
+        expect(activity.period_end).to eq(latest_certifiable_month.end_of_month)
         expect(activity.source_type).to eq("api")
         expect(activity.source_id).to be_nil
       end
@@ -182,16 +183,16 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             },
             {
               "type" => "hourly",
               "category" => "community_service",
               "hours" => 10,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -220,8 +221,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 620,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "name" => "Acme Corp",
               "verification_status" => verification_status
@@ -243,7 +244,7 @@ RSpec.describe Certifications::CreationService, type: :service do
 
         expect(ExternalIncomeActivity.pluck(:member_id, :category, :gross_income, :source_type, :period_start, :period_end)).to eq(
           [
-            [ member_id, "employment", 620, "api", certification_date.beginning_of_month, certification_date.end_of_month ]
+            [ member_id, "employment", 620, "api", latest_certifiable_month.beginning_of_month, latest_certifiable_month.end_of_month ]
           ]
         )
         expect(ExternalIncomeActivity.pick(:metadata)).to include("employer" => "Acme Corp")
@@ -385,16 +386,16 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "hourly",
               "category" => "employment",
               "hours" => 40,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             },
             {
               "type" => "income",
               "category" => "employment",
               "gross_income" => 580,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             }
@@ -471,8 +472,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "hourly",
               "category" => "employment",
               "hours" => -10, # Invalid: negative hours
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "verification_status" => "verified"
             }
           ]
@@ -499,8 +500,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 500,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             },
@@ -508,8 +509,8 @@ RSpec.describe Certifications::CreationService, type: :service do
               "type" => "income",
               "category" => "employment",
               "gross_income" => 500,
-              "period_start" => certification_date.beginning_of_month,
-              "period_end" => certification_date.end_of_month,
+              "period_start" => latest_certifiable_month.beginning_of_month,
+              "period_end" => latest_certifiable_month.end_of_month,
               "source" => "api",
               "verification_status" => "verified"
             }

--- a/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
+++ b/reporting-app/spec/services/member_dashboard_compliance_service_spec.rb
@@ -441,7 +441,8 @@ RSpec.describe MemberDashboardComplianceService do
       let(:activity_report_application_form) { create(:activity_report_application_form, :with_submitted_status, certification_case_id: certification_case.id) }
 
       before do
-        create(:income_activity, activity_report_application_form_id: activity_report_application_form.id, income: 30_00, month: certification_date)
+        create(:income_activity, activity_report_application_form_id: activity_report_application_form.id, income: 30_00,
+               month: certification.certification_requirements.months_that_can_be_certified.max)
         activity_report_application_form.reload
       end
 


### PR DESCRIPTION
## Ticket

Resolves PBI-70650

## Changes

- `Certifications::RequirementParams#months_that_can_be_certified` now starts one month earlier: the window still spans `lookback_period` months, but ends the month before the certification month instead of including it.
- Demo scenario data follows the window — the `:certification_member_data` factory anchors every activity trait to the latest certifiable month, so `Demo::Certifications::CreateForm` scenarios reach the same determinations as before.
- `:certification_certification_requirements` mirrors the production derivation, so specs exercise the same window the app generates.
- API docs examples (`oas.json` and the regenerated `openapi.generated.yml`) shifted to match what the endpoint now returns.
- Removed a stale TODO on `Certifications::Requirements` that proposed this window shape as a future idea.

## Context for reviewers

As we replace the concept of `certification_date` with `application_date`, we should push the lookback window back one month, so it no longer includes the month of application.

The window is persisted in `certification_requirements` (and snapshotted onto `ActivityReportApplicationForm`), so this affects newly created certifications only; existing cases keep the window they were created with. No backfill.

Two consequences worth naming:

- DocAI payslips dated in the certification month are now rejected by `PayslipToIncomeActivityCreateService`, since that month is no longer a reporting period. The DocAI e2e test moved its certification date to March 2026 so its February 2026 fixture paystub still lands inside the window.
- The `MemberDashboardComplianceService` spec planted a member income activity in the certification month; it now uses the latest certifiable month.

## Testing

New specs, written to fail before the change (12 failures) and green after:

- `Certifications::RequirementParams` — window contents, exclusion of the certification month, single-month lookback, year-boundary rollover, and the `to_requirements` / `continuous_lookback_period` bounds.
- `Demo::Certifications::CreateForm` — per-scenario activity count, every activity inside `months_that_can_be_certified`, most recent activity in the month before the certification month, and the age scenario still under 19 across the window.

Existing demo request specs now assert against `months_that_can_be_certified.max` rather than the certification month.

```
make lint   # 573 files inspected, no offenses detected
make test   # 3456 examples, 0 failures
```

e2e test passes

Manually tested demo: receiving inpatient medical care, fully met income requirement, fully met hourly requirement, half-time education enrollment

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->