### PR TITLE
PBI-70969: Add external activity service

### DIFF
--- a/reporting-app/app/services/concerns/activity_aggregator.rb
+++ b/reporting-app/app/services/concerns/activity_aggregator.rb
@@ -107,16 +107,44 @@ module ActivityAggregator
 
   # Apportions by the number of days each month covers.
   def daily_values_map(period_start, period_end, value)
-    apportioned_values_map(period_start, period_end, value) do |months|
-      months.map { |month_start, month_end| month_end - month_start + 1 }
-    end
+    apportioned_values_map(period_start, period_end, value, weight: :daily)
   end
 
   # Apportions evenly.
   def monthly_values_map(period_start, period_end, value)
-    apportioned_values_map(period_start, period_end, value) do |months|
-      Array.new(months.size, 1)
+    apportioned_values_map(period_start, period_end, value, weight: :monthly)
+  end
+
+  # Apportions several named values across one set of month periods using the same weights, so a
+  # submission carrying both hours and gross_income divides both along the same month boundaries.
+  # Returns [start, end, {name => share}] triples.
+  #
+  # Apportioning each value separately and zipping the results would not do: the single-value map
+  # drops a month whose share rounds away, so a small value can lose a month a larger one keeps
+  # and the two lists fall out of step. Here a month survives when *any* value has a non-zero
+  # share, and a value whose own share rounded away is left nil for that month, rolled into a
+  # later one by the running total.
+  #
+  # @param weight [Symbol] :daily (by days each month covers) or :monthly (evenly)
+  # @return [Array<Array(Date, Date, Hash)>]
+  def apportioned_multi_values_map(period_start, period_end, weight:, **values)
+    whole_period = [ [ period_start, period_end, values ] ]
+    months = month_periods(period_start, period_end)
+
+    # Malformed input (blank values or dates, reversed period) goes to the model as-is so it
+    # raises RecordInvalid rather than failing in the arithmetic below.
+    return whole_period if values.values.all?(&:blank?) || months.size <= 1
+
+    weights = month_weights(months, weight)
+    shares = values.transform_values do |value|
+      value.blank? ? Array.new(months.size) : apportioned_shares(value, weights)
     end
+
+    entries = months.each_with_index.map do |(current_period_start, current_period_end), index|
+      [ current_period_start, current_period_end, month_shares(shares, index) ]
+    end
+
+    entries.reject { |_, _, month_values| month_values.values.all?(&:nil?) }.presence || whole_period
   end
 
   private
@@ -127,8 +155,7 @@ module ActivityAggregator
     rows.sum(BigDecimal("0")) { |row| BigDecimal((row.public_send(attribute) || 0).to_s) }
   end
 
-  # The block supplies the per-month weights to apportion by.
-  def apportioned_values_map(period_start, period_end, value)
+  def apportioned_values_map(period_start, period_end, value, weight:)
     whole_period = [ [ period_start, period_end, value ] ]
     months = month_periods(period_start, period_end)
 
@@ -136,24 +163,48 @@ module ActivityAggregator
     # so it raises RecordInvalid rather than failing in the arithmetic below.
     return whole_period if value.blank? || months.size <= 1
 
-    weights = yield(months)
-    total_weight = weights.sum # number of months or number of days
-    covered_weight = 0
-    allocated = 0
-    entries = months.zip(weights).map do |(current_period_start, current_period_end), weight|
-      # Apportion against the running total rather than per month, so rounding cannot
-      # drift and the entries always sum back to +value+.
-      covered_weight += weight
-      cumulative_value = (covered_weight * value / total_weight).round(VALUE_SCALE)
-      current_value = cumulative_value - allocated
-      allocated = cumulative_value
-
-      [ current_period_start, current_period_end, current_value ]
+    shares = apportioned_shares(value, month_weights(months, weight))
+    entries = months.zip(shares).map do |(current_period_start, current_period_end), share|
+      [ current_period_start, current_period_end, share ]
     end
 
     # A share too small to survive rounding would fail the models' greater-than-zero
     # validations; drop it and let the running total roll it into the next month.
-    entries.reject { |_, _, current_value| current_value.zero? }.presence || whole_period
+    entries.reject { |_, _, share| share.zero? }.presence || whole_period
+  end
+
+  def month_weights(months, weight)
+    case weight
+    when :daily then months.map { |month_start, month_end| month_end - month_start + 1 }
+    when :monthly then Array.new(months.size, 1)
+    else raise ArgumentError, "unknown apportionment weight #{weight.inspect}"
+    end
+  end
+
+  # Apportions +value+ against a running total rather than per month, so rounding cannot drift
+  # and the shares always sum back to +value+.
+  def apportioned_shares(value, weights)
+    total_weight = weights.sum # number of months or number of days
+    covered_weight = 0
+    allocated = 0
+
+    weights.map do |weight|
+      covered_weight += weight
+      cumulative_value = (covered_weight * value / total_weight).round(VALUE_SCALE)
+      share = cumulative_value - allocated
+      allocated = cumulative_value
+
+      share
+    end
+  end
+
+  # One month's slice across every value, with a share that rounded away left nil so it fails no
+  # greater-than-zero validation and does not keep the month alive on its own.
+  def month_shares(shares, index)
+    shares.transform_values do |value_shares|
+      share = value_shares[index]
+      share unless share.nil? || share.zero?
+    end
   end
 
 

