### PR TITLE
PBI-71033: Record the application date on every creation path

### DIFF
--- a/e2e/reporting-app/pages/CertificationRequestPage.ts
+++ b/e2e/reporting-app/pages/CertificationRequestPage.ts
@@ -10,7 +10,7 @@ export class CertificationRequestPage extends BasePage {
   readonly firstNameField: Locator;
   readonly lastNameField: Locator;
   readonly caseNumberField: Locator;
-  readonly certificationDateField: Locator;
+  readonly applicationDateField: Locator;
   readonly requestCertificationButton: Locator;
 
   constructor(page: Page) {
@@ -19,23 +19,23 @@ export class CertificationRequestPage extends BasePage {
     this.firstNameField = page.getByLabel('First or given name');
     this.lastNameField = page.getByLabel('Last or family name');
     this.caseNumberField = page.getByLabel('Case number');
-    this.certificationDateField = page.getByLabel('Certification date');
+    this.applicationDateField = page.getByLabel('Application date');
     this.requestCertificationButton = page.getByRole('button', { name: /Request certification/i });
   }
 
-  async fillAndSubmit(email: string, certificationDate?: string) {
+  async fillAndSubmit(email: string, applicationDate?: string) {
     // Generate a random 9-digit case number
     const caseNumber = String(
       Math.floor(Math.random() * (1_000_000_000 - 100_000_000)) + 100_000_000
     );
 
-    const date = certificationDate ?? new Date().toLocaleDateString('en-US');
+    const date = applicationDate ?? new Date().toLocaleDateString('en-US');
 
     await this.emailField.fill(email);
     await this.firstNameField.fill('John');
     await this.lastNameField.fill('Doe');
     await this.caseNumberField.fill(caseNumber);
-    await this.certificationDateField.fill(date);
+    await this.applicationDateField.fill(date);
     await this.requestCertificationButton.click({ force: true });
   }
 }

--- a/reporting-app/app/forms/demo/certifications/base_create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/base_create_form.rb
@@ -37,7 +37,7 @@ module Demo
       # TODO: add validation you can't set both certification_type and the other params?
       attribute :certification_type, :enum, options: ::Certifications::Requirements::CERTIFICATION_TYPE_OPTIONS
 
-      strata_attribute :certification_date, :us_date
+      strata_attribute :application_date, :us_date
 
       # TODO: would maybe prefer to use ISO8601 duration values here instead of integers of months
       attribute :lookback_period, :integer, default: LOOKBACK_PERIOD_OPTIONS[0]
@@ -47,7 +47,7 @@ module Demo
 
       attribute :region, :string
 
-      validates :certification_date, presence: true
+      validates :application_date, presence: true
       validates :region, inclusion: { in: proc { User.regions }, message: "is not a valid option" }, allow_blank: true
 
       # Name validations

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -29,8 +29,7 @@ module Demo
       end
 
       def to_certification
-        # RequirementParams slices to its own attribute names and still validates
-        # certification_date; supply it until that field is removed from the model.
+        # TODO: drop this merge when certification_date leaves the model, still validated present until all readers have been repointed.
         certification_requirement_params = ::Certifications::RequirementParams.new_filtered(
           attributes.with_indifferent_access.merge(certification_date: application_date)
         )
@@ -47,11 +46,6 @@ module Demo
           return false
         end
 
-        # Generated member data is anchored on the application date. That is correct only for a
-        # new application, where the evaluated month is the application month. Recertification
-        # and change in circumstance evaluate a month derived from the certification period,
-        # which this form does not collect, so their generated data stops lining up once the
-        # exclusion repoint makes the evaluated month type-dependent.
         member_data = {}
 
         case external_scenario

--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -29,7 +29,11 @@ module Demo
       end
 
       def to_certification
-        certification_requirement_params = ::Certifications::RequirementParams.new_filtered(attributes.with_indifferent_access)
+        # RequirementParams slices to its own attribute names and still validates
+        # certification_date; supply it until that field is removed from the model.
+        certification_requirement_params = ::Certifications::RequirementParams.new_filtered(
+          attributes.with_indifferent_access.merge(certification_date: application_date)
+        )
         # shouldn't be possible, but we need to ensure the params are valid in
         # order to construct the requirements next
         if certification_requirement_params.invalid?
@@ -43,78 +47,83 @@ module Demo
           return false
         end
 
+        # Generated member data is anchored on the application date. That is correct only for a
+        # new application, where the evaluated month is the application month. Recertification
+        # and change in circumstance evaluate a month derived from the certification period,
+        # which this form does not collect, so their generated data stops lining up once the
+        # exclusion repoint makes the evaluated month type-dependent.
         member_data = {}
 
         case external_scenario
         when "Partially met work hours requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :partially_met_work_hours_requirement, cert_date: certification_date
+              :certification_member_data, :partially_met_work_hours_requirement, cert_date: application_date
             ).attributes.compact
           )
         when "Fully met work hours requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :fully_met_work_hours_requirement, cert_date: certification_date, num_months: number_of_months_to_certify
