### PR TITLE
PBI-71081: evaluate exclusions from the application date

### DIFF
--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -91,4 +91,11 @@ class Certification < ApplicationRecord
   def region
     certification_requirements&.region
   end
+
+  # The month a member's exclusion status is evaluated for. Bound into the rules
+  # engine as the `evaluated_month` fact, which resolves by matching the ruleset's
+  # parameter name -- renaming one side without the other fails silently.
+  def evaluated_month
+    application_date&.beginning_of_month
+  end
 end

--- a/reporting-app/app/models/rules/exclusion_ruleset.rb
+++ b/reporting-app/app/models/rules/exclusion_ruleset.rb
@@ -12,71 +12,71 @@ module Rules
     # Incarceration excludes through this many months after the incarceration month
     INMATE_BUFFER_MONTHS = 3
 
-    def is_pregnant(pregnancy, postpartum, certification_date)
-      meets_end_condition(pregnancy, certification_date) || meets_end_condition(postpartum, certification_date)
+    def is_pregnant(pregnancy, postpartum, evaluated_month)
+      meets_end_condition(pregnancy, evaluated_month) || meets_end_condition(postpartum, evaluated_month)
     end
 
     def is_american_indian_or_alaska_native(american_indian_or_alaska_native)
       american_indian_or_alaska_native.present?
     end
 
-    def is_veteran_with_disability(veteran_disability, certification_date)
-      meets_end_condition(veteran_disability, certification_date)
+    def is_veteran_with_disability(veteran_disability, evaluated_month)
+      meets_end_condition(veteran_disability, evaluated_month)
     end
 
-    # Former foster youth are excluded until age FORMER_FOSTER_CARE_AGE_CAP, evaluated against the
-    # certification date at month granularity (consistent with pregnancy).
-    def former_foster_care(was_in_foster_care, date_of_birth, certification_date)
+    # Former foster youth are excluded until age FORMER_FOSTER_CARE_AGE_CAP, evaluated at month
+    # granularity (consistent with pregnancy).
+    def former_foster_care(was_in_foster_care, date_of_birth, evaluated_month)
       return if was_in_foster_care.nil?
-      return if date_of_birth.nil? || certification_date.nil?
+      return if date_of_birth.nil? || evaluated_month.nil?
 
-      certification_date.beginning_of_month < date_of_birth + FORMER_FOSTER_CARE_AGE_CAP.years
+      evaluated_month.beginning_of_month < date_of_birth + FORMER_FOSTER_CARE_AGE_CAP.years
     end
 
     # Members determined currently medically frail are excluded.
-    def medically_frail(medical_condition, certification_date)
-      meets_end_condition(medical_condition, certification_date)
+    def medically_frail(medical_condition, evaluated_month)
+      meets_end_condition(medical_condition, evaluated_month)
     end
 
-    # Caretakers are excluded if they are caretaking an infirm person during the certification month,
+    # Caretakers are excluded if they are caretaking an infirm person during the evaluated month,
     # or caring for a dependent child under CARETAKER_CHILD_AGE_THRESHOLD. Both windows are evaluated
-    # against the certification date at month granularity (consistent with the other date-based checks).
+    # at month granularity (consistent with the other date-based checks).
     # A caregiver_child period starts on the child's date of birth, one period per child.
-    def caretaker(caregiver_disability, caregiver_child, certification_date)
-      return if certification_date.nil?
+    def caretaker(caregiver_disability, caregiver_child, evaluated_month)
+      return if evaluated_month.nil?
 
-      cert_month = certification_date.beginning_of_month
+      month = evaluated_month.beginning_of_month
       caring_for_child = Array(caregiver_child&.periods).any? do |period|
         next unless period.period_start
 
-        period.period_start.beginning_of_month <= cert_month &&
-          cert_month < period.period_start + CARETAKER_CHILD_AGE_THRESHOLD.years
+        period.period_start.beginning_of_month <= month &&
+          month < period.period_start + CARETAKER_CHILD_AGE_THRESHOLD.years
       end
 
-      caring_for_child || meets_end_condition(caregiver_disability, certification_date)
+      caring_for_child || meets_end_condition(caregiver_disability, evaluated_month)
     end
 
     # Members already meeting SNAP/TANF work requirements are excluded.