--- a/reporting-app/app/services/external_activity_service.rb
+++ b/reporting-app/app/services/external_activity_service.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# Service for creating and validating ExternalActivity entries from API and batch intake.
+# Supersedes ExternalHourlyActivityService and ExternalIncomeActivityService: one submission may
+# report hours, gross income, or both, and is split into one entry per calendar month it touches.
+#
+# After a successful save, optional compliance recalculation (+recalculate_compliance+, default
+# +true+) records exactly one determination for the member's open case — hours first, falling
+# through to income only when hours fall short. Certification intake passes
+# +recalculate_compliance: false+ so rows created before the case exists do not run this path.
+class ExternalActivityService
+  include Strata::VirtualActor
+
+  AUDIT_ACTION_CREATE = "external_activity.create"
+
+  class << self
+    include ActivityAggregator
+    include OriginHash
+
+    # Create one entry per calendar month the period touches.
+    # A submission already on file is logged and skipped, leaving the caller's other work intact.
+    # @param identity [Array] values beyond the name identifying whose figures these are (household
+    #   income passes the member's tax ID and date of birth), folded into the fingerprint.
+    # @return [Array<ExternalActivity>] the entries created, empty for a duplicate
+    # @raise [ActiveRecord::RecordInvalid] on validation failure
+    def create_entries(member_id:, category:, period_start:, period_end:, source_type:,
+                       hours: nil, gross_income: nil, source_id: nil, reported_at: Time.current,
+                       metadata: {}, name: nil, employer: nil, identity: [],
+                       recalculate_compliance: true)
+      origin_hash = origin_hash_for(member_id, category, hours, gross_income,
+                                    period_start, period_end, name, *identity)
+
+      if duplicate_entry?(origin_hash)
+        log_duplicate_submission(origin_hash, member_id:, category:, period_start:, period_end:)
+        return []
+      end
+
+      entries = month_entries(hours:, gross_income:, period_start:, period_end:)
+        .map do |current_period_start, current_period_end, values|
+          create_entry(member_id:, category:,
+                       hours: values[:hours], gross_income: values[:gross_income],
+                       period_start: current_period_start, period_end: current_period_end,
+                       source_type:, source_id:, reported_at:, metadata:, name:, employer:,
+                       origin_hash:, recalculate_compliance: false)
+        end
+
+      maybe_recalculate_compliance(member_id, hours:, gross_income:) if recalculate_compliance
+      entries
+    end
+
+    # Duplicate detection belongs to +create_entries+.
+    # @param recalculate_compliance [Boolean] when +true+ (default), after save record one
+    #   automated determination for the open case (may +close!+ when compliant);
+    #   +Certifications::CreationService+ passes +false+.
+    # @return [ExternalActivity] on success
+    # @raise [ActiveRecord::RecordInvalid] on validation failure
+    def create_entry(member_id:, category:, period_start:, period_end:, source_type:,
+                     hours: nil, gross_income: nil, source_id: nil, reported_at: Time.current,
+                     metadata: {}, name: nil, employer: nil, origin_hash: nil,
+                     recalculate_compliance: true)
+      entry = ExternalActivity.new
+
+      Strata::AuditLog.record do |log|
+        entry.update!(
+          member_id: member_id,
+          category: category,
+          hours: hours,
+          gross_income: gross_income,
+          period_start: period_start,
+          period_end: period_end,
+          source_type: source_type,
+          source_id: source_id,
+          reported_at: reported_at,
+          name: name,
+          origin_hash: origin_hash,
+          metadata: (metadata || {}).merge(employer.present? ? { "employer" => employer } : {})
+        )
+
+        log.add_line(
+          actor: self,
+          action: AUDIT_ACTION_CREATE,
+          subject: entry,
+          data: entry.attributes
+        )
+      end
+
+      if recalculate_compliance
+        maybe_recalculate_compliance(entry.member_id, hours: entry.hours, gross_income: entry.gross_income)
+      end
+
+      entry
+    end
+
+    # Entries carrying no fingerprint (rows written before this column existed) are
+    # not duplicates of anything.
+    # @return [Boolean]
+    def duplicate_entry?(origin_hash)
+      return false if origin_hash.blank?
+
+      ExternalActivity.exists?(origin_hash: origin_hash)
+    end
+
+    private
+
+    # Hours present means both values apportion by days, so the two halves of one activity divide
+    # along the same month boundaries. An income-only submission keeps the income rule: evenly
+    # across whole calendar months, by days otherwise.
+    def month_entries(hours:, gross_income:, period_start:, period_end:)
+      if hours.present?
+        return apportioned_multi_values_map(period_start, period_end, weight: :daily,
+                                            hours:, gross_income:)
+      end
+
+      weight = whole_months?(period_start, period_end) ? :monthly : :daily
+      apportioned_multi_values_map(period_start, period_end, weight:, gross_income:)
+    end
+
+    def whole_months?(period_start, period_end)
+      period_start&.beginning_of_month == period_start && period_end&.end_of_month == period_end
+    end
+
+    # The open certification is resolved once: +open_certification_id_for_member+ filters on open
+    # cases and recording a compliant outcome +close!+s the case, so a per-track lookup would let
+    # the first compliant close silently skip the second track.
+    def maybe_recalculate_compliance(member_id, hours:, gross_income:)
+      certification_id = CertificationCase.open_certification_id_for_member(member_id)
+      return if certification_id.blank?
+
+      certification = Certification.find(certification_id)
+      kase = certification_case_for_certification(certification)
+      raise ActiveRecord::RecordNotFound, "Couldn't find CertificationCase for Certification #{certification_id}" unless kase
+
+      record_one_determination(kase, certification, hours:, gross_income:)
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.warn(
+        "ExternalActivityService: skipped compliance recalculation " \
+        "(case or certification missing) for member_id=#{member_id}"
+      )
+    end
+
+    # Hours take precedence: income is consulted only when hours do not already satisfy the
+    # requirement, so one save records one determination even for a row carrying both.
+    #
+    # The determination services' +.calculate+ methods aggregate *and* record, so calling both
+    # would write two rows. The pieces they build on are public, so the branch is decided here and
+    # only the winning track is recorded.
+    #
+    # Hours compliance is judged on monthly hours alone, matching
+    # +HoursComplianceDeterminationService#calculate+: the education-enrollment track belongs to
+    # +CommunityEngagementCheckService+, so consulting it here would widen this outcome.
+    def record_one_determination(kase, certification, hours:, gross_income:)
+      application_form = ActivityReportApplicationForm.find_by(certification_case_id: kase.id)
+
+      if hours.present?
+        hours_data = HoursComplianceDeterminationService
+          .aggregate_hours_for_certification(certification, application_form:)
+        hours_compliant = HoursComplianceDeterminationService
+          .compliant_for_monthly_hours?(hours_data[:hours_by_month])
+
+        if hours_compliant || gross_income.blank?
+          return kase.record_hours_compliance(hours_compliant ? :compliant : :not_compliant, hours_data)
+        end
+      end
+
+      income_data = IncomeComplianceDeterminationService
+        .aggregate_income_for_certification(certification, application_form:)
+      income_compliant = IncomeComplianceDeterminationService
+        .compliant_for_monthly_income?(income_data[:income_by_month])
+
+      kase.record_income_compliance(income_compliant ? :compliant : :not_compliant, income_data)
+    end
+  end
+end