+              :certification_member_data, :fully_met_work_hours_requirement, cert_date: application_date, num_months: number_of_months_to_certify
             ).attributes.compact)
         when "Meets age-based exemption requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :meets_age_based_exemption_requirement, cert_date: certification_date
+              :certification_member_data, :meets_age_based_exemption_requirement, cert_date: application_date
             ).attributes.compact
           )
         when "Partially met income requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :partially_met_income_requirement, cert_date: certification_date
+              :certification_member_data, :partially_met_income_requirement, cert_date: application_date
             ).attributes.compact
           )
         when "Fully met income requirement"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :fully_met_income_requirement, cert_date: certification_date
+              :certification_member_data, :fully_met_income_requirement, cert_date: application_date
             ).attributes.compact
           )
         when "Half-time education enrollment"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :half_time_education_enrollment, cert_date: certification_date
+              :certification_member_data, :half_time_education_enrollment, cert_date: application_date
             ).attributes.compact
           )
         when "Less than half-time education enrollment"
           member_data.merge!(
             FactoryBot.build(
-              :certification_member_data, :less_than_half_time_education_enrollment, cert_date: certification_date
+              :certification_member_data, :less_than_half_time_education_enrollment, cert_date: application_date
             ).attributes.compact
           )
         end
 
         exemptions = []
 
-        exemptions << end_exemption(:pregnancy, certification_date) if pregnancy_status
-        exemptions << end_exemption(:former_foster_care, certification_date) if was_in_foster_care
-        exemptions << end_exemption(:medical_condition, certification_date) if currently_medically_frail
-        exemptions << end_exemption(:veteran_disability, certification_date) if veteran_with_disability
-        exemptions << end_exemption(:caregiver_disability, certification_date) if caretaker
-        exemptions << end_exemption(:meeting_tanf_or_snap_work, certification_date) if tanf_snap_work
-        exemptions << end_exemption(:substance_treatment, certification_date) if drug_treatment
-        exemptions << end_exemption(:incarceration, certification_date) if inmate
+        exemptions << end_exemption(:pregnancy, application_date) if pregnancy_status
+        exemptions << end_exemption(:former_foster_care, application_date) if was_in_foster_care
+        exemptions << end_exemption(:medical_condition, application_date) if currently_medically_frail
+        exemptions << end_exemption(:veteran_disability, application_date) if veteran_with_disability
+        exemptions << end_exemption(:caregiver_disability, application_date) if caretaker
+        exemptions << end_exemption(:meeting_tanf_or_snap_work, application_date) if tanf_snap_work
+        exemptions << end_exemption(:substance_treatment, application_date) if drug_treatment
+        exemptions << end_exemption(:incarceration, application_date) if inmate
         if race_ethnicity == "american_indian_or_alaska_native"
-          exemptions << end_exemption(:american_indian_or_alaska_native, certification_date)
+          exemptions << end_exemption(:american_indian_or_alaska_native, application_date)
         end
 
         member_data[:exemptions] = exemptions
         member_data = ::Certifications::MemberData.new(member_data).tap do |md|
           md.name = member_name if member_name.present?
           md.date_of_birth = date_of_birth if date_of_birth.present?
-          md.pregnancy_due_or_parturition_date = certification_date if pregnancy_status
+          md.pregnancy_due_or_parturition_date = application_date if pregnancy_status
           md.was_in_foster_care = was_in_foster_care
           md.currently_medically_frail = currently_medically_frail
           md.veteran_with_disability = veteran_with_disability
-          md.dates_caretaking_infirm = [ certification_date ] if caretaker
+          md.dates_caretaking_infirm = [ application_date ] if caretaker
           md.meeting_tanf_or_snap_work = tanf_snap_work
-          md.dates_in_drug_treatment = [ certification_date ] if drug_treatment
-          md.dates_incarcerated = [ certification_date ] if inmate
+          md.dates_in_drug_treatment = [ application_date ] if drug_treatment
+          md.dates_incarcerated = [ application_date ] if inmate
           md.race_ethnicity = race_ethnicity if race_ethnicity.present?
           md.va_icn = va_icn if va_icn.present?
           apply_external_exception(md, certification_requirements.months_that_can_be_certified)
