### PR TITLE
PBI-70969 Create external activity

### DIFF
--- a/reporting-app/app/models/external_activity.rb
+++ b/reporting-app/app/models/external_activity.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# ExternalActivity stores trusted hours and/or gross income data from external sources, like the
+# state system. A single row may report hours, income, or both — states report hours and earnings
+# for the same job over the same period, and one row keeps that pairing intact.
+#
+# These are automated or external figures as opposed to member reported ones from
+# ActivityReportApplicationForm. External data is auto-verified and doesn't require staff review.
+#
+# Activities are linked to certifications through member_id - since there's only one active
+# certification per member at a time, the relationship is implicit.
+#
+# Supersedes ExternalHourlyActivity and ExternalIncomeActivity, which remain as read-only stubs
+# over their retained tables. See docs/architecture/income-data/income-data.md.
+#
+# Append-only policy: Normal intake flows create records only. Updates or deletes are exceptional
+# (e.g., corrections, backfills) and must be fully audited.
+#
+class ExternalActivity < ApplicationRecord
+  include Strata::Attributes
+
+  # Shared with member-reported Activity via ActivityCategories; household is external-only,
+  # since a member never reports another household member's income as their own activity.
+  CATEGORY_HOUSEHOLD = "household"
+  ALLOWED_CATEGORIES = (ActivityCategories::ALL + [ CATEGORY_HOUSEHOLD ]).freeze
+
+  SOURCE_TYPES = {
+    api: "api",
+    batch: "batch_upload"
+  }.freeze
+  ALLOWED_SOURCE_TYPES = SOURCE_TYPES.values.freeze
+
+  HOURS_PER_DAY = 24
+
+  # --- Strata Attributes ---
+
+  # DateRange provides built-in validation (start <= end)
+  strata_attribute :period, :us_date, range: true
+
+  # --- Validations ---
+
+  validates :member_id, presence: true
+  validates :category, presence: true, inclusion: { in: ALLOWED_CATEGORIES }
+  # allow_nil rather than presence: each value is individually optional, and the pair is required
+  # by hours_or_gross_income_present below.
+  validates :hours, numericality: { greater_than: 0 }, allow_nil: true
+  validates :gross_income, numericality: { greater_than: 0 }, allow_nil: true
+  validate :hours_or_gross_income_present
+  validate :hours_within_period
+  validates :period_start, presence: true
+  validates :period_end, presence: true
+  validates :source_type, presence: true, inclusion: { in: ALLOWED_SOURCE_TYPES }
+  validates :reported_at, presence: true
+
+  # --- Scopes ---
+
+  scope :for_member, ->(member_id) { where(member_id: member_id) }
+
+  scope :within_period, ->(lookback_period) {
+    return all unless lookback_period.present?
+
+    start_date = lookback_period.start.to_date
+    end_date = lookback_period.end.to_date.end_of_month
+
+    where("period_start >= ? AND period_end <= ?", start_date, end_date)
+  }
+
+  # A row reporting both values belongs to both scopes: it contributes to both compliance tracks.
+  scope :with_hours, -> { where.not(hours: nil) }
+  scope :with_income, -> { where.not(gross_income: nil) }
+
+  def month
+    period_start.beginning_of_month
+  end
+
+  def hours?
+    hours.present?
+  end
+
+  def income?
+    gross_income.present?
+  end
+
+  private
+
+  def hours_or_gross_income_present
+    return if hours.present? || gross_income.present?
+
+    errors.add(:base, :hours_or_gross_income_required)
+  end
+
+  # Hours cannot exceed the wall-clock hours the reported period contains, which catches
+  # implausible figures a flat annual ceiling would let through. Dates are inclusive, matching
+  # how ActivityAggregator#month_periods treats them. A reversed period is left to the
+  # strata_attribute range validator rather than reported twice.
+  def hours_within_period
+    return if hours.blank? || period_start.blank? || period_end.blank? || period_end < period_start
+
+    maximum = ((period_end - period_start).to_i + 1) * HOURS_PER_DAY
+    return if hours <= maximum
+
+    errors.add(:hours, :greater_than_period, maximum: maximum)
+  end
+end

--- a/reporting-app/config/locales/defaults/en.yml
+++ b/reporting-app/config/locales/defaults/en.yml
@@ -73,6 +73,12 @@ en:
     attributes:
       spam_trap:
         present: "This field should be left empty. It is intended to prevent bots from submitting spam using this form."