--- a/reporting-app/app/services/external_activity_service.rb
+++ b/reporting-app/app/services/external_activity_service.rb
@@ -106,7 +106,7 @@ class ExternalActivityService
     # along the same month boundaries. An income-only submission keeps the income rule: evenly
     # across whole calendar months, by days otherwise.
     def month_entries(hours:, gross_income:, period_start:, period_end:)
-      if hours.present?
+      if hours &.> 0
         return apportioned_multi_values_map(period_start, period_end, weight: :daily,
                                             hours:, gross_income:)
       end

--- a/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
+++ b/reporting-app/spec/services/concerns/activity_aggregator_spec.rb
@@ -127,4 +127,79 @@ RSpec.describe ActivityAggregator, type: :concern do
       end
     end
   end
+
+  describe ".apportioned_multi_values_map" do
+    def shares(period_start, period_end, weight:, **values)
+      service.apportioned_multi_values_map(period_start, period_end, weight:, **values)
+    end
+
+    context "with :daily weights" do
+      # Jan 20-31 is 12 days and Feb 1-10 is 10 days, so a 22-unit total splits 12/10.
+      it "apportions each value by the days its month covers" do
+        result = shares(Date.new(2026, 1, 20), Date.new(2026, 2, 10), weight: :daily,
+                        hours: 22, gross_income: 220)
+
+        expect(result.map { |month_start, _, _| month_start })
+          .to eq([ Date.new(2026, 1, 20), Date.new(2026, 2, 1) ])
+        expect(result.map { |_, _, values| values[:hours] }).to eq([ 12, 10 ])
+        expect(result.map { |_, _, values| values[:gross_income] }).to eq([ 120, 100 ])
+      end
+    end
+
+    context "with :monthly weights" do
+      it "apportions each value evenly across the months" do
+        result = shares(Date.new(2026, 1, 1), Date.new(2026, 3, 31), weight: :monthly, gross_income: 300)
+
+        expect(result.map { |_, _, values| values[:gross_income] }).to eq([ 100, 100, 100 ])
+      end
+    end
+
+    it "sums each value back to its total without rounding drift" do
+      result = shares(Date.new(2026, 5, 1), Date.new(2026, 7, 31), weight: :daily,
+                      hours: BigDecimal("100"), gross_income: BigDecimal("1000"))
+
+      expect(result.sum { |_, _, values| values[:hours] }).to eq(BigDecimal("100"))
+      expect(result.sum { |_, _, values| values[:gross_income] }).to eq(BigDecimal("1000"))
+    end
+
+    # Apportioning the values independently and zipping the results would drop a month for one
+    # value but not the other, misaligning the two lists.
+    it "keeps months aligned when one value's share rounds to zero" do
+      result = shares(Date.new(2026, 1, 31), Date.new(2026, 3, 31), weight: :daily,
+                      hours: 300, gross_income: BigDecimal("0.02"))
+
+      expect(result.size).to eq(3)
+      expect(result.map { |_, _, values| values[:hours] }).to all be > 0
+      expect(result.map { |_, _, values| values[:gross_income] }).to include(nil)
+      expect(result.sum { |_, _, values| values[:gross_income] || 0 }).to eq(BigDecimal("0.02"))
+    end
+
+    it "drops a month only when every value's share rounds to zero" do
+      result = shares(Date.new(2026, 1, 31), Date.new(2026, 12, 31), weight: :daily,
+                      hours: 1, gross_income: BigDecimal("0.05"))
+
+      expect(result.map { |month_start, _, _| month_start }).not_to include(Date.new(2026, 1, 31))
+    end
+
+    it "returns the whole period unsplit when it falls inside one month" do
+      result = shares(Date.new(2026, 1, 5), Date.new(2026, 1, 20), weight: :daily, hours: 40)
+
+      expect(result).to eq([ [ Date.new(2026, 1, 5), Date.new(2026, 1, 20), { hours: 40 } ] ])
+    end
+
+    # Malformed input goes to the model as-is so it raises RecordInvalid rather than failing here.
+    it "returns the whole period when every value is blank" do
+      result = shares(Date.new(2026, 1, 1), Date.new(2026, 3, 31), weight: :daily,
+                      hours: nil, gross_income: nil)
+
+      expect(result.size).to eq(1)
+      expect(result.first.last).to eq({ hours: nil, gross_income: nil })
+    end
+
+    it "returns the whole period when the period is reversed" do
+      result = shares(Date.new(2026, 3, 31), Date.new(2026, 1, 1), weight: :daily, hours: 40)
+
+      expect(result).to eq([ [ Date.new(2026, 3, 31), Date.new(2026, 1, 1), { hours: 40 } ] ])
+    end
+  end
 end

