### PR TITLE
PBI-70896: Record determination time instead of the certification date

### DIFF
--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -67,7 +67,7 @@ class CertificationCase < Strata::Case
         reasons: [ Determination::REASON_CODE_MAPPING[:hours_reported_compliant] ],
         outcome: :compliant,
         determination_data: Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor: user
       )
     end
@@ -89,7 +89,7 @@ class CertificationCase < Strata::Case
         reasons: [ Determination::REASON_CODE_MAPPING[:hours_reported_insufficient] ],
         outcome: :not_compliant,
         determination_data: Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor: user
       )
     end
@@ -111,7 +111,7 @@ class CertificationCase < Strata::Case
         decision_method: :manual,
         reasons: [ Determination::REASON_CODE_MAPPING[:exemption_request_compliant] ],
         outcome: :exempt,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         determination_data: {
           exemption_type: application_form.exemption_type
         },
@@ -151,7 +151,7 @@ class CertificationCase < Strata::Case
         reasons: [ Determination::REASON_CODE_MAPPING[:denial_response_convincing] ],
         outcome: :compliant,
         determination_data: { denial_response_application_form_id: application_form.id },
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor: user
       )
     end
@@ -172,7 +172,7 @@ class CertificationCase < Strata::Case
         reasons: [ Determination::REASON_CODE_MAPPING[:denial_response_not_convincing] ],
         outcome: :not_compliant,
         determination_data: { denial_response_application_form_id: application_form.id },
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor: user
       )
     end
@@ -210,7 +210,7 @@ class CertificationCase < Strata::Case
         reasons: reason_codes,
         outcome: :excluded,
         determination_data: determination_data,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor:
       )
     end
@@ -239,7 +239,7 @@ class CertificationCase < Strata::Case
         reasons: reason_codes,
         outcome: :excepted,
         determination_data: determination_data,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor:
       )
     end
@@ -370,7 +370,7 @@ class CertificationCase < Strata::Case
         reasons: reasons,
         outcome: outcome,
         determination_data: determination_data,
-        determined_at: certification.certification_requirements.certification_date,
+        determined_at: Time.current,
         actor:
       )
     end

--- a/reporting-app/lib/dev/member_dashboard_frame_setup.rb
+++ b/reporting-app/lib/dev/member_dashboard_frame_setup.rb
@@ -186,7 +186,7 @@ module Dev
         reasons: [ Determination::REASON_CODE_MAPPING.fetch(:exemption_request_compliant) ],
         outcome: :exempt,
         determination_data: { "exemption_type" => exemption_form.exemption_type },
-        determined_at: certification.certification_requirements.certification_date
+        determined_at: Time.current
       )
     end
 
@@ -206,7 +206,7 @@ module Dev
           "calculation_type" => Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED,
           "satisfied_by" => Determination::SATISFIED_BY_BOTH
         },
-        determined_at: certification.certification_requirements.certification_date
+        determined_at: Time.current
       )
     end
 
@@ -216,7 +216,7 @@ module Dev
         reasons: [ "hours_reported_compliant" ],
         outcome: MemberStatus::NOT_COMPLIANT,
         determination_data: { "calculation_type" => Determination::CALCULATION_TYPE_HOURS_BASED },
-        determined_at: certification.certification_requirements.certification_date
+        determined_at: Time.current
       )
     end
 

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe CertificationCase, type: :model do
       })
     end
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets approval status and closes case' do
       certification_case.accept_activity_report(user, application_form)
       certification_case.reload
@@ -82,7 +84,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("hours_reported_compliant")
       expect(determination.outcome).to eq("compliant")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       expect(determination.determination_data["total_hours"]).to eq(85)
     end
 
@@ -123,6 +125,8 @@ RSpec.describe CertificationCase, type: :model do
       })
     end
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets denial status' do
       certification_case.deny_activity_report(user, application_form)
       certification_case.reload
@@ -160,7 +164,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("hours_reported_insufficient")
       expect(determination.outcome).to eq("not_compliant")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       expect(determination.determination_data["total_hours"]).to eq(40)
     end
 
@@ -226,6 +230,8 @@ RSpec.describe CertificationCase, type: :model do
 
     before { allow(Strata::EventManager).to receive(:publish) }
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets approval status and closes case' do
       certification_case.accept_exemption_request(user, application_form)
       certification_case.reload
@@ -239,7 +245,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("exemption_request_compliant")
       expect(determination.outcome).to eq("exempt")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       expect(determination.determination_data).to eq({ "exemption_type" => "short_term_hardship" })
     end
 
@@ -301,6 +307,8 @@ RSpec.describe CertificationCase, type: :model do
 
     before { allow(Strata::EventManager).to receive(:publish) }
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets approval status and closes case' do
       certification_case.accept_denial_response(user, application_form)
       certification_case.reload
@@ -318,7 +326,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("denial_response_convincing")
       expect(determination.outcome).to eq("compliant")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       expect(determination.determination_data).to eq({ "denial_response_application_form_id" => application_form.id })
     end
 
@@ -344,6 +352,8 @@ RSpec.describe CertificationCase, type: :model do
 
     before { allow(Strata::EventManager).to receive(:publish) }
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets denial status' do
       certification_case.deny_denial_response(user, application_form)
       certification_case.reload
@@ -360,7 +370,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("manual")
       expect(determination.reasons).to include("denial_response_not_convincing")
       expect(determination.outcome).to eq("not_compliant")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       expect(determination.determination_data).to eq({ "denial_response_application_form_id" => application_form.id })
     end
 
@@ -419,6 +429,8 @@ RSpec.describe CertificationCase, type: :model do
     # highest-priority exclusion and owns the conditional logic and events.
     before { stub_const("MockSubmitter", Class.new { include Strata::VirtualActor }) }
 
+    around { |example| freeze_time { example.run } }
+
     it 'sets approval status and closes case' do
       certification_case.record_exclusion_determination([ "pregnancy_excluded" ], MockSubmitter, "api")
       certification_case.reload
@@ -443,7 +455,7 @@ RSpec.describe CertificationCase, type: :model do
       expect(determination.decision_method).to eq("automated")
       expect(determination.reasons).to eq([ "pregnancy_excluded" ])
       expect(determination.outcome).to eq("excluded")
-      expect(determination.determined_at).to be_present
+      expect(determination.determined_at).to eq(Time.current)
       # determination_data is a jsonb column and must be stored as a Hash, never a JSON
       # String (writing reasons.to_json double-encodes it into a String — see #680). For
       # automated exclusions it records the granting reason codes.


### PR DESCRIPTION
## Ticket

Resolves PBI-70896

## Changes

- All eight `record_determination!` calls in `CertificationCase` pass
`determined_at: Time.current` instead of
`certification.certification_requirements.certification_date`.
- The three `determined_at` writes in `Dev::MemberDashboardFrameSetup`
do the same.
- The six determination specs that asserted `determined_at` was
`be_present` now assert exact equality under a frozen clock, with one
`around` hook per describe.

## Context for reviewers

Every determination on a certification carried an identical timestamp at
midnight, describing the period under review rather than the moment a
decision was made. The three readers already interpret the column as the
time a decision happened, so none changed, and no backfill is needed since
the API has no live consumers.

`Dev::MemberDashboardFrameSetup` has no spec coverage, so those three
lines were verified by running the frames against a development database.

Also removes the last `certification_date` reference from both files.

## Testing

Reintroducing the defect at all eight call sites fails 6 of the 57
examples in the file, so the specs discriminate rather than merely pass.

```
make lint   # 584 files inspected, no offenses detected
make test   # 3504 examples, 0 failures
```

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->