-    def tanf_snap_work(meeting_tanf_or_snap_work, certification_date)
-      meets_end_condition(meeting_tanf_or_snap_work, certification_date)
+    def tanf_snap_work(meeting_tanf_or_snap_work, evaluated_month)
+      meets_end_condition(meeting_tanf_or_snap_work, evaluated_month)
     end
 
-    # Members participating in a drug/alcohol treatment program during the certification month are
+    # Members participating in a drug/alcohol treatment program during the evaluated month are
     # excluded (month granularity, consistent with the other date-based checks).
-    def drug_treatment(substance_treatment, certification_date)
-      meets_end_condition(substance_treatment, certification_date)
+    def drug_treatment(substance_treatment, evaluated_month)
+      meets_end_condition(substance_treatment, evaluated_month)
     end
 
     # Incarcerated members are excluded while incarcerated and for INMATE_BUFFER_MONTHS afterward,
-    # evaluated against the certification date at month granularity.
-    def inmate(incarceration, certification_date)
-      return if certification_date.nil?
+    # evaluated at month granularity.
+    def inmate(incarceration, evaluated_month)
+      return if evaluated_month.nil?
       return if incarceration.nil?
 
-      cert_month = certification_date.beginning_of_month
+      month = evaluated_month.beginning_of_month
       Array(incarceration.periods).any? do |period|
         next unless period.period_start && period.period_end
-        period.period_start.beginning_of_month <= cert_month && cert_month <= period.period_end.end_of_month + INMATE_BUFFER_MONTHS.months
+        period.period_start.beginning_of_month <= month && month <= period.period_end.end_of_month + INMATE_BUFFER_MONTHS.months
       end
     end
 
@@ -89,14 +89,14 @@ module Rules
 
     private
 
-    def meets_end_condition(member_data_exemption, certification_date)
-      return if certification_date.nil?
+    def meets_end_condition(member_data_exemption, evaluated_month)
+      return if evaluated_month.nil?
       return if member_data_exemption.nil?
 
-      cert_month = certification_date.beginning_of_month
+      month = evaluated_month.beginning_of_month
       Array(member_data_exemption.periods).any? do |period|
         next unless period.period_start && period.period_end
-        period.period_start.beginning_of_month <= cert_month && cert_month <= period.period_end.end_of_month
+        period.period_start.beginning_of_month <= month && month <= period.period_end.end_of_month
       end
     end
   end