--- a/reporting-app/spec/services/external_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_activity_service_spec.rb
@@ -1,0 +1,830 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExternalActivityService do
+  describe ".create_entry" do
+    let(:valid_params) do
+      {
+        member_id: "123456789",
+        category: "employment",
+        hours: 40.0,
+        period_start: Date.current.beginning_of_month,
+        period_end: Date.current.end_of_month,
+        source_type: ExternalActivity::SOURCE_TYPES[:api]
+      }
+    end
+
+    context "with valid data" do
+      it "creates an hours-only ExternalActivity" do
+        result = described_class.create_entry(**valid_params)
+
+        expect(result).to be_a(ExternalActivity)
+        expect(result).to be_persisted
+        expect(result.member_id).to eq("123456789")
+        expect(result.category).to eq("employment")
+        expect(result.hours).to eq(40.0)
+        expect(result.gross_income).to be_nil
+      end
+
+      it "creates an income-only ExternalActivity" do
+        result = described_class.create_entry(**valid_params.merge(hours: nil, gross_income: 580.00))
+
+        expect(result.hours).to be_nil
+        expect(result.gross_income).to eq(580.00)
+      end
+
+      it "creates an ExternalActivity carrying both hours and income" do
+        result = described_class.create_entry(**valid_params.merge(gross_income: 580.00))
+
+        expect(result.hours).to eq(40.0)
+        expect(result.gross_income).to eq(580.00)
+      end
+
+      it "sets source_type correctly" do
+        expect(described_class.create_entry(**valid_params).source_type).to eq("api")
+      end
+
+      it "sets optional source_id when provided" do
+        expect(described_class.create_entry(**valid_params, source_id: "batch-123").source_id).to eq("batch-123")
+      end
+
+      it "stores the origin_hash it is given" do
+        expect(described_class.create_entry(**valid_params, origin_hash: "abc123").origin_hash).to eq("abc123")
+      end
+
+      it "stores the reported name" do
+        expect(described_class.create_entry(**valid_params, name: "Acme Corp").name).to eq("Acme Corp")
+      end
+
+      it "merges employer into metadata when provided" do
+        result = described_class.create_entry(**valid_params, employer: "Acme Corp", metadata: { "note" => "x" })
+
+        expect(result.metadata).to eq({ "note" => "x", "employer" => "Acme Corp" })
+      end
+
+      it "stores the reported name alongside the employer metadata" do
+        result = described_class.create_entry(**valid_params, name: "Acme Corp", employer: "Acme Payroll")
+
+        expect(result.name).to eq("Acme Corp")
+        expect(result.metadata).to eq({ "employer" => "Acme Payroll" })
+      end
+
+      # Hours rows previously had no reported_at column at all; every row carries one now.
+      it "defaults reported_at when omitted" do
+        freeze_time do
+          expect(described_class.create_entry(**valid_params).reported_at).to eq(Time.current)
+        end
+      end
+
+      it "logs a created event for an hours-only row" do
+        result = described_class.create_entry(**valid_params)
+
+        log_count = Strata::AuditLine.where(subject: result, actor_type: described_class.name,
+                                            action: "external_activity.create", data: result.attributes).count
+        expect(log_count).to eq 1
+      end
+
+      it "logs the same action for an income-only row" do
+        result = described_class.create_entry(**valid_params.merge(hours: nil, gross_income: 580.00))
+
+        log_count = Strata::AuditLine.where(subject: result, actor_type: described_class.name,
+                                            action: "external_activity.create").count
+        expect(log_count).to eq 1
+      end
+    end
+
+    context "with an existing identical entry" do
+      before do
+        create(:external_activity, :with_hours,
+               member_id: valid_params[:member_id],
+               category: valid_params[:category],
+               hours: valid_params[:hours],
+               period_start: valid_params[:period_start],
+               period_end: valid_params[:period_end])
+      end
+
+      it "creates the entry, since duplicates are rejected by create_entries" do
+        expect { described_class.create_entry(**valid_params) }
+          .to change(ExternalActivity, :count).by(1)
+      end
+    end
+
+    context "with validation errors" do
+      it "returns error for missing member_id" do
+        expect { described_class.create_entry(**valid_params.merge(member_id: nil)) }.to raise_error(/Member/)
+      end
+
+      it "returns error for invalid category" do
+        expect { described_class.create_entry(**valid_params.merge(category: "invalid")) }.to raise_error(/Category/)
+      end
+
+      it "returns error for zero hours" do
+        expect { described_class.create_entry(**valid_params.merge(hours: 0)) }.to raise_error(/Hours/)
+      end
+
+      it "returns error for negative hours" do
+        expect { described_class.create_entry(**valid_params.merge(hours: -10)) }.to raise_error(/Hours/)
+      end
+
+      it "returns error for zero gross_income" do
+        expect { described_class.create_entry(**valid_params.merge(hours: nil, gross_income: 0)) }
+          .to raise_error(/Gross income/)
+      end
+
+      it "returns error when neither hours nor gross_income is given" do
+        expect { described_class.create_entry(**valid_params.merge(hours: nil)) }
+          .to raise_error(/must report hours, gross income, or both/)
+      end
+
+      it "returns error for invalid source_type" do
+        expect { described_class.create_entry(**valid_params.merge(source_type: "invalid")) }
+          .to raise_error(/Source type/)
+      end
+
+      it "returns error for hours exceeding the reported period" do
+        expect {
+          described_class.create_entry(
+            **valid_params.merge(period_start: Date.new(2026, 1, 1), period_end: Date.new(2026, 1, 7), hours: 500)
+          )
+        }.to raise_error(/cannot exceed 168 hours/)
+      end
+    end
+
+    context "with batch_upload source" do
+      it "creates entry with batch source_type and source_id" do
+        result = described_class.create_entry(
+          **valid_params, source_type: ExternalActivity::SOURCE_TYPES[:batch], source_id: "upload-456"
+        )
+
+        expect(result.source_type).to eq("batch_upload")
+        expect(result.source_id).to eq("upload-456")
+      end
+    end
+  end
+
+  describe ".create_entries" do
+    let(:base_params) do
+      {
+        member_id: "123456789",
+        category: "employment",
+        period_start:,
+        period_end:,
+        source_type: ExternalActivity::SOURCE_TYPES[:api]
+      }
+    end
+
+    # --- Hours: always apportioned by days ---
+
+    describe "an hours-only submission" do
+      let(:hours) { period_end - period_start + 1 } # 1 hour per day
+      let(:valid_params) { base_params.merge(hours:) }
+
+      context "with 3 full months" do
+        let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "has three months" do
+          expect(described_class.create_entries(**valid_params).size).to eq 3
+        end
+
+        it "apportions hours by number of days in month" do
+          described_class.create_entries(**valid_params).each do |result|
+            expect(result.hours).to eq(result.period_end - result.period_start + 1)
+          end
+        end
+
+        it "leaves gross_income unset on every entry" do
+          expect(described_class.create_entries(**valid_params).map(&:gross_income)).to all be_nil
+        end
+      end
+
+      context "with partial months" do
+        let(:days_in_start_month) { 10 }
+        let(:days_in_end_month) { 15 }
+        let(:period_start) { (3.months.ago.end_of_month - days_in_start_month.days + 1).to_date }
+        let(:period_end) { (2.months.ago.end_of_month + days_in_end_month.days).to_date }
+
+        it "has 3 months" do
+          expect(described_class.create_entries(**valid_params).size).to eq 3
+        end
+
+        it "apportions hours by number of days in period in month" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.first.hours).to eq days_in_start_month
+          expect(results.last.hours).to eq days_in_end_month
+          expect(results[1].hours).to eq(results[1].period_end - results[1].period_start + 1)
+        end
+      end
+
+      context "when spans year boundary" do
+        let(:period_start) { 20.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "has twenty months" do
+          expect(described_class.create_entries(**valid_params).size).to eq 20
+        end
+
+        it "apportions hours by number of days in month" do
+          described_class.create_entries(**valid_params).each do |result|
+            expect(result.hours).to eq(result.period_end - result.period_start + 1)
+          end
+        end
+      end
+
+      context "when not 1 hour per day" do
+        let(:days_in_start_month) { 10 }
+        let(:days_in_end_month) { 18 }
+        let(:hours) { (days_in_start_month + days_in_end_month) / 2 }
+        let(:period_start) { (3.months.ago.end_of_month - days_in_start_month.days + 1).to_date }
+        let(:period_end) { (3.months.ago.end_of_month + days_in_end_month.days).to_date }
+
+        it "apportions hours by number of days in period in month" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.first.hours).to eq days_in_start_month / 2
+          expect(results.last.hours).to eq days_in_end_month / 2
+        end
+      end
+
+      context "when hours do not divide evenly" do
+        let(:hours) { BigDecimal("100") }
+        let(:period_start) { Date.new(2026, 5, 1) }
+        let(:period_end) { Date.new(2026, 7, 31) }
+
+        it "apportions the full total without rounding drift" do
+          expect(described_class.create_entries(**valid_params).sum(&:hours)).to eq hours
+        end
+
+        it "keeps each entry within a hundredth of an hour of its exact share" do
+          total_days = period_end - period_start + 1
+
+          described_class.create_entries(**valid_params).each do |result|
+            days = result.period_end - result.period_start + 1
+            expect(result.hours).to be_within(0.01).of(days * hours / total_days)
+          end
+        end
+      end
+
+      context "when a month's share rounds to zero" do
+        let(:hours) { 1 }
+        let(:period_start) { Date.new(2026, 1, 31) }
+        let(:period_end) { Date.new(2026, 12, 31) }
+
+        it "skips the month rather than failing the whole period" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.map(&:period_start)).not_to include(period_start)
+          expect(results.map(&:hours)).to all be > 0
+          expect(results.sum(&:hours)).to eq hours
+        end
+      end
+    end
+
+    # --- Income: evenly for whole months, by days otherwise ---
+
+    describe "an income-only submission" do
+      let(:gross_income) { period_end - period_start + 1 } # 1 dollar per day
+      let(:valid_params) { base_params.merge(gross_income:) }
+
+      context "with 3 full months" do
+        let(:gross_income) { 300 }
+        let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "has three months" do
+          expect(described_class.create_entries(**valid_params).size).to eq 3
+        end
+
+        it "apportions income equally by month" do
+          described_class.create_entries(**valid_params).each do |result|
+            expect(result.gross_income).to eq 100
+          end
+        end
+
+        it "leaves hours unset on every entry" do
+          expect(described_class.create_entries(**valid_params).map(&:hours)).to all be_nil
+        end
+      end
+
+      context "with 3 full months income not divisible by 3" do
+        let(:gross_income) { 301.to_f }
+        let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "cumulative adds up to gross income" do
+          expect(described_class.create_entries(**valid_params).sum(&:gross_income)).to eq gross_income
+        end
+      end
+
+      context "with partial months" do
+        let(:days_in_start_month) { 10 }
+        let(:days_in_end_month) { 15 }
+        let(:period_start) { (3.months.ago.end_of_month - days_in_start_month.days + 1).to_date }
+        let(:period_end) { (2.months.ago.end_of_month + days_in_end_month.days).to_date }
+
+        it "apportions gross_income by number of days in period in month" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.size).to eq 3
+          expect(results.first.gross_income).to eq days_in_start_month
+          expect(results.last.gross_income).to eq days_in_end_month
+        end
+      end
+
+      context "when spans year boundary with full months" do
+        let(:gross_income) { 20_000 }
+        let(:period_start) { 20.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "apportions gross_income equally by month" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.size).to eq 20
+          expect(results.map(&:gross_income)).to all eq 1_000
+        end
+      end
+
+      context "when spans year boundary with partial month" do
+        let(:period_start) { 20.months.ago.beginning_of_month.to_date + 1.day }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+        it "apportions gross_income by number of days in month" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.size).to eq 20
+          results.each do |result|
+            expect(result.gross_income).to eq(result.period_end - result.period_start + 1)
+          end
+        end
+      end
+
+      context "when gross_income does not divide evenly" do
+        let(:gross_income) { BigDecimal("100") }
+        let(:period_start) { Date.new(2026, 5, 2) }
+        let(:period_end) { Date.new(2026, 7, 31) }
+
+        it "apportions the full total without rounding drift" do
+          expect(described_class.create_entries(**valid_params).sum(&:gross_income)).to eq gross_income
+        end
+      end
+
+      context "when a month's share rounds to zero" do
+        let(:gross_income) { BigDecimal("0.05") }
+        let(:period_start) { Date.new(2026, 1, 31) }
+        let(:period_end) { Date.new(2026, 12, 31) }
+
+        it "skips the month rather than failing the whole period" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.map(&:period_start)).not_to include(period_start)
+          expect(results.map(&:gross_income)).to all be > 0
+          expect(results.sum(&:gross_income)).to eq gross_income
+        end
+      end
+    end
+
+    # --- Combined: hours present, so both columns apportion by days ---
+
+    describe "a submission carrying both hours and income" do
+      let(:valid_params) { base_params.merge(hours:, gross_income:) }
+
+      context "with 3 full months" do
+        let(:hours) { 300 }
+        let(:gross_income) { 3_000 }
+        let(:period_start) { Date.new(2026, 1, 1) }
+        let(:period_end) { Date.new(2026, 3, 31) }
+
+        it "creates one entry per month carrying both values" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.size).to eq 3
+          expect(results.map(&:hours)).to all be_present
+          expect(results.map(&:gross_income)).to all be_present
+        end
+
+        it "apportions both totals in full" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.sum(&:hours)).to eq hours
+          expect(results.sum(&:gross_income)).to eq gross_income
+        end
+
+        # Whole months would normally split income evenly; the presence of hours makes both
+        # values apportion by days so the halves of one activity stay aligned.
+        it "apportions income by days rather than evenly, because hours are present" do
+          results = described_class.create_entries(**valid_params)
+          total_days = period_end - period_start + 1
+
+          results.each do |result|
+            days = result.period_end - result.period_start + 1
+            expect(result.gross_income).to be_within(0.01).of(days * gross_income / total_days)
+          end
+        end
+      end
+
+      context "when one value's share rounds to zero in a month" do
+        let(:hours) { 300 }
+        let(:gross_income) { BigDecimal("0.05") }
+        let(:period_start) { Date.new(2026, 1, 31) }
+        let(:period_end) { Date.new(2026, 12, 31) }
+
+        # Apportioning the two values independently and zipping them would misalign the months.
+        it "keeps every month the hours need and leaves income unset where its share vanished" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.map(&:hours)).to all be_present
+          expect(results.map(&:period_start)).to include(period_start)
+          expect(results.map(&:gross_income).compact).to all be > 0
+        end
+
+        it "still apportions both totals in full" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.sum(&:hours)).to eq hours
+          expect(results.filter_map(&:gross_income).sum).to eq gross_income
+        end
+      end
+
+      context "with a single month" do
+        let(:hours) { 40 }
+        let(:gross_income) { 620 }
+        let(:period_start) { Date.new(2026, 1, 1) }
+        let(:period_end) { Date.new(2026, 1, 31) }
+
+        it "creates one entry with both values" do
+          results = described_class.create_entries(**valid_params)
+
+          expect(results.size).to eq 1
+          expect(results.first.hours).to eq 40
+          expect(results.first.gross_income).to eq 620
+        end
+      end
+    end
+
+    # --- Shared behavior ---
+
+    describe "submission-wide attributes" do
+      let(:valid_params) { base_params.merge(hours: 300) }
+      let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+      let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+      it "sets source_id on every entry" do
+        results = described_class.create_entries(**valid_params, source_id: "batch-123")
+
+        expect(results.size).to be > 1
+        expect(results.map(&:source_id)).to all eq "batch-123"
+      end
+
+      it "sets source_id on a single-month period" do
+        results = described_class.create_entries(
+          **valid_params.merge(period_end: period_start.end_of_month), source_id: "batch-123"
+        )
+
+        expect(results.map(&:source_id)).to eq [ "batch-123" ]
+      end
+
+      it "stores the name on every entry of the submission" do
+        results = described_class.create_entries(**valid_params, name: "Acme Corp")
+
+        expect(results.size).to eq 3
+        expect(results.map(&:name)).to all eq "Acme Corp"
+      end
+
+      it "stamps the same origin_hash on every entry of the submission" do
+        results = described_class.create_entries(**valid_params, name: "Acme Corp")
+
+        expect(results.map(&:origin_hash).uniq.size).to eq 1
+        expect(results.first.origin_hash).to be_present
+      end
+    end
+
+    describe "invalid submissions" do
+      let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+      let(:period_end) { 1.month.ago.end_of_month.to_date }
+
+      it "raises when neither hours nor gross_income is given" do
+        expect { described_class.create_entries(**base_params) }
+          .to raise_error(ActiveRecord::RecordInvalid, /must report hours, gross income, or both/)
+      end
+
+      context "when the period is reversed" do
+        let(:period_start) { 1.month.ago.end_of_month.to_date }
+        let(:period_end) { 3.months.ago.beginning_of_month.to_date }
+
+        it "raises a validation error" do
+          expect { described_class.create_entries(**base_params.merge(hours: BigDecimal("40"))) }
+            .to raise_error(ActiveRecord::RecordInvalid, /cannot be after end date/)
+        end
+
+        it "creates no entries" do
+          expect {
+            begin
+              described_class.create_entries(**base_params.merge(hours: BigDecimal("40")))
+            rescue ActiveRecord::RecordInvalid
+              nil
+            end
+          }.not_to change(ExternalActivity, :count)
+        end
+      end
+    end
+
+    describe "duplicate detection" do
+      let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+      let(:period_end) { 1.month.ago.end_of_month.to_date }
+      let(:valid_params) { base_params.merge(hours: 300) }
+
+      before do
+        allow(Rails.logger).to receive(:warn)
+        described_class.create_entries(**valid_params, name: "Acme Corp")
+      end
+
+      it "creates no entries" do
+        expect { described_class.create_entries(**valid_params, name: "Acme Corp") }
+          .not_to change(ExternalActivity, :count)
+      end
+
+      it "returns no entries" do
+        expect(described_class.create_entries(**valid_params, name: "Acme Corp")).to eq []
+      end
+
+      it "logs the duplicate" do
+        described_class.create_entries(**valid_params, name: "Acme Corp")
+
+        expect(Rails.logger).to have_received(:warn).with(/skipped duplicate submission/)
+      end
+
+      it "ignores name casing and surrounding whitespace" do
+        expect { described_class.create_entries(**valid_params, name: " acme corp ") }
+          .not_to change(ExternalActivity, :count)
+      end
+
+      it "ignores how the value is typed or scaled" do
+        [ 300, 300.0, BigDecimal("300.00") ].each do |equivalent|
+          expect { described_class.create_entries(**valid_params.merge(hours: equivalent), name: "Acme Corp") }
+            .not_to change(ExternalActivity, :count)
+        end
+      end
+
+      it "ignores the employer, which is metadata rather than identity" do
+        expect { described_class.create_entries(**valid_params, name: "Acme Corp", employer: "Other Payroll") }
+          .not_to change(ExternalActivity, :count)
+      end
+
+      it "accepts the same activity reported under a different name" do
+        expect { described_class.create_entries(**valid_params, name: "Other Corp") }
+          .to change(ExternalActivity, :count).by(3)
+      end
+
+      it "accepts the same activity for a different member" do
+        expect { described_class.create_entries(**valid_params.merge(member_id: "987654321"), name: "Acme Corp") }
+          .to change(ExternalActivity, :count).by(3)
+      end
+
+      # The fingerprint covers both values, so the three shapes can never collide.
+      it "treats the same total as income rather than hours as a different submission" do
+        expect {
+          described_class.create_entries(**base_params.merge(gross_income: 300), name: "Acme Corp")
+        }.to change(ExternalActivity, :count).by(3)
+      end
+
+      it "treats adding income to an existing hours submission as a different submission" do
+        expect {
+          described_class.create_entries(**valid_params.merge(gross_income: 3_000), name: "Acme Corp")
+        }.to change(ExternalActivity, :count).by(3)
+      end
+    end
+
+    describe "duplicate detection for an unnamed submission" do
+      let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+      let(:period_end) { 1.month.ago.end_of_month.to_date }
+      let(:valid_params) { base_params.merge(hours: 300) }
+
+      before { described_class.create_entries(**valid_params) }
+
+      it "creates no entries" do
+        expect { described_class.create_entries(**valid_params) }
+          .not_to change(ExternalActivity, :count)
+      end
+
+      it "treats a blank name as no name" do
+        expect { described_class.create_entries(**valid_params, name: "  ") }
+          .not_to change(ExternalActivity, :count)
+      end
+    end
+
+    describe "duplicate detection for a household submission" do
+      let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+      let(:period_end) { 1.month.ago.end_of_month.to_date }
+      let(:household_params) do
+        base_params.merge(
+          category: ExternalActivity::CATEGORY_HOUSEHOLD,
+          gross_income: 300,
+          name: "Elizabeth Doe",
+          identity: [ "000000002", Date.new(1979, 9, 1) ]
+        )
+      end
+
+      before do
+        allow(Rails.logger).to receive(:warn)
+        described_class.create_entries(**household_params)
+      end
+
+      it "creates no entries for the same household member" do
+        expect { described_class.create_entries(**household_params) }
+          .not_to change(ExternalActivity, :count)
+      end
+
+      it "accepts the same income from another household member" do
+        expect {
+          described_class.create_entries(
+            **household_params.merge(name: "Richard Doe", identity: [ "000000003", Date.new(1983, 10, 2) ])
+          )
+        }.to change(ExternalActivity, :count).by(3)
+      end
+
+      it "tells household members who share a name apart by tax ID and date of birth" do
+        expect {
+          described_class.create_entries(**household_params.merge(identity: [ "000000003", Date.new(1983, 10, 2) ]))
+        }.to change(ExternalActivity, :count).by(3)
+      end
+
+      it "accepts a different income from the same household member" do
+        expect { described_class.create_entries(**household_params.merge(gross_income: 450)) }
+          .to change(ExternalActivity, :count).by(3)
+      end
+    end
+  end
+
+  # Exactly one determination per save: hours first, falling through to income only when hours
+  # fall short. The aggregates run for real; only the threshold checks are stubbed, since the
+  # read paths still fetch from the superseded tables until the cutover.
+  describe "compliance recalculation" do
+    let(:certification) { create(:certification) }
+    let(:period_start) { certification.certification_requirements.continuous_lookback_period.start.to_date }
+    let(:period_end) { period_start.end_of_month }
+    let(:params) do
+      {
+        member_id: certification.member_id,
+        category: "employment",
+        period_start:,
+        period_end:,
+        source_type: ExternalActivity::SOURCE_TYPES[:api]
+      }
+    end
+
+    before do
+      allow(Strata::EventManager).to receive(:publish)
+      allow(NotificationService).to receive(:send_email_notification)
+    end
+
+    def stub_thresholds(hours_ok:, income_ok:)
+      allow(HoursComplianceDeterminationService).to receive(:compliant_for_monthly_hours?).and_return(hours_ok)
+      allow(IncomeComplianceDeterminationService).to receive(:compliant_for_monthly_income?).and_return(income_ok)
+    end
+
+    def determinations
+      Determination.unscope(:order).where(subject_id: certification.id)
+    end
+
+    def calculation_type
+      latest_determination_for(certification.id).determination_data["calculation_type"]
+    end
+
+    context "when the member has an open certification case" do
+      let!(:kase) { create(:certification_case, certification: certification) }
+
+      it "records an hours determination for an hours-only row" do
+        stub_thresholds(hours_ok: true, income_ok: false)
+
+        expect { described_class.create_entry(**params, hours: 100) }
+          .to change(determinations, :count).by(1)
+
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
+        expect(latest_determination_for(certification.id).outcome).to eq("compliant")
+        expect(kase.reload).to be_closed
+      end
+
+      it "records a not-compliant hours determination when hours fall short" do
+        stub_thresholds(hours_ok: false, income_ok: false)
+
+        described_class.create_entry(**params, hours: 100)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
+        expect(latest_determination_for(certification.id).outcome).to eq("not_compliant")
+      end
+
+      it "records an income determination for an income-only row" do
+        stub_thresholds(hours_ok: false, income_ok: true)
+
+        described_class.create_entry(**params, gross_income: 600)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_INCOME_BASED)
+        expect(latest_determination_for(certification.id).outcome).to eq("compliant")
+      end
+
+      # Hours take precedence, so income is not consulted at all.
+      it "records only the hours determination for a combined row whose hours qualify" do
+        stub_thresholds(hours_ok: true, income_ok: true)
+
+        described_class.create_entry(**params, hours: 100, gross_income: 600)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
+      end
+
+      it "falls through to income for a combined row whose hours fall short" do
+        stub_thresholds(hours_ok: false, income_ok: true)
+
+        described_class.create_entry(**params, hours: 100, gross_income: 600)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_INCOME_BASED)
+        expect(latest_determination_for(certification.id).outcome).to eq("compliant")
+      end
+
+      it "records a not-compliant income determination when neither track qualifies" do
+        stub_thresholds(hours_ok: false, income_ok: false)
+
+        described_class.create_entry(**params, hours: 100, gross_income: 600)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_INCOME_BASED)
+        expect(latest_determination_for(certification.id).outcome).to eq("not_compliant")
+      end
+
+      it "skips recalculation when recalculate_compliance is false" do
+        stub_thresholds(hours_ok: true, income_ok: true)
+
+        expect { described_class.create_entry(**params, hours: 100, recalculate_compliance: false) }
+          .not_to change(determinations, :count)
+      end
+
+      it "recalculates once for the whole submission, not once per entry" do
+        stub_thresholds(hours_ok: false, income_ok: false)
+        multi_month = params.merge(period_start: period_start, period_end: (period_start + 2.months).end_of_month)
+
+        expect { described_class.create_entries(**multi_month, hours: 300) }
+          .to change(determinations, :count).by(1)
+      end
+
+      it "recalculates only for a submission that created entries" do
+        stub_thresholds(hours_ok: false, income_ok: false)
+        described_class.create_entries(**params, hours: 100, name: "Acme Corp")
+
+        expect { described_class.create_entries(**params, hours: 100, name: "Acme Corp") }
+          .not_to change(determinations, :count)
+      end
+    end
+
+    context "when the member has no open certification case" do
+      it "creates the row without recording a determination" do
+        stub_thresholds(hours_ok: true, income_ok: true)
+
+        expect { described_class.create_entry(**params, hours: 100) }
+          .not_to change(Determination, :count)
+      end
+    end
+
+    context "when the case cannot be resolved" do
+      before { create(:certification_case, certification: certification) }
+
+      it "logs a warning rather than failing the save" do
+        stub_thresholds(hours_ok: true, income_ok: true)
+        allow(Certification).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+        allow(Rails.logger).to receive(:warn)
+
+        expect { described_class.create_entry(**params, hours: 100) }
+          .to change(ExternalActivity, :count).by(1)
+        expect(Rails.logger).to have_received(:warn).with(/skipped compliance recalculation/)
+      end
+    end
+  end
+
+  describe ".duplicate_entry?" do
+    let(:existing_entry) { create(:external_activity, :with_hours, :employment, origin_hash: "abc123") }
+
+    it "returns true when an entry with the origin hash exists" do
+      expect(described_class.duplicate_entry?(existing_entry.origin_hash)).to be true
+    end
+
+    it "returns false for an origin hash that has not been seen" do
+      existing_entry
+
+      expect(described_class.duplicate_entry?("def456")).to be false
+    end
+
+    it "returns false with no existing entries" do
+      expect(described_class.duplicate_entry?("abc123")).to be false
+    end
+
+    it "returns false for a blank origin hash, so unfingerprinted entries never match" do
+      create(:external_activity, :with_hours, :employment, origin_hash: nil)
+
+      expect(described_class.duplicate_entry?(nil)).to be false
+    end
+  end
+end