+      hours:
+        greater_than_period: "cannot exceed %{maximum} hours for the reported period"
+    messages:
+      # ExternalActivity and Certifications::MemberData::Activity: a row must report a value.
+      # Added on :base, so it also resolves through the nested member_data.activities[n] path.
+      hours_or_gross_income_required: "must report hours, gross income, or both"
   helpers:
     submit:
       create: "Submit"

--- a/reporting-app/config/locales/views/certification_cases/en.yml
+++ b/reporting-app/config/locales/views/certification_cases/en.yml
@@ -68,9 +68,10 @@ en:
       source: "Source"
       activity_type: "Activity type"
       gross_income: "Gross income"
-      # Labels for ExternalIncomeActivity#source_type (see ExternalIncomeActivity::ALLOWED_SOURCE_TYPES). Add a key when adding a type.
+      # Labels for ExternalActivity#source_type (see ExternalActivity::ALLOWED_SOURCE_TYPES). Add a key when adding a type.
       source_types:
         api: "State verification (API)"
+        batch_upload: "State verification (batch upload)"
     hours_reported_table:
       title: "Hours reported"
       organization_name: "Organization name"

--- a/reporting-app/spec/factories/external_activities_factory.rb
+++ b/reporting-app/spec/factories/external_activities_factory.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # The base factory carries neither value, so it is deliberately invalid on its own: a row must
+  # report hours, income, or both. Always build with :with_hours, :with_income,
+  # :with_hours_and_income, or :household.
+  factory :external_activity do
+    member_id { Faker::NationalHealthService.british_number }
+    # Not ALLOWED_CATEGORIES: "household" belongs to income-only rows, so :household sets it.
+    category { ActivityCategories::ALL.sample }
+    period_start { Date.current.beginning_of_month }
+    period_end { Date.current.end_of_month }
+    source_type { ExternalActivity::SOURCE_TYPES[:api] }
+    source_id { nil }
+    reported_at { Time.current }
+    metadata { {} }
+
+    trait :with_hours do
+      hours { Faker::Number.between(from: 1.0, to: 200.0).round(2) }
+    end
+
+    trait :with_income do
+      gross_income { Faker::Number.between(from: 1.0, to: 10_000.0).round(2) }
+    end
+
+    trait :with_hours_and_income do
+      with_hours
+      with_income
+    end
+
+    trait :household do
+      category { ExternalActivity::CATEGORY_HOUSEHOLD }
+      with_income
+    end
+
+    trait :employment do
+      category { 'employment' }
+    end
+
+    trait :community_service do
+      category { 'community_service' }
+    end
+
+    trait :education do
+      category { 'education' }
+    end
+
+    trait :from_batch do
+      source_type { ExternalActivity::SOURCE_TYPES[:batch] }
+      source_id { SecureRandom.uuid }
+    end
+  end
+end