@@ -125,6 +134,7 @@ module Demo
           :connected_to_email,
           email: member_email,
           case_number: case_number,
+          application_date: application_date,
           certification_requirements: certification_requirements,
           member_data: member_data,
         )
@@ -152,15 +162,15 @@ module Demo
         ]
       end
 
-      def end_exemption(exemption_type, cert_date)
+      def end_exemption(exemption_type, application_date)
         {
           type: exemption_type,
           value: true,
           verification_status: :verified,
           periods: [
             {
-              period_start: cert_date - 4.months,
-              period_end: cert_date
+              period_start: application_date - 4.months,
+              period_end: application_date
             }
           ]
         }

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -109,6 +109,10 @@ class UnifiedRecordProcessor
     Certification.new(
       member_id: record["member_id"],
       case_number: record["case_number"],
+      # The file carries one date, so it is recorded as the application date. Exact for
+      # new_application rows and an approximation for recertification rows, which the
+      # published template cannot yet distinguish.
+      application_date: Date.parse(record["certification_date"]),
       member_data: build_member_data(record),
       certification_requirements: build_certification_requirements(record)
     )

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -109,9 +109,7 @@ class UnifiedRecordProcessor
     Certification.new(
       member_id: record["member_id"],
       case_number: record["case_number"],
-      # The file carries one date, so it is recorded as the application date. Exact for
-      # new_application rows and an approximation for recertification rows, which the
-      # published template cannot yet distinguish.
+      # TODO: read directly from the application_date field once batch uploads accept it in place of certification_date.
       application_date: Date.parse(record["certification_date"]),
       member_data: build_member_data(record),
       certification_requirements: build_certification_requirements(record)

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -110,7 +110,7 @@ class UnifiedRecordProcessor
       member_id: record["member_id"],
       case_number: record["case_number"],
       # TODO: read directly from the application_date field once batch uploads accept it in place of certification_date.
-      application_date: Date.parse(record["certification_date"]),
+      application_date: record["certification_date"],
       member_data: build_member_data(record),
       certification_requirements: build_certification_requirements(record)
     )

--- a/reporting-app/app/views/demo/certifications/new.html.erb
+++ b/reporting-app/app/views/demo/certifications/new.html.erb
@@ -24,7 +24,7 @@
 
   <%= f.select :region, @regions, {  prompt: t(".select_region") } %>
 
-  <%= f.date_picker :certification_date %>
+  <%= f.date_picker :application_date %>
 
   <%= f.select :lookback_period, Demo::Certifications::CreateForm::LOOKBACK_PERIOD_OPTIONS.map { |i| [ t("certifications.demo_create.lookback_period_options.#{i}"), i ] }, {}, disabled: @form.locked_type_params? %>
   <%= f.select :number_of_months_to_certify, Demo::Certifications::CreateForm::NUMBER_OF_MONTHS_TO_CERTIFY_OPTIONS.map { |i| [ t("certifications.demo_create.number_of_months_to_certify_options.#{i}"), i ] }, {}, disabled: @form.locked_type_params? %>

--- a/reporting-app/spec/factories/certifications_factory.rb
+++ b/reporting-app/spec/factories/certifications_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     member_id { Faker::NationalHealthService.british_number }
     case_number { "C-%d" % Faker::Number.within(range: 1..10000) }
+    application_date { Date.current }
     certification_requirements { build(:certification_certification_requirements) }
     member_data { build(:certification_member_data) }
 

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -12,13 +12,6 @@ RSpec.describe Demo::Certifications::CreateForm do
     it "records the date collected on the form as the certification's application date" do
       expect(certification.application_date).to eq(collected)
     end
-
-    # Regression guard for the params slice: RequirementParams.new_filtered slices to that
-    # class's own attribute names, and it declares certification_date (validated present) and
-    # no application_date. Without an explicit merge the value is dropped and the form is invalid.
-    it "still supplies the certification date the requirements validate on" do
-      expect(certification.certification_requirements.certification_date).to eq(collected)
-    end
   end
 
   describe "#to_certification external exception mapping" do

--- a/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
+++ b/reporting-app/spec/forms/demo/certifications/create_form_spec.rb
@@ -3,10 +3,28 @@
 require "rails_helper"
 
 RSpec.describe Demo::Certifications::CreateForm do
