### PR TITLE
remove expectation that depends on Faker randomness

### DIFF
--- a/reporting-app/spec/services/income_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/income_compliance_determination_service_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe IncomeComplianceDeterminationService do
         described_class.calculate(certification.id)
 
         data = Determination.where(subject_id: certification.id).last.determination_data
-        expect(data["total_income"]).to be > data["target_income"]
         expect(data["maximum_monthly_income"]).to eq(300.0)
       end
     end


### PR DESCRIPTION
## Changes

Unimportant expectation with random failure removed.

## Context for reviewers

We use Faker random to determine the number of months in the lookback period, which makes this test unreliable; and we don't really need this test.

## Testing

- CI passes

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->