--- a/reporting-app/spec/models/external_activity_spec.rb
+++ b/reporting-app/spec/models/external_activity_spec.rb
@@ -1,0 +1,381 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalActivity, type: :model do
+  describe 'factory' do
+    it 'creates a valid hours-only record' do
+      expect(build(:external_activity, :with_hours)).to be_valid
+    end
+
+    it 'creates a valid income-only record' do
+      expect(build(:external_activity, :with_income)).to be_valid
+    end
+
+    it 'creates a valid record carrying both hours and income' do
+      expect(build(:external_activity, :with_hours_and_income)).to be_valid
+    end
+
+    it 'creates a valid household income record' do
+      expect(build(:external_activity, :household)).to be_valid
+    end
+  end
+
+  describe 'validations' do
+    subject(:activity) { build(:external_activity, :with_hours) }
+
+    describe 'member_id' do
+      it 'is required' do
+        activity.member_id = nil
+        expect(activity).not_to be_valid
+        expect(activity.errors[:member_id]).to include("can't be blank")
+      end
+    end
+
+    describe 'category' do
+      it 'is required' do
+        activity.category = nil
+        expect(activity).not_to be_valid
+        expect(activity.errors[:category]).to include("can't be blank")
+      end
+
+      it 'accepts every allowed category' do
+        ExternalActivity::ALLOWED_CATEGORIES.each do |category|
+          activity.category = category
+          expect(activity).to be_valid
+        end
+      end
+
+      it 'accepts the household category' do
+        activity.category = ExternalActivity::CATEGORY_HOUSEHOLD
+        expect(activity).to be_valid
+      end
+
+      it 'rejects unknown categories' do
+        activity.category = 'invalid_category'
+        expect(activity).not_to be_valid
+        expect(activity.errors[:category]).to include('is not included in the list')
+      end
+    end
+
+    describe 'hours and gross_income' do
+      it 'accepts a row reporting hours only' do
+        expect(build(:external_activity, :with_hours)).to be_valid
+      end
+
+      it 'accepts a row reporting income only' do
+        expect(build(:external_activity, :with_income)).to be_valid
+      end
+
+      it 'accepts a row reporting both' do
+        expect(build(:external_activity, hours: 40, gross_income: 620)).to be_valid
+      end
+
+      it 'rejects a row reporting neither' do
+        activity = build(:external_activity)
+
+        expect(activity).not_to be_valid
+        expect(activity.errors[:base]).to include('must report hours, gross income, or both')
+      end
+
+      it 'is enforced by the database when validations are bypassed' do
+        activity = build(:external_activity)
+
+        expect { activity.save(validate: false) }
+          .to raise_error(ActiveRecord::StatementInvalid, /external_activities_hours_or_income/)
+      end
+
+      it 'rejects zero hours' do
+        activity.hours = 0
+        expect(activity).not_to be_valid
+        expect(activity.errors[:hours]).to include('must be greater than 0')
+      end
+
+      it 'rejects zero gross_income' do
+        activity = build(:external_activity, :with_income, gross_income: 0)
+        expect(activity).not_to be_valid
+        expect(activity.errors[:gross_income]).to include('must be greater than 0')
+      end
+
+      it 'rejects negative hours' do
+        activity.hours = -1
+        expect(activity).not_to be_valid
+      end
+    end
+
+    describe 'hours against the reported period' do
+      # The ceiling is the wall-clock hours the period contains, so implausible hours are caught
+      # even when they are well under a year's worth.
+      it 'accepts hours equal to the hours the period contains' do
+        activity = build(:external_activity,
+                         period_start: Date.new(2026, 1, 1),
+                         period_end: Date.new(2026, 1, 7),
+                         hours: 7 * 24)
+
+        expect(activity).to be_valid
+      end
+
+      it 'rejects hours exceeding a one-week period' do
+        activity = build(:external_activity,
+                         period_start: Date.new(2026, 1, 1),
+                         period_end: Date.new(2026, 1, 7),
+                         hours: 500)
+
+        expect(activity).not_to be_valid
+        expect(activity.errors[:hours]).to include('cannot exceed 168 hours for the reported period')
+      end
+
+      it 'rejects more than 24 hours in a single-day period' do
+        activity = build(:external_activity,
+                         period_start: Date.new(2026, 1, 1),
+                         period_end: Date.new(2026, 1, 1),
+                         hours: 25)
+
+        expect(activity).not_to be_valid
+        expect(activity.errors[:hours]).to include('cannot exceed 24 hours for the reported period')
+      end
+
+      it 'accepts 24 hours in a single-day period' do
+        activity = build(:external_activity,
+                         period_start: Date.new(2026, 1, 1),
+                         period_end: Date.new(2026, 1, 1),
+                         hours: 24)
+
+        expect(activity).to be_valid
+      end
+
+      it 'does not constrain gross_income' do
+        activity = build(:external_activity, :with_income,
+                         period_start: Date.new(2026, 1, 1),
+                         period_end: Date.new(2026, 1, 1),
+                         gross_income: 10_000)
+
+        expect(activity).to be_valid
+      end
+
+      # The range validator owns reversed periods; reporting a negative ceiling on top of it
+      # would say the same thing twice.
+      it 'leaves a reversed period to the period validator' do
+        activity = build(:external_activity, hours: 5_000)
+        activity.period = Strata::DateRange.new(
+          start: Strata::USDate.new(2026, 1, 31),
+          end: Strata::USDate.new(2026, 1, 1)
+        )
+
+        expect(activity).not_to be_valid
+        expect(activity.errors[:period]).to include('start date cannot be after end date')
+        expect(activity.errors[:hours]).to be_empty
+      end
+    end
+
+    describe 'period dates' do
+      it 'requires period_start' do
+        activity.period_start = nil
+        expect(activity).not_to be_valid
+      end
+
+      it 'requires period_end' do
+        activity.period_end = nil
+        expect(activity).not_to be_valid
+      end
+
+      it 'rejects period_end before period_start' do
+        activity.period = Strata::DateRange.new(
+          start: Strata::USDate.new(2026, 1, 15),
+          end: Strata::USDate.new(2026, 1, 1)
+        )
+
+        expect(activity).not_to be_valid
+        expect(activity.errors[:period]).to include('start date cannot be after end date')
+      end
+
+      it 'accepts period_end equal to period_start' do
+        activity.period = Strata::DateRange.new(
+          start: Strata::USDate.new(2026, 1, 15),
+          end: Strata::USDate.new(2026, 1, 15)
+        )
+        activity.hours = 8
+
+        expect(activity).to be_valid
+      end
+    end
+
+    describe 'source_type' do
+      it 'is required' do
+        activity.source_type = nil
+        expect(activity).not_to be_valid
+      end
+
+      it 'accepts every allowed source type' do
+        ExternalActivity::ALLOWED_SOURCE_TYPES.each do |source_type|
+          activity.source_type = source_type
+          expect(activity).to be_valid
+        end
+      end
+
+      it 'accepts a batch upload row' do
+        expect(build(:external_activity, :with_hours, :from_batch)).to be_valid
+      end
+
+      it 'rejects unknown source types' do
+        activity.source_type = 'invalid'
+        expect(activity).not_to be_valid
+      end
+    end
+
+    describe 'reported_at' do
+      it 'is required' do
+        activity.reported_at = nil
+        expect(activity).not_to be_valid
+        expect(activity.errors[:reported_at]).to include("can't be blank")
+      end
+    end
+  end
+
+  describe 'scopes' do
+    describe '.for_member' do
+      it 'returns entries for the given member' do
+        entry = create(:external_activity, :with_hours, member_id: 'M12345')
+        create(:external_activity, :with_hours, member_id: 'OTHER')
+
+        expect(described_class.for_member('M12345')).to eq([ entry ])
+      end
+    end
+
+    describe '.within_period' do
+      let(:lookback) do
+        Strata::DateRange.new(
+          start: Strata::USDate.new(2026, 1, 1),
+          end: Strata::USDate.new(2026, 3, 31)
+        )
+      end
+
+      it 'returns all when lookback_period is nil' do
+        create(:external_activity, :with_hours,
+               period_start: Date.new(2025, 1, 1), period_end: Date.new(2025, 1, 31))
+
+        expect(described_class.within_period(nil).count).to eq(1)
+      end
+
+      it 'returns all when lookback_period is blank' do
+        create(:external_activity, :with_hours)
+
+        expect(described_class.within_period('').count).to eq(1)
+      end
+
+      it 'includes records fully inside the lookback window' do
+        inside = create(:external_activity, :with_hours,
+                        period_start: Date.new(2026, 2, 1), period_end: Date.new(2026, 2, 28))
+
+        expect(described_class.within_period(lookback)).to include(inside)
+      end
+
+      it 'excludes records that extend before the lookback start' do
+        create(:external_activity, :with_hours,
+               period_start: Date.new(2025, 12, 1), period_end: Date.new(2026, 2, 28))
+
+        expect(described_class.within_period(lookback)).to be_empty
+      end
+
+      it 'excludes records that extend after the lookback end' do
+        create(:external_activity, :with_hours,
+               period_start: Date.new(2026, 3, 1), period_end: Date.new(2026, 5, 31))
+
+        expect(described_class.within_period(lookback)).to be_empty
+      end
+
+      # The lookback end is widened to the end of its month before comparing.
+      it 'includes a record ending later in the lookback end month' do
+        inside = create(:external_activity, :with_hours,
+                        period_start: Date.new(2026, 3, 1), period_end: Date.new(2026, 3, 31))
+        partial_lookback = Strata::DateRange.new(
+          start: Strata::USDate.new(2026, 1, 1),
+          end: Strata::USDate.new(2026, 3, 15)
+        )
+
+        expect(described_class.within_period(partial_lookback)).to include(inside)
+      end
+    end
+
+    # A combined row contributes to both compliance tracks, so it belongs to both scopes.
+    describe '.with_hours and .with_income' do
+      let!(:hours_only) { create(:external_activity, :with_hours) }
+      let!(:income_only) { create(:external_activity, :with_income) }
+      let!(:combined) { create(:external_activity, :with_hours_and_income) }
+
+      it '.with_hours includes hours-only and combined rows' do
+        expect(described_class.with_hours).to contain_exactly(hours_only, combined)
+      end
+
+      it '.with_hours excludes income-only rows' do
+        expect(described_class.with_hours).not_to include(income_only)
+      end
+
+      it '.with_income includes income-only and combined rows' do
+        expect(described_class.with_income).to contain_exactly(income_only, combined)
+      end
+
+      it '.with_income excludes hours-only rows' do
+        expect(described_class.with_income).not_to include(hours_only)
+      end
+
+      it 'chains to select only combined rows' do
+        expect(described_class.with_hours.with_income).to contain_exactly(combined)
+      end
+    end
+  end
+
+  describe '#month' do
+    it 'returns the first day of the period start month' do
+      activity = build(:external_activity, :with_hours,
+                       period_start: Date.new(2026, 2, 14), period_end: Date.new(2026, 2, 28))
+
+      expect(activity.month).to eq(Date.new(2026, 2, 1))
+    end
+  end
+
+  describe '#hours? and #income?' do
+    it 'reports which values an hours-only row carries' do
+      activity = build(:external_activity, :with_hours)
+
+      expect(activity.hours?).to be(true)
+      expect(activity.income?).to be(false)
+    end
+
+    it 'reports which values an income-only row carries' do
+      activity = build(:external_activity, :with_income)
+
+      expect(activity.hours?).to be(false)
+      expect(activity.income?).to be(true)
+    end
+
+    it 'reports both for a combined row' do
+      activity = build(:external_activity, :with_hours_and_income)
+
+      expect(activity.hours?).to be(true)
+      expect(activity.income?).to be(true)
+    end
+  end
+
+  describe 'constants' do
+    it 'defines ALLOWED_CATEGORIES as the shared categories plus household' do
+      expect(ExternalActivity::ALLOWED_CATEGORIES)
+        .to eq(%w[employment community_service education unearned household])
+    end
+
+    it 'defines the API and batch source types' do
+      expect(ExternalActivity::SOURCE_TYPES[:api]).to eq('api')
+      expect(ExternalActivity::SOURCE_TYPES[:batch]).to eq('batch_upload')
+    end
+  end
+
+  describe 'i18n contract for source_type' do
+    it 'has a certification_cases.income.source_types entry for each allowed source type' do
+      ExternalActivity::ALLOWED_SOURCE_TYPES.each do |source_type|
+        key = "certification_cases.income.source_types.#{source_type}"
+        expect(I18n.exists?(key.to_sym, :en)).to be(true),
+          "Missing locale :en key #{key.inspect} for ExternalActivity source_type #{source_type.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Resolves #70969

