### PR TITLE
Wire certification period bounds through certifications API

### DIFF
--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -2,6 +2,8 @@
 
 class Certifications::RequirementParams < Certifications::RequirementTypeParams
   attribute :certification_date, :date
+  attribute :certification_period_start, :date
+  attribute :certification_period_end, :date
   attribute :certification_type, :string, default: nil
 
   attribute :due_date, :date
@@ -31,6 +33,8 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   def to_requirements
     Certifications::Requirements.new({
       "certification_date": certification_date,
+      "certification_period_start": certification_period_start,
+      "certification_period_end": certification_period_end,
       "certification_type": certification_type,
       "months_that_can_be_certified": months_that_can_be_certified,
       "number_of_months_to_certify": number_of_months_to_certify,

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -56,6 +56,8 @@
               "case_number": "C-111",
               "certification_requirements": {
                 "certification_date": "2025-09-26",
+                "certification_period_start": "2025-04-01",
+                "certification_period_end": "2025-09-30",
                 "number_of_months_to_certify": 1,
                 "due_date": "2025-10-26",
                 "months_that_can_be_certified": [
@@ -109,6 +111,8 @@
               "case_number": "C-111",
               "certification_requirements": {
                 "certification_date": "2025-09-26",
+                "certification_period_start": "2025-04-01",
+                "certification_period_end": "2025-09-30",
                 "lookback_period": 3,
                 "number_of_months_to_certify": 1,
                 "due_period_days": 30
@@ -168,6 +172,16 @@
             "format": "date",
             "description": "The date of the certification"
           },
+          "certification_period_start": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "First day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application, which has no prior coverage period."
+          },
+          "certification_period_end": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "Last day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application."
+          },
           "certification_type": {
             "type": ["string", "null"],
 	    "enum": [
@@ -216,6 +230,16 @@
             "format": "date",
             "description": "The date of the certification"
           },
+          "certification_period_start": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "First day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application, which has no prior coverage period."
+          },
+          "certification_period_end": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "Last day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application."
+          },
           "lookback_period": {
             "type": "integer",
             "description": "The number of months before `certification_date` the Member can choose from"
@@ -242,6 +266,16 @@
             "type": "string",
             "format": "date",
             "description": "The date of the certification"
+          },
+          "certification_period_start": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "First day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application, which has no prior coverage period."
+          },
+          "certification_period_end": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "Last day of the member's active certification period. Supplied for recertification and change in circumstance; absent for a new application."
           },
           "certification_type": {
             "type": "string",

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -48,6 +48,8 @@ components:
             case_number: C-111
             certification_requirements:
               certification_date: '2025-09-26'
+              certification_period_start: '2025-04-01'
+              certification_period_end: '2025-09-30'
               number_of_months_to_certify: 1
               due_date: '2025-10-26'
               months_that_can_be_certified:
@@ -89,6 +91,8 @@ components:
             case_number: C-111
             certification_requirements:
               certification_date: '2025-09-26'
+              certification_period_start: '2025-04-01'
+              certification_period_end: '2025-09-30'
               lookback_period: 3
               number_of_months_to_certify: 1
               due_period_days: 30
@@ -133,6 +137,21 @@ components:
           type: string
           format: date
           description: The date of the certification
+        certification_period_start:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: First day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application,
+            which has no prior coverage period.
+        certification_period_end:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: Last day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application.
         certification_type:
           type:
           - string
@@ -181,6 +200,21 @@ components:
           type: string
           format: date
           description: The date of the certification
+        certification_period_start:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: First day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application,
+            which has no prior coverage period.
+        certification_period_end:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: Last day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application.
         lookback_period:
           type: integer
           description: The number of months before `certification_date` the Member
@@ -202,6 +236,21 @@ components:
           type: string
           format: date
           description: The date of the certification
+        certification_period_start:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: First day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application,
+            which has no prior coverage period.
+        certification_period_end:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: Last day of the member's active certification period. Supplied
+            for recertification and change in circumstance; absent for a new application.
         certification_type:
           type: string
           enum:
@@ -795,73 +844,73 @@ components:
       required:
       - status
   responses:
-    97b7961e71e50273645f83deb9a36c61:
+    1d11eb189bf138adcc6118aa03024266:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    46a16e2accf3afd8af454e34d75b8ff5:
+    88788142f7cde6114eafcf01c1a875bf:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    a0cd30798b6f58a5b8383ac34e9b046c:
+    10d5d916650c69da15f8c7681a0f7d0a:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    a83413b9d41e58b4134b113b5fbf9796:
+    866cda7ee7bb56ab7f407786d4ed0695:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    1ecceed86c18b203880874495cd64043:
+    '0009c1f2c57cfc4ccf580fb86487c5d9':
       description: Existing Certification returned for a duplicate request.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    9059d8b7005896da239ea7f4a22f0d47:
+    aaf6317dae1abac0058eb541697a5f0f:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    c1dd4c539de38facb9f3e04263c9b3f3:
+    c3020d20994dbd765aea697b8f38e107:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    ff2485bd417055ab349e909c601c2708:
+    28a28e72b66b09ac7a79e7a74e51ce26:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    '080c214d3aa3c1240f1851360f3cf3db':
+    fccae5435dbe2411dd9be2a83b258dd4:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    26003162718b460a46d1682738e2c795:
+    e295118dba2900a4260c80a98ee4b19c:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    6cca329dabea9581b6ae2f0a3c893e38:
+    6da89506e463b70296e04fed15ce4b14:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    a5bd9a84fef503c6d49680f7838ee7b8:
+    0dce8d376b615135191f32270f4701ce:
       description: Response
       content:
         application/json:
@@ -893,7 +942,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    0cb88fb096fd80d410d5b2e432ff47e1:
+    b91aac4a97afee8dc32086895b8031c7:
       description: The Certification data.
       content:
         application/json:
@@ -986,11 +1035,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/97b7961e71e50273645f83deb9a36c61"
+          "$ref": "#/components/responses/1d11eb189bf138adcc6118aa03024266"
         '202':
-          "$ref": "#/components/responses/46a16e2accf3afd8af454e34d75b8ff5"
+          "$ref": "#/components/responses/88788142f7cde6114eafcf01c1a875bf"
         '404':
-          "$ref": "#/components/responses/a0cd30798b6f58a5b8383ac34e9b046c"
+          "$ref": "#/components/responses/10d5d916650c69da15f8c7681a0f7d0a"
       security:
       - hmac: []
       deprecated: false
@@ -1004,18 +1053,18 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/0cb88fb096fd80d410d5b2e432ff47e1"
+        "$ref": "#/components/requestBodies/b91aac4a97afee8dc32086895b8031c7"
       responses:
         '201':
-          "$ref": "#/components/responses/a83413b9d41e58b4134b113b5fbf9796"
+          "$ref": "#/components/responses/866cda7ee7bb56ab7f407786d4ed0695"
         '200':
-          "$ref": "#/components/responses/1ecceed86c18b203880874495cd64043"
+          "$ref": "#/components/responses/0009c1f2c57cfc4ccf580fb86487c5d9"
         '202':
-          "$ref": "#/components/responses/9059d8b7005896da239ea7f4a22f0d47"
+          "$ref": "#/components/responses/aaf6317dae1abac0058eb541697a5f0f"
         '400':
-          "$ref": "#/components/responses/c1dd4c539de38facb9f3e04263c9b3f3"
+          "$ref": "#/components/responses/c3020d20994dbd765aea697b8f38e107"
         '422':
-          "$ref": "#/components/responses/ff2485bd417055ab349e909c601c2708"
+          "$ref": "#/components/responses/28a28e72b66b09ac7a79e7a74e51ce26"
       security:
       - hmac: []
       deprecated: false
@@ -1030,9 +1079,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/080c214d3aa3c1240f1851360f3cf3db"
+          "$ref": "#/components/responses/fccae5435dbe2411dd9be2a83b258dd4"
         '404':
-          "$ref": "#/components/responses/26003162718b460a46d1682738e2c795"
+          "$ref": "#/components/responses/e295118dba2900a4260c80a98ee4b19c"
       security:
       - hmac: []
       deprecated: false
@@ -1067,9 +1116,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/6cca329dabea9581b6ae2f0a3c893e38"
+          "$ref": "#/components/responses/6da89506e463b70296e04fed15ce4b14"
         '503':
-          "$ref": "#/components/responses/a5bd9a84fef503c6d49680f7838ee7b8"
+          "$ref": "#/components/responses/0dce8d376b615135191f32270f4701ce"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -79,4 +79,42 @@ RSpec.describe Certifications::RequirementParams do
       expect(lookback.end).to eq expected_end
     end
   end
+
+  describe "#to_requirements certification period bounds" do
+    subject(:requirements) { params.to_requirements }
+
+    # Coverage runs Jan to Jun and the renewal is requested in May, so the period
+    # supplied is the currently active one, not the upcoming one.
+    let(:certification_date) { Date.new(2026, 5, 20) }
+    let(:params) do
+      build(
+        :certification_certification_requirement_params, :with_direct_params,
+        certification_date:,
+        **overrides
+      )
+    end
+    let(:overrides) { {} }
+
+    it "leaves both bounds nil when the request does not supply them" do
+      expect(requirements.certification_period_start).to be_nil
+      expect(requirements.certification_period_end).to be_nil
+    end
+
+    context "when the request supplies the period bounds" do
+      let(:overrides) do
+        {
+          certification_period_start: Date.new(2026, 1, 1),
+          certification_period_end: Date.new(2026, 6, 30)
+        }
+      end
+
+      it "carries the supplied start through" do
+        expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+      end
+
+      it "carries the supplied end through" do
+        expect(requirements.certification_period_end).to eq Date.new(2026, 6, 30)
+      end
+    end
+  end
 end

--- a/reporting-app/spec/models/certifications/requirements_spec.rb
+++ b/reporting-app/spec/models/certifications/requirements_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Certifications::Requirements do
       requirements = CertificationService.new.certification_requirements_from_input(
         bounds.merge(
           "certification_date" => "2026-05-20",
-          "certification_type" => "new_application"
+          "certification_type" => "recertification"
         )
       )
 

--- a/reporting-app/spec/models/certifications/requirements_spec.rb
+++ b/reporting-app/spec/models/certifications/requirements_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Certifications::Requirements do
     end
   end
 
-  describe "the bounds survive the request and storage paths" do
+  describe "supplied period bounds" do
     let(:bounds) do
       {
         "certification_period_start" => "2026-01-01",
@@ -48,7 +48,7 @@ RSpec.describe Certifications::Requirements do
       }
     end
 
-    it "are carried when the request supplies full requirements as JSON" do
+    it "survives a full-requirements request" do
       input = Api::Certifications::RequirementsOrParamsInput.new(
         bounds.merge(
           "certification_date" => "2026-05-20",
@@ -60,7 +60,7 @@ RSpec.describe Certifications::Requirements do
       expect(input.certification_period_start).to eq Date.new(2026, 1, 1)
     end
 
-    it "are carried when the request supplies parameters" do
+    it "survives a parameter-shaped request" do
       input = Api::Certifications::RequirementsOrParamsInput.new(
         bounds.merge(
           "certification_date" => "2026-05-20",
@@ -74,7 +74,7 @@ RSpec.describe Certifications::Requirements do
       expect(input.to_requirements.certification_period_start).to eq Date.new(2026, 1, 1)
     end
 
-    it "are carried when built from batch upload input" do
+    it "survives batch upload input" do
       requirements = CertificationService.new.certification_requirements_from_input(
         bounds.merge(
           "certification_date" => "2026-05-20",
@@ -85,7 +85,7 @@ RSpec.describe Certifications::Requirements do
       expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)
     end
 
-    it "round-trip through the database" do
+    it "survives a database round trip" do
       certification = create(
         :certification,
         certification_requirements: build(

--- a/reporting-app/spec/models/certifications/requirements_spec.rb
+++ b/reporting-app/spec/models/certifications/requirements_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Certifications::Requirements do
+  let(:certification_date) { Date.new(2026, 5, 20) }
+
+  # The certification period is supplied by the caller and never derived here. On a
+  # recertification it is the member's currently active, expiring period; a new
+  # application has none, because the member has no prior coverage period.
+  describe "certification period bounds" do
+    subject(:requirements) { build(:certification_certification_requirements, certification_date:, **overrides) }
+
+    let(:overrides) { {} }
+
+    it "leaves both bounds nil when the request does not supply them" do
+      expect(requirements.certification_period_start).to be_nil
+      expect(requirements.certification_period_end).to be_nil
+    end
+
+    it "adds no presence validation, so unsupplied bounds are still valid" do
+      expect(requirements).to be_valid
+    end
+
+    context "when the request supplies the bounds" do
+      let(:overrides) do
+        {
+          certification_period_start: Date.new(2026, 1, 1),
+          certification_period_end: Date.new(2026, 6, 30)
+        }
+      end
+
+      it "keeps the supplied start" do
+        expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+      end
+
+      it "keeps the supplied end" do
+        expect(requirements.certification_period_end).to eq Date.new(2026, 6, 30)
+      end
+    end
+  end
+
+  describe "the bounds survive the request and storage paths" do
+    let(:bounds) do
+      {
+        "certification_period_start" => "2026-01-01",
+        "certification_period_end" => "2026-06-30"
+      }
+    end
+
+    it "are carried when the request supplies full requirements as JSON" do
+      input = Api::Certifications::RequirementsOrParamsInput.new(
+        bounds.merge(
+          "certification_date" => "2026-05-20",
+          "months_that_can_be_certified" => [ "2026-07-01" ]
+        )
+      )
+
+      expect(input).to be_a(described_class)
+      expect(input.certification_period_start).to eq Date.new(2026, 1, 1)
+    end
+
+    it "are carried when the request supplies parameters" do
+      input = Api::Certifications::RequirementsOrParamsInput.new(
+        bounds.merge(
+          "certification_date" => "2026-05-20",
+          "lookback_period" => 6,
+          "number_of_months_to_certify" => 3,
+          "due_period_days" => 30
+        )
+      )
+
+      expect(input).to be_a(Certifications::RequirementParams)
+      expect(input.to_requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+    end
+
+    it "are carried when built from batch upload input" do
+      requirements = CertificationService.new.certification_requirements_from_input(
+        bounds.merge(
+          "certification_date" => "2026-05-20",
+          "certification_type" => "new_application"
+        )
+      )
+
+      expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+    end
+
+    it "round-trip through the database" do
+      certification = create(
+        :certification,
+        certification_requirements: build(
+          :certification_certification_requirements,
+          certification_date:,
+          certification_period_start: Date.new(2026, 1, 1),
+          certification_period_end: Date.new(2026, 6, 30)
+        )
+      )
+
+      stored = certification.reload.certification_requirements
+
+      expect(stored.certification_period_start).to eq Date.new(2026, 1, 1)
+      expect(stored.certification_period_end).to eq Date.new(2026, 6, 30)
+    end
+  end
+end

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -224,6 +224,62 @@ RSpec.describe "/api/certifications", type: :request do
       end
     end
 
+    context "with certification period bounds supplied" do
+      it "stores the bounds the request supplied" do
+        # The period supplied is the currently active, expiring one, so it precedes
+        # the request rather than starting after it.
+        requirement_params = build(
+          :certification_certification_requirement_params, :with_direct_params,
+          certification_date: Date.new(2026, 5, 20),
+          certification_period_start: Date.new(2026, 1, 1),
+          certification_period_end: Date.new(2026, 6, 30)
+        )
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+
+        requirements = Certification.find(response.parsed_body[:id]).certification_requirements
+        expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+        expect(requirements.certification_period_end).to eq Date.new(2026, 6, 30)
+      end
+    end
+
+    context "without certification period bounds" do
+      it "stores no bounds, since OSCER never derives them" do
+        requirement_params = build(
+          :certification_certification_requirement_params, :with_direct_params,
+          certification_date: Date.new(2026, 8, 20)
+        )
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+
+        requirements = Certification.find(response.parsed_body[:id]).certification_requirements
+        expect(requirements.certification_period_start).to be_nil
+        expect(requirements.certification_period_end).to be_nil
+      end
+    end
+
     context "with member data" do
       it "creates a new Certification and renders response" do
         member_data = build(:certification_member_data,


### PR DESCRIPTION
## Changes

- Add `certification_period_start` and `certification_period_end` attributes to `Certifications::RequirementParams`, and pass both through `to_requirements`.
- Document both fields in `lib/assets/oas.json` as optional, nullable dates on all three request shapes that already carry `certification_date`, and add them to two request examples. Regenerated `openapi.generated.yml` to match.
- Add `spec/models/certifications/requirements_spec.rb`, covering the bounds through the full-requirements request shape, the parameter shape, batch upload input, and a database round trip.
- Add `RequirementParams#to_requirements` specs for both supplied and omitted bounds.
- Add request specs asserting that supplied bounds are stored and that omitted bounds stay null.

## Context for reviewers

Both attributes were already declared on `Certifications::Requirements`, but nothing else in the application or its specs referenced them. `RequirementParams#to_requirements` did not pass them through, so they could not be set from a parameter-shaped request, and they were missing from the published API spec, so a caller had no way to send them at all. They were effectively unreachable. This makes them settable end to end.

**The bounds are supplied, never derived.** On a recertification or a change in circumstance they describe the member's currently active, expiring certification period, which is the window the caller is renewing out of. A new application has no certification period at all, because the member has no prior coverage to describe, so its month anchor is the application date instead. That is why there is no derivation and no presence validation here: when a request omits the bounds, they stay null, and a spec asserts that on the model, through `to_requirements`, and through a live API request.

This is deliberately additive and safe to land on its own, because nothing reads either field before or after the change. Repointing the exclusion rules and the member dashboard onto the new anchor is separate follow-up work, and `certification_date` is untouched here.

One fixture convention, called out because it is easy to copy wrongly: the examples use a certification period that *precedes* the request (certification date 2026-05-20 inside a 2026-01-01 to 2026-06-30 period) rather than one starting after it. The period being described is the one currently running out, not an upcoming one, and the spec comments say so at each site.

## Testing

```
make lint   # 584 files inspected, no offenses detected
make test   # 3469 examples, 0 failures
```

Line coverage 96.83%, branch coverage 84.25%, both above the configured minimums. No determination outcomes change, which the existing exclusion and determination specs confirm by passing without expectation edits.

Targeted re-run of the three affected spec files after the final fixture change: 62 examples, 0 failures.

No manual or end-to-end verification was done. Nothing reads these fields yet, so there is no user-visible behaviour to exercise.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->