+  describe "#to_certification application date" do
+    subject(:certification) { form.to_certification }
+
+    let(:collected) { Date.new(2026, 3, 15) }
+    let(:form) { described_class.new(application_date: collected) }
+
+    it "records the date collected on the form as the certification's application date" do
+      expect(certification.application_date).to eq(collected)
+    end
+
+    # Regression guard for the params slice: RequirementParams.new_filtered slices to that
+    # class's own attribute names, and it declares certification_date (validated present) and
+    # no application_date. Without an explicit merge the value is dropped and the form is invalid.
+    it "still supplies the certification date the requirements validate on" do
+      expect(certification.certification_requirements.certification_date).to eq(collected)
+    end
+  end
+
   describe "#to_certification external exception mapping" do
     subject(:member_data) { certification.member_data }
 
-    let(:form) { described_class.new(certification_date: Date.current, external_exception: selected) }
+    let(:form) { described_class.new(application_date: Date.current, external_exception: selected) }
     let(:certification) { form.to_certification }
     let(:months) { certification.certification_requirements.months_that_can_be_certified }
 
@@ -63,101 +81,101 @@ RSpec.describe Demo::Certifications::CreateForm do
     end
 
     context "when pregnancy is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, pregnancy_status: true) }
+      let(:form) { described_class.new(application_date: Date.current, pregnancy_status: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'pregnancy'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when was_in_foster_care is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, was_in_foster_care: true) }
+      let(:form) { described_class.new(application_date: Date.current, was_in_foster_care: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'former_foster_care'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when currently_medically_frail is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, currently_medically_frail: true) }
+      let(:form) { described_class.new(application_date: Date.current, currently_medically_frail: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'medical_condition'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when veteran_with_disability is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, veteran_with_disability: true) }
+      let(:form) { described_class.new(application_date: Date.current, veteran_with_disability: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'veteran_disability'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when caretaker is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, caretaker: true) }
+      let(:form) { described_class.new(application_date: Date.current, caretaker: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'caregiver_disability'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when tanf_snap_work is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, tanf_snap_work: true) }
+      let(:form) { described_class.new(application_date: Date.current, tanf_snap_work: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'meeting_tanf_or_snap_work'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when drug_treatment is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, drug_treatment: true) }
+      let(:form) { described_class.new(application_date: Date.current, drug_treatment: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'substance_treatment'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when inmate is selected" do
-      let(:form) { described_class.new(certification_date: Date.current, inmate: true) }
+      let(:form) { described_class.new(application_date: Date.current, inmate: true) }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'incarceration'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
 
     context "when race_ethnicity is american_indian_or_alaska_native" do
-      let(:form) { described_class.new(certification_date: Date.current, race_ethnicity: 'american_indian_or_alaska_native') }
+      let(:form) { described_class.new(application_date: Date.current, race_ethnicity: 'american_indian_or_alaska_native') }
 
       it "Adds exemption to member data" do
         expect(member_data.exemptions.length).to eq 1
         exemption = member_data.exemptions.first
         expect(exemption.type).to eq 'american_indian_or_alaska_native'
-        expect(exemption.periods.first.period_end).to eq form.certification_date
+        expect(exemption.periods.first.period_end).to eq form.application_date
       end
     end
   end
@@ -170,7 +188,7 @@ RSpec.describe Demo::Certifications::CreateForm do
     let(:certification) { form.to_certification }
     let(:form) do
       described_class.new(
-        certification_date: Date.new(2026, 8, 20),
+        application_date: Date.new(2026, 8, 20),
         external_scenario: scenario,
         lookback_period: 3,
         number_of_months_to_certify: 3

--- a/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
+++ b/reporting-app/spec/jobs/process_certification_batch_chunk_job_spec.rb
@@ -99,6 +99,42 @@ RSpec.describe ProcessCertificationBatchChunkJob, type: :job do
       end
     end
 
+    context 'with several valid members in the chunk' do
+      let(:second_valid_record) do
+        {
+          "member_id" => "M900",
+          "case_number" => "C-900",
+          "member_email" => "test9@example.com",
+          "first_name" => "Test",
+          "last_name" => "Nine",
+          "certification_date" => "2025-06-20",
+          "certification_type" => "new_application"
+        }
+      end
+      let(:records) { [ valid_record, second_valid_record ] }
+      let(:record_count) { 2 }
+
+      before do
+        allow(csv_reader).to receive(:read_chunk).and_return(records)
+      end
+
+      it 'records an application date on every certification it creates' do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+
+        created = Certification.where(member_id: %w[M600 M900])
+
+        expect(created.count).to eq(2)
+        expect(created.map(&:application_date)).to all(be_present)
+      end
+
+      it "records each row's own date rather than the first row's" do
+        described_class.perform_now(batch_upload.id, 1, headers, start_byte, end_byte, record_count)
+
+        expect(Certification.find_by!(member_id: "M600").application_date).to eq(Date.new(2025, 4, 10))
+        expect(Certification.find_by!(member_id: "M900").application_date).to eq(Date.new(2025, 6, 20))
+      end
+    end
+
     context 'with mixed valid and invalid records' do
       let(:records) { [ valid_record, invalid_record, duplicate_record ] }
 

--- a/reporting-app/spec/requests/demo/certifications_spec.rb
+++ b/reporting-app/spec/requests/demo/certifications_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "/demo/certifications", type: :request do
       member_name_first: "Jane",
       member_name_last: "Doe",
       case_number: "C-123",
-      certification_date: "09/25/2025",
+      application_date: "09/25/2025",
       date_of_birth: "01/15/1990"
     }
   }
@@ -78,6 +78,14 @@ RSpec.describe "/demo/certifications", type: :request do
       expect(response).to be_successful
     end
 
+    it "asks for the application date and not the certification date" do
+      get new_demo_certification_url
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("label", text: "Application date")
+      expect(page).not_to have_css("label", text: "Certification date")
+    end
+
     it "renders New Application form" do
       get new_demo_certification_url, params: { certification_type: "new_application" }
       expect(response).to be_successful
@@ -103,6 +111,7 @@ RSpec.describe "/demo/certifications", type: :request do
       cert = Certification.order(created_at: :desc).last
       expect(cert.case_number).to eq(create_attrs[:case_number])
       expect(cert.certification_requirements.certification_date).to eq(Date.new(2025, 9, 25))
+      expect(cert.application_date).to eq(Date.new(2025, 9, 25))
       expect(cert.certification_requirements.due_date).not_to be_nil
       expect(cert.member_name).to eq(Strata::Name.new({
         "first": create_attrs[:member_name_first],
@@ -523,11 +532,11 @@ RSpec.describe "/demo/certifications", type: :request do
     end
 
     context "with validation errors" do
-      it "renders form with errors when certification_date is missing" do
+      it "renders form with errors when application_date is missing" do
         post demo_certifications_url,
              params: {
                demo_certifications_create_form:
-                 valid_request_attributes.except(:certification_date).merge(
+                 valid_request_attributes.except(:application_date).merge(
                    member_name_first: "Jane",
                    member_name_last: "Doe"
                  )
@@ -540,7 +549,7 @@ RSpec.describe "/demo/certifications", type: :request do
              params: {
                demo_certifications_create_form:
                  valid_request_attributes.except(:member_name_first).merge(
-                   certification_date: "09/25/2025"
+                   application_date: "09/25/2025"
                  )
              }
         expect(response).to have_http_status(:unprocessable_content)
@@ -551,7 +560,7 @@ RSpec.describe "/demo/certifications", type: :request do
              params: {
                demo_certifications_create_form:
                  valid_request_attributes.except(:member_name_last).merge(
-                   certification_date: "09/25/2025"
+                   application_date: "09/25/2025"
                  )
              }
         expect(response).to have_http_status(:unprocessable_content)

--- a/reporting-app/spec/services/unified_record_processor_spec.rb
+++ b/reporting-app/spec/services/unified_record_processor_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe UnifiedRecordProcessor do
         expect(result.case_number).to eq("C-001")
       end
 
+      it "records the record's certification date as the application date" do
+        allow(Strata::EventManager).to receive(:publish)
+
+        certification = processor.process(record)
+
+        expect(certification.application_date).to eq(Date.new(2025, 1, 15))
+      end
+
       it "builds member_data from record fields" do
         allow(Strata::EventManager).to receive(:publish)
 


### PR DESCRIPTION
## Ticket

Resolves PBI-71033

## Changes

- `UnifiedRecordProcessor#build_certification` sets `application_date` from
the file's certification date column
- `Demo::Certifications::CreateForm` collects `application_date` in place of
`certification_date`, and supplies `certification_date` to `RequirementParams`
explicitly
- The `:certification` factory sets an `application_date` default, covering the
demo path and `db/seeds/development.rb`
- `CertificationRequestPage` (e2e) locates the renamed form field

## Context for reviewers

The API already recorded `application_date`. Batch upload and the demo form did
not, so a certification created by either carried nothing in that column.
Nothing reads the field yet, so no determination outcome changes in this PR. It
is populated now because the exclusion repoint that follows needs an anchor on
every creation path, and a missing anchor does not raise, it silently stops
every exclusion firing.

## Testing

```
$ make lint
586 files inspected, no offenses detected

$ make test
3569 examples, 0 failures
Line coverage: 5713 / 5898 (96.86%)
Branch coverage: 1387 / 1651 (84.00%)

$ cd e2e && npm run type-check
(clean)
```

Manually created a certification through the demo form and confirmed the
persisted row carries a populated `application_date`.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->