## Changes

Adds  the `ExternalActivity` model that will consolidate `ExternalHourlyActivity` and
`ExternalIncomeActivity`, where a single row reports hours, gross income, or both.

- New `ExternalActivity` — union of both models' categories (including `household`) and source
  types (`api` and `batch_upload`), the shared `for_member` / `within_period` scopes, and new
  `with_hours` / `with_income` scopes plus `#hours?` / `#income?` for separating the two tracks.
- Hours are now validated against the **reported period** rather than a flat annual ceiling.
- `:external_activity` factory and model spec.
- Locale entries for the two new error messages and for the `batch_upload` source label.

Nothing reads or writes `ExternalActivity` yet — this is purely additive. The intake service and the
read-path cutover follow in separate PRs, and both old tables stay in place until a later backfill.

## Context for reviewers

Two smaller notes:

`household` stays external-only in `ExternalActivity::ALLOWED_CATEGORIES` rather than moving into
`ActivityCategories`, since a member-reported `Activity` can never be household income.

## Testing

Migration applied and rolled back cleanly, and `make db-reset` confirms the check constraint
round-trips through `schema.rb` (which is what `db-reset` loads, not the migrations):

```
== 20260903145559 CreateExternalActivities: migrating ====
-- create_table(:external_activities, ...)
== 20260903145559 CreateExternalActivities: migrated ====

t.check_constraint "hours IS NOT NULL OR gross_income IS NOT NULL", name: "external_activities_hours_or_income"
t.index ["period_start", "period_end"], name: "index_external_activities_on_period"
t.index ["source_type", "source_id"], name: "index_external_activities_on_source"
```

`make lint` — 580 files inspected, no offenses.

Full suite:

```
3614 examples, 0 failures

Line coverage: 5755 / 5939 (96.90%)
Branch coverage: 1396 / 1659 (84.14%)
```

The model spec (51 examples) covers each value combination — hours-only, income-only, both, and
neither rejected by the model *and* by the DB constraint when validations are bypassed — the hours
ceiling at its boundaries (`days * 24` accepted, 25 hours in a one-day period and 500 in a one-week
period rejected, income unconstrained, reversed periods reported once), `within_period` containment
including the end-of-month widening, and that a combined row appears in **both** `with_hours` and
`with_income` while chaining them selects only combined rows.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->