--- a/reporting-app/spec/services/external_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_activity_service_spec.rb
@@ -308,6 +308,23 @@ RSpec.describe ExternalActivityService do
         end
       end
 
+      context "with hours set to zero" do
+        let(:gross_income) { 300 }
+        let(:period_start) { 3.months.ago.beginning_of_month.to_date }
+        let(:period_end) { 1.month.ago.end_of_month.to_date }
+        let(:valid_params) { base_params.merge(gross_income:, hours: 0) }
+
+        it "has three months" do
+          expect(described_class.create_entries(**valid_params).size).to eq 3
+        end
+
+        it "apportions income equally by month" do
+          described_class.create_entries(**valid_params).each do |result|
+            expect(result.gross_income).to eq 100
+          end
+        end
+      end
+
       context "with 3 full months income not divisible by 3" do
         let(:gross_income) { 301.to_f }
         let(:period_start) { 3.months.ago.beginning_of_month.to_date }


### PR DESCRIPTION
## Ticket

Part of PBI-70969

## Changes

Adds `ExternalActivityService`, the single intake path for `ExternalActivity`, superseding
`ExternalHourlyActivityService` and `ExternalIncomeActivityService`. One submission may report hours,
gross income, or both, and is split into one entry per calendar month it touches.

- `ExternalActivityService` — `create_entries` / `create_entry` / `duplicate_entry?` taking `hours:`
  and `gross_income:` together, one fingerprint covering both values, every row written inside
  `Strata::AuditLog` under a single `external_activity.create` action, and one
  `recalculate_compliance:` keyword in place of the old per-track flags.
