### PR TITLE
PBI-70930: Accept the supplied due date instead of deriving it

### DIFF
--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -13,12 +13,10 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   validates :certification_date, presence: true
   validates :lookback_period, presence: true
   validates :number_of_months_to_certify, presence: true
-  # one or the other
-  validates :due_period_days, presence: true, if: Proc.new { |params| params.due_date.blank? }
-  validates :due_date, presence: true, if: Proc.new { |params| params.due_period_days.blank? }
-  after_validation :set_due_date_from_period
+  validates :due_date, presence: true
 
   before_validation :set_type_params
+  before_validation :set_due_date_from_period
 
   def set_type_params
     if certification_type.blank? || !Certifications::Requirements::CERTIFICATION_TYPE_OPTIONS.include?(certification_type)
@@ -26,8 +24,6 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
     end
 
     set_params_for_type(certification_type)
-    # unset any existing explicit due_date
-    self.due_date = nil
   end
 
   def to_requirements
@@ -52,8 +48,6 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   private
 
   def set_due_date_from_period
-    if due_period_days
-      self.due_date ||= certification_date + due_period_days.days
-    end
+    self.due_date ||= Date.current + (due_period_days || DEFAULT_DUE_PERIOD_DAYS).days
   end
 end

--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -14,6 +14,7 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   validates :lookback_period, presence: true
   validates :number_of_months_to_certify, presence: true
   validates :due_date, presence: true
+  validate :due_date_must_be_a_date
 
   before_validation :set_type_params
   before_validation :set_due_date_from_period
@@ -49,5 +50,13 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
 
   def set_due_date_from_period
     self.due_date ||= Date.current + (due_period_days || DEFAULT_DUE_PERIOD_DAYS).days
+  end
+
+  # ActiveModel's date cast passes non-String values through untouched, so an
+  # array or integer would otherwise persist and crash every reader of the field.
+  def due_date_must_be_a_date
+    return if due_date.nil? || due_date.is_a?(Date)
+
+    errors.add(:due_date, :invalid)
   end
 end

--- a/reporting-app/app/models/certifications/requirement_type_params.rb
+++ b/reporting-app/app/models/certifications/requirement_type_params.rb
@@ -3,9 +3,12 @@
 class Certifications::RequirementTypeParams < ValueObject
   include ActiveModel::AsJsonAttributeType
 
+  # Days a member gets to report when the request carries no due date.
+  DEFAULT_DUE_PERIOD_DAYS = 30
+
   attribute :lookback_period, :integer
   attribute :number_of_months_to_certify, :integer
-  attribute :due_period_days, :integer
+  attribute :due_period_days, :integer, default: DEFAULT_DUE_PERIOD_DAYS
 
   def set_params_for_type(certification_type)
     type_params = self.class.cert_type_params_for(certification_type)