--- a/reporting-app/app/services/exclusion_determination_service.rb
+++ b/reporting-app/app/services/exclusion_determination_service.rb
@@ -121,7 +121,7 @@ class ExclusionDeterminationService
       engine.set_facts(
         pregnancy: extract_exemption(certification, :pregnancy),
         postpartum: extract_exemption(certification, :postpartum),
-        certification_date: certification.certification_requirements.certification_date,
+        evaluated_month: certification.evaluated_month,
         american_indian_or_alaska_native: extract_exemption(certification, :american_indian_or_alaska_native),
         veteran_disability: extract_exemption(certification, :veteran_disability),
         was_in_foster_care: extract_exemption(certification, :former_foster_care),

--- a/reporting-app/spec/models/certification_spec.rb
+++ b/reporting-app/spec/models/certification_spec.rb
@@ -203,6 +203,20 @@ RSpec.describe Certification, type: :model do
     end
   end
 
+  describe '#evaluated_month' do
+    it 'returns the first of the month the member applied in' do
+      certification = build(:certification, application_date: Date.new(2026, 1, 15))
+
+      expect(certification.evaluated_month).to eq(Date.new(2026, 1, 1))
+    end
+
+    it 'returns nil when the certification has no application date' do
+      certification = build(:certification, application_date: nil)
+
+      expect(certification.evaluated_month).to be_nil
+    end
+  end
+
   describe 'outcome' do
     let(:certification) { create(:certification) }
 

--- a/reporting-app/spec/services/exclusion_determination_service_spec.rb
+++ b/reporting-app/spec/services/exclusion_determination_service_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ExclusionDeterminationService do
       create(
         :certification,
         member_data: member_data,
+        application_date: cert_date,
         certification_requirements: build(:certification_certification_requirements, certification_date: cert_date)
       )
     end
@@ -576,6 +577,45 @@ RSpec.describe ExclusionDeterminationService do
         end
       end
     end
+
+    # The two dates name different months, and only the application month falls
+    # inside the exemption period.
+    context 'when the application date and the certification date name different months' do
+      let(:application_month) { Date.new(2025, 7, 1) }
+      let(:certification) do
+        create(
+          :certification,
+          member_data: member_data,
+          application_date: application_month,
+          certification_requirements: build(
+            :certification_certification_requirements,
+            certification_date: Date.new(2025, 12, 1)
+          )
+        )
+      end
+      let(:exemptions) do
+        [
+          {
+            type: :pregnancy,
+            value: true,
+            verification_status: :verified,
+            periods: [
+              {
+                period_start: application_month,
+                period_end: application_month.end_of_month
+              }
+            ]
+          }
+        ]
+      end
+      let(:member_data) { build(:certification_member_data, exemptions:, cert_date: application_month) }
+
+      it 'evaluates the member for the application month' do
+        service.determine(kase)
+
+        expect(recorded_exclusion.reasons).to eq([ "pregnancy_excluded" ])
+      end
+    end
   end
 
   # After the rules engine runs, the service consults the registered verification
@@ -590,6 +630,7 @@ RSpec.describe ExclusionDeterminationService do
       create(
         :certification,
         member_data: member_data,
+        application_date: cert_date,
         certification_requirements: build(:certification_certification_requirements, certification_date: cert_date)
       )
     end


### PR DESCRIPTION
## Ticket

Resolves PBI-71081

## Changes

- `Certification#evaluated_month` returns `application_date.beginning_of_month`,
the single resolver for the month a member's exclusion status is evaluated for.
- `ExclusionDeterminationService` sets the rules-engine fact `evaluated_month`
from that resolver, replacing the `certification_date` it read off
`certification_requirements`.
- `Rules::ExclusionRuleset` renames the `certification_date` parameter to
`evaluated_month` across the eight date-based rules and `meets_end_condition`.
The comparison bodies are unchanged; the `cert_month` locals become `month`,
and the comments naming the certification date as the anchor are corrected.

## Context for reviewers

`certification_date` is being removed from the certifications API contract, so
the exclusion rules need a different anchor. They now take their month from
`application_date`. The demo tooling and batch upload write the same value to
both fields, and nothing in `app/`, `lib/` or `spec/` compares the two, so no
member's outcome changes.

`evaluated_month` is a method rather than an inline expression at the one call
site because it names a domain concept. The field it replaces was answering two
different questions, which month a member's status is evaluated for and which
months they must report activities on, and separating those is the point of this
ticket set. It sits on `Certification` because that is the only object holding
both candidate fields: `application_date` is a column, `certification_period_start`
is inside the `certification_requirements` jsonb. It will need updating when
recertification logic is introduced.

The rules engine binds facts by parameter name, so the fact key and the nine
parameters had to move together. A mismatch is silent: it resolves to nil, every
rule bails, and the member is reported as not excluded with nothing failing. The
rule bodies themselves needed no edits, since each already calls
`.beginning_of_month`, which a month-start Date makes idempotent.

## Testing

`make lint` clean (586 files, no offenses) and `make test` green (3571 examples,
0 failures; line 96.86%, branch 84.02%).

Coverage is two resolver specs plus one behavioural example, in which the
application date and the certification date name different months and only the
application month falls inside the exemption period.

Both were checked against mutated code rather than assumed. With the service
still feeding the certification date and the resolver left correct, that
behavioural example is the only one of 3571 that fails, so it is what proves the
repoint is wired rather than merely present. With the resolver returning the
certification date instead, the two resolver specs fail alongside it.

The existing exclusion fixtures had diverged: every exemption period is built
around `cert_date` of 2025-07-01 while the factory defaults `application_date`
to today, and the spec set the field zero times. Both `let` blocks now pin it
explicitly, rather than deriving it in the factory, so the diff shows which
fixtures depended on the anchor. Removing either pin fails loudly (11 examples
and 1).

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->