- `ActivityAggregator#apportioned_multi_values_map` — apportions several values across one set of
  month periods using the same weights. The cumulative-share arithmetic and weight selection are
  extracted so the single- and multi-value paths share them; `daily_values_map` and
  `monthly_values_map` keep their signatures.
- Compliance recalculation records **exactly one** determination per save: hours first, falling
  through to income only when hours fall short.
- Merged service spec (86 examples, replacing the two 391- and 589-line specs at cutover) and new
  `apportioned_multi_values_map` coverage.

Nothing calls `ExternalActivityService` yet — `Certifications::CreationService` still uses the old
pair, and the old services are untouched. This is purely additive, like the model in #70969's first
PR. The read-path and intake cutover follow in the next PR.

## Context for reviewers

`apportioned_multi_values_map` apportions each value over one shared set of month periods and keeps a
month when **any** value has a non-zero share; a value whose own share rounded away is left `nil` for
that month and rolled into a later one by the running total. `nil` rather than zero matters: the model
validates `greater_than: 0` with `allow_nil`, so a zero share would fail the save.

**Which split rule applies** is decided once per submission, from whether hours are present:

- hours present → both columns apportion **by days**
- income only → the existing income rule (evenly across whole calendar months, by days otherwise)

So adding hours to a payload changes how its income is apportioned. That falls out of keeping one
activity's two halves on the same boundaries, but it will look surprising in isolation.