@@ -26,20 +29,17 @@ class Certifications::RequirementTypeParams < ValueObject
     when "new_application"
       new({
         lookback_period: 1,
-        number_of_months_to_certify: 1,
-        due_period_days: 30
+        number_of_months_to_certify: 1
       })
     when "recertification"
       new({
         lookback_period: 6,
-        number_of_months_to_certify: 3,
-        due_period_days: 30
+        number_of_months_to_certify: 3
       })
     when "change_in_circumstance"
       new({
         lookback_period: 6,
-        number_of_months_to_certify: 3,
-        due_period_days: 30
+        number_of_months_to_certify: 3
       })
     else
       nil

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -250,13 +250,17 @@
           },
           "due_period_days": {
             "type": "integer"
+          },
+          "due_date": {
+            "type": [ "string", "null" ],
+            "format": "date",
+            "description": "Date by which the Member must have submitted their evidence"
           }
         },
         "required": [
           "certification_date",
           "lookback_period",
-          "number_of_months_to_certify",
-          "due_period_days"
+          "number_of_months_to_certify"
         ]
       },
       "CertificationRequirementTypeParameters": {

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -224,11 +224,16 @@ components:
           description: The number of months the Member needs to certify
         due_period_days:
           type: integer
+        due_date:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: Date by which the Member must have submitted their evidence
       required:
       - certification_date
       - lookback_period
       - number_of_months_to_certify
-      - due_period_days
     CertificationRequirementTypeParameters:
       type: object
       properties:

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -208,6 +208,31 @@ RSpec.describe Certifications::RequirementParams do
       end
     end
 
+    context "when the request supplies a due date that is not a date" do
+      subject(:validity) { params.valid? }
+
+      [
+        [ "an array", [ "2026-12-15" ] ],
+        [ "an integer", 12_345 ],
+        [ "a boolean", true ]
+      ].each do |label, value|
+        context "when it is #{label}" do
+          let(:params) do
+            described_class.new_filtered(
+              "certification_date" => certification_date,
+              "certification_type" => "recertification",
+              "due_date" => value
+            )
+          end
+
+          it "rejects the request" do
+            expect(validity).to be false
+            expect(params.errors).to include(:due_date)
+          end
+        end
+      end
+    end
+
     context "when the request supplies neither a due date nor a due period" do
       let(:params) do
         build(

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -117,4 +117,114 @@ RSpec.describe Certifications::RequirementParams do
       end
     end
   end
+
+  describe "due date" do
+    # The API reaches these callbacks through UnionObject.new, which calls valid?
+    # as its type dispatch. Validating here is what production actually does.
+    subject(:requirements) do
+      params.valid?
+      params.to_requirements
+    end
+
+    # Sits well away from today, so anchoring on the certification date is
+    # distinguishable from anchoring on the day the request is processed.
+    let(:certification_date) { Date.new(2026, 11, 20) }
+
+    around { |example| freeze_time { example.run } }
+
+    context "when the request supplies a due date" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date:,
+          certification_type: "recertification",
+          due_date: Date.new(2026, 12, 15)
+        )
+      end
+
+      it "keeps the supplied due date" do
+        expect(requirements.due_date).to eq Date.new(2026, 12, 15)
+      end
+    end
+
+    context "when the request supplies no due date" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date:,
+          certification_type: "recertification"
+        )
+      end
+
+      it "sets the due date the configured number of days from the processing date" do
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+    end
+
+    context "when the due period comes from the batch or demo path instead of a type" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params, :with_direct_params,
+          certification_date:,
+          due_period_days: 45
+        )
+      end
+
+      it "offsets by the configured due period from the processing date" do
+        expect(requirements.due_date).to eq Date.current + 45.days
+      end
+    end
+
+    context "when the request supplies an explicit null due period" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date:,
+          lookback_period: 6,
+          number_of_months_to_certify: 3,
+          due_period_days: nil
+        )
+      end
+
+      # An explicit null beats the attribute default, so the fallback has to
+      # carry the default itself rather than rely on the attribute.
+      it "still offsets by the default due period" do
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+    end
+
+    context "when the request supplies a certification type and its own due period" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date:,
+          certification_type: "recertification",
+          due_period_days: 45
+        )
+      end
+
+      it "discards the supplied due period in favor of the default" do
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+    end
+
+    context "when the request supplies neither a due date nor a due period" do
+      let(:params) do
+        build(
+          :certification_certification_requirement_params,
+          certification_date:,
+          lookback_period: 6,
+          number_of_months_to_certify: 3
+        )
+      end
+
+      it "accepts the request and offsets by the default due period" do
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+
+      it "no longer rejects the request for having neither field" do
+        expect(params).to be_valid
+      end
+    end
+  end
 end

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -280,6 +280,90 @@ RSpec.describe "/api/certifications", type: :request do
       end
     end
 