**One determination, hours first.** Both determination services' `.calculate` methods aggregate *and*
record, so calling both for a combined row would write two `Determination` rows — and
`Determination.latest_per_subject` orders by `created_at`, so which one drove member status would
depend on insertion order. Instead `record_one_determination` decides the branch and records only the
winning track, building on the services' already-public `aggregate_*` and `compliant_for_*?` methods.

The open certification is resolved **once**, before either track: `open_certification_id_for_member`
filters on open cases and recording a compliant outcome closes the case, so a per-track lookup would
let a compliant close silently skip the second track.

Hours compliance is judged on monthly hours alone, matching
`HoursComplianceDeterminationService#calculate` — the education-enrollment track belongs to
`CommunityEngagementCheckService`, so consulting it here would quietly widen this outcome.

**Why the recalculation specs stub the threshold checks.** `ActivityAggregator` still fetches from the
superseded tables in this PR, so a freshly written `ExternalActivity` row does not appear in the
aggregates yet. The aggregates and both record paths run for real — real determination rows, real case
closure — but the compliant/not-compliant branch is driven by stubbing
`compliant_for_monthly_hours?` / `compliant_for_monthly_income?`. End-to-end figures become testable in
the cutover PR, once reads move to `external_activities`.

One behavioural note carried over from the schema: hours-bearing rows now get a `reported_at` (the
hours table had no such column) and can carry `metadata["employer"]`.

## Testing

`make lint` — 582 files inspected, no offenses.

Full suite:

```
3708 examples, 0 failures

Line coverage: 5826 / 6012 (96.90%)
Branch coverage: 1429 / 1698 (84.15%)
```

Up 94 examples from the previous PR, with coverage holding.

The merged service spec ports the full behaviour of both old specs — day-proportional hours splits
across partial months and year boundaries, even income splits for whole months, rounding that sums
back to the total without drift, `source_id` / `name` / `origin_hash` stamped across a submission,
reversed periods and blank values reaching the model as-is, and the duplicate rules including
household identity by tax ID and date of birth — then adds:

- Combined submissions: one entry per month carrying both values, both totals apportioned in full, and
  income apportioned by days rather than evenly because hours are present.
- Month alignment when one value's share rounds to zero: 300 hours with `0.02` income over
  Jan 31 – Mar 31 keeps all three months' hours, leaves income unset in January, and still sums both
  totals exactly.
- Fingerprint distinctness across the three shapes — the same total as income rather than hours, and
  adding income to an existing hours submission, are both new submissions rather than duplicates.
- All six recalculation branches, including that a combined row whose hours qualify records **only**
  the hours determination and never consults income, and that a combined row whose hours fall short
  records only the income one.
- Recalculation runs once per submission rather than once per monthly entry, and not at all for a
  duplicate that created nothing.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->