+    context "with a due date supplied" do
+      around { |example| freeze_time { example.run } }
+
+      it "stores the supplied due date instead of deriving one" do
+        requirement_params = build(
+          :certification_certification_requirement_params,
+          certification_date: Date.new(2026, 11, 20),
+          certification_type: "recertification",
+          due_date: Date.new(2026, 12, 15)
+        )
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+
+        requirements = Certification.find(response.parsed_body[:id]).certification_requirements
+        expect(requirements.due_date).to eq Date.new(2026, 12, 15)
+      end
+    end
+
+    context "without a due date" do
+      around { |example| freeze_time { example.run } }
+
+      it "derives one from the day OSCER processed the request" do
+        requirement_params = build(
+          :certification_certification_requirement_params,
+          certification_date: Date.new(2026, 11, 20),
+          certification_type: "recertification"
+        )
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+
+        requirements = Certification.find(response.parsed_body[:id]).certification_requirements
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+    end
+
+    context "with an explicit null due period and no due date" do
+      around { |example| freeze_time { example.run } }
+
+      it "still derives a due date rather than storing none" do
+        params = valid_json_request_attributes.merge({
+          certification_requirements: {
+            certification_date: "2026-11-20",
+            lookback_period: 6,
+            number_of_months_to_certify: 3,
+            due_period_days: nil
+          }
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.to change(Certification, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        requirements = Certification.find(response.parsed_body[:id]).certification_requirements
+        expect(requirements.due_date).to eq Date.current + 30.days
+      end
+    end
+
     context "with member data" do
       it "creates a new Certification and renders response" do
         member_data = build(:certification_member_data,

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -337,6 +337,27 @@ RSpec.describe "/api/certifications", type: :request do
       end
     end
 
+    context "with a due date that is not a date" do
+      it "rejects the request instead of persisting an unusable deadline" do
+        params = valid_json_request_attributes.merge({
+          certification_requirements: {
+            certification_date: "2026-11-20",
+            certification_type: "recertification",
+            due_date: [ "2026-12-15" ]
+          }
+        })
+
+        expect {
+          post api_certifications_url,
+              params: params,
+              headers: auth_headers(params),
+              as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
     context "with an explicit null due period and no due date" do
       around { |example| freeze_time { example.run } }
 


### PR DESCRIPTION
## Ticket

Resolves PBI-70930

## Changes

- Keep a caller-supplied `due_date` instead of discarding it in `set_type_params`
- Anchor the derived due date on the processing date (`Date.current`) rather than `certification_date`
- Add `DEFAULT_DUE_PERIOD_DAYS` to `Certifications::RequirementTypeParams` and drop the three identical per-type literals
- Move `set_due_date_from_period` from `after_validation` to `before_validation`, and add `validates :due_date, presence: true`
- Remove the one-or-the-other `due_date` / `due_period_days` validation pair
- Drop `due_period_days` from the `CertificationRequirementParameters` required list in `oas.json` and the generated spec
- Declare `due_date` on `CertificationRequirementParameters`, which honors the field but never documented it
- Reject a `due_date` that is not a date, rather than persisting it

## Context for reviewers

ARIES supplies a due date and OSCER was discarding it, deriving its own from `certification_date`. This is one of a series removing `certification_date` from the certifications API and model (ADO 70259), following PBI 70717 (#873, period bounds) and PBI 70896 (#877, determination time); the field's uses split four ways and the removal itself is gated on each of them landing.

Two things to note: the fallback carries its own default (`due_period_days || DEFAULT_DUE_PERIOD_DAYS`) rather than trusting the attribute default, because an explicit JSON `null` overrides an ActiveModel `default:`; without it, `"due_period_days": null` with no due date would persist a nil deadline and crash `MemberMailer` after the row committed. That request was a 422 before this change. And the derivation moved to `before_validation` so `validates :due_date, presence: true` has something to guard, since an `after_validation` callback produces a value nothing can check.

Keeping a caller-supplied date meant it needed a type check. ActiveModel's date cast passes non-String values through untouched, so an array or integer would validate and land in the `certification_requirements` jsonb, and `&.due_date&.strftime` does not help because `&.` guards nil rather than the wrong class. The readers then fail permanently for that record, including `MemberMailer` inside the notification chain that runs within the create request. The wipe this PR removes was incidentally the only thing preventing that.

The `oas.json` edit is here because this change caused it: removing the validation pair left the published spec marking `due_period_days` required while OSCER no longer does. The generated YAML carries one hand-applied line because `make openapi-spec` rewrites random component identifiers on every run.

## Testing

- Drove the specs red before implementing. The "keeps a supplied due date" failure returned `certification_date + 30` instead of the supplied date, confirming the value was wiped and rebuilt rather than merely unset.
- Reintroduced the defect after implementing to confirm the request specs discriminate through the full HTTP path, including the `UnionObject` type dispatch that fires the callbacks.
- Reordered the two `before_validation` callbacks to confirm the ordering spec fails.
- `make test`: 3535 examples, 0 failures. Coverage 96.85% line, 84.09% branch.
- `make lint`: 584 files, no offenses.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->