### PR TITLE
PBI-71083: derive the reportable months from the application date

### DIFF
--- a/reporting-app/app/forms/demo/certifications/create_form.rb
+++ b/reporting-app/app/forms/demo/certifications/create_form.rb
@@ -40,7 +40,7 @@ module Demo
           return false
         end
 
-        certification_requirements = certification_requirement_params.to_requirements
+        certification_requirements = certification_requirement_params.to_requirements(application_date:)
         if certification_requirements.invalid?
           errors.merge!(certification_requirements.errors)
           return false

--- a/reporting-app/app/models/api/certifications/create_request.rb
+++ b/reporting-app/app/models/api/certifications/create_request.rb
@@ -10,9 +10,12 @@ class Api::Certifications::CreateRequest < ValueObject
   attribute :household_data, Certifications::HouseholdData.to_type
 
   validates :certification_requirements, presence: true
-  # Not on RequirementParams: it is a union member whose valid? decides type dispatch, and this
-  # field is not in the nested requirements hash. See RequirementParams#to_requirements.
+  # application_date is a Certification attribute, not a RequirementParams one: RequirementParams'
+  # valid? doubles as type dispatch (UnionObject#new), so presence-validating application_date
+  # there would make every parameter-shaped request invalid, matching neither union member. See
+  # RequirementParams#to_requirements.
   validates :application_date, presence: true
+  validate :application_date_must_be_a_date
 
   def self.from_request_params(params)
     new_filtered(params)
@@ -32,5 +35,15 @@ class Api::Certifications::CreateRequest < ValueObject
 
     cert_attrs = attributes.merge({ certification_requirements: certification_requirements })
     Certification.new(cert_attrs)
+  end
+
+  private
+
+  # ActiveModel's date cast passes non-String values through untouched, so an
+  # integer, float, or array would otherwise reach months_that_can_be_certified and crash it.
+  def application_date_must_be_a_date
+    return if application_date.nil? || application_date.is_a?(Date)
+
+    errors.add(:application_date, :invalid)
   end
 end

--- a/reporting-app/app/models/api/certifications/create_request.rb
+++ b/reporting-app/app/models/api/certifications/create_request.rb
@@ -10,10 +10,6 @@ class Api::Certifications::CreateRequest < ValueObject
   attribute :household_data, Certifications::HouseholdData.to_type
 
   validates :certification_requirements, presence: true
-  # application_date is a Certification attribute, not a RequirementParams one: RequirementParams'
-  # valid? doubles as type dispatch (UnionObject#new), so presence-validating application_date
-  # there would make every parameter-shaped request invalid, matching neither union member. See
-  # RequirementParams#to_requirements.
   validates :application_date, presence: true
   validate :application_date_must_be_a_date
 

--- a/reporting-app/app/models/api/certifications/create_request.rb
+++ b/reporting-app/app/models/api/certifications/create_request.rb
@@ -10,6 +10,9 @@ class Api::Certifications::CreateRequest < ValueObject
   attribute :household_data, Certifications::HouseholdData.to_type
 
   validates :certification_requirements, presence: true
+  # Not on RequirementParams: it is a union member whose valid? decides type dispatch, and this
+  # field is not in the nested requirements hash. See RequirementParams#to_requirements.
+  validates :application_date, presence: true
 
   def self.from_request_params(params)
     new_filtered(params)
@@ -21,7 +24,7 @@ class Api::Certifications::CreateRequest < ValueObject
       # we are good to go
       certification_requirements = self.certification_requirements
     when Certifications::RequirementParams
-      certification_requirements = self.certification_requirements.to_requirements
+      certification_requirements = self.certification_requirements.to_requirements(application_date:)
     else
       # this should never be reached, something in the code is wrong
       raise TypeError

--- a/reporting-app/app/models/certification.rb
+++ b/reporting-app/app/models/certification.rb
@@ -65,8 +65,9 @@ class Certification < ApplicationRecord
   # (member_id + case_number + application_date). Used to make
   # POST /api/certifications idempotent for state-system integrations.
   # Returns nil if any key component is blank so unrelated records with
-  # missing values are never treated as duplicates. application_date will
-  # be required on create in a follow-up; keep this guard until then.
+  # missing values are never treated as duplicates.
+  # TODO: drop the application_date clause. CreateRequest validates it present now, so it is
+  # unreachable from the API. member_id and case_number are still unvalidated there.
   def self.find_duplicate(member_id:, case_number:, application_date:)
     return nil if member_id.blank? || case_number.blank? || application_date.blank?
 

--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -27,16 +27,17 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
     set_params_for_type(certification_type)
   end
 
-  # Keep the anchor an argument. RequirementParams is a union member whose valid? is type dispatch
-  # (UnionObject#new), and the application date is not in the nested requirements hash, so
-  # validating it here would match neither member. CreateRequest validates it.
+  # application_date stays a method argument rather than an attribute here: RequirementParams is a
+  # union member whose valid? doubles as type dispatch (UnionObject#new). Presence-validating
+  # application_date on this class would make every parameter-shaped request invalid, matching
+  # neither union member. CreateRequest validates application_date instead.
   def to_requirements(application_date:)
     Certifications::Requirements.new({
       "certification_date": certification_date,
       "certification_period_start": certification_period_start,
       "certification_period_end": certification_period_end,
       "certification_type": certification_type,
-      "months_that_can_be_certified": months_that_can_be_certified(application_date),
+      "months_that_can_be_certified": months_that_can_be_certified(application_date:),
       "number_of_months_to_certify": number_of_months_to_certify,
       "due_date": due_date,
       "region": region,
@@ -47,7 +48,7 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
   # Excludes the application month, which is still in progress.
   # TODO: recertifications should count forward from certification_period_start rather than back
   # from here. Deferred until the certification period contract is defined.
-  def months_that_can_be_certified(application_date)
+  def months_that_can_be_certified(application_date:)
     lookback_period.times.map { |i| application_date.beginning_of_month << (i + 1) }
   end
 

--- a/reporting-app/app/models/certifications/requirement_params.rb
+++ b/reporting-app/app/models/certifications/requirement_params.rb
@@ -27,13 +27,16 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
     set_params_for_type(certification_type)
   end
 
-  def to_requirements
+  # Keep the anchor an argument. RequirementParams is a union member whose valid? is type dispatch
+  # (UnionObject#new), and the application date is not in the nested requirements hash, so
+  # validating it here would match neither member. CreateRequest validates it.
+  def to_requirements(application_date:)
     Certifications::Requirements.new({
       "certification_date": certification_date,
       "certification_period_start": certification_period_start,
       "certification_period_end": certification_period_end,
       "certification_type": certification_type,
-      "months_that_can_be_certified": months_that_can_be_certified,
+      "months_that_can_be_certified": months_that_can_be_certified(application_date),
       "number_of_months_to_certify": number_of_months_to_certify,
       "due_date": due_date,
       "region": region,
@@ -41,9 +44,11 @@ class Certifications::RequirementParams < Certifications::RequirementTypeParams
     })
   end
 
-  # Excludes the certification month, which is still in progress.
-  def months_that_can_be_certified
-    lookback_period.times.map { |i| certification_date.beginning_of_month << (i + 1) }
+  # Excludes the application month, which is still in progress.
+  # TODO: recertifications should count forward from certification_period_start rather than back
+  # from here. Deferred until the certification period contract is defined.
+  def months_that_can_be_certified(application_date)
+    lookback_period.times.map { |i| application_date.beginning_of_month << (i + 1) }
   end
 
   private

--- a/reporting-app/app/services/certification_service.rb
+++ b/reporting-app/app/services/certification_service.rb
@@ -50,7 +50,9 @@ class CertificationService
     User.find_by(email: email)
   end
 
-  def certification_requirements_from_input(requirements_input)
+  # Required keyword: the batch chunk job rescues StandardError per row, so a nil anchor would
+  # persist rows with no reportable months instead of failing visibly.
+  def certification_requirements_from_input(requirements_input, application_date:)
     # if they've directly provided in a valid Certifications::Requirements, use it
     requirements = Certifications::Requirements.new_filtered(requirements_input)
     if requirements.valid?
@@ -62,7 +64,7 @@ class CertificationService
     requirement_params = Certifications::RequirementParams.new_filtered(requirements_input)
     requirement_params.validate!
 
-    requirement_params.to_requirements
+    requirement_params.to_requirements(application_date:)
   end
 
   def hydrate_cases_with_certifications!(cases)

--- a/reporting-app/app/services/unified_record_processor.rb
+++ b/reporting-app/app/services/unified_record_processor.rb
@@ -152,7 +152,13 @@ class UnifiedRecordProcessor
       "region" => record["region"]
     }.compact_blank
 
-    @certification_service.certification_requirements_from_input(requirement_input)
+    # Cast because the CSV holds dates as strings and the anchor is a plain argument now. Same cast
+    # the certification_date attribute applies, so an unparseable value becomes nil and fails
+    # RequirementParams' presence validation.
+    @certification_service.certification_requirements_from_input(
+      requirement_input,
+      application_date: ActiveModel::Type::Date.new.cast(record["certification_date"])
+    )
   end
 
   # Accepted (case-insensitive) spellings of a truthy pregnancy_status flag in an uploaded CSV.

--- a/reporting-app/lib/assets/oas.json
+++ b/reporting-app/lib/assets/oas.json
@@ -21,9 +21,9 @@
             "description": "An identifier for the case associated with the certification"
           },
           "application_date": {
-            "type": ["string", "null"],
+            "type": "string",
             "format": "date",
-            "description": "The date of the application"
+            "description": "The date of the application. The reportable months are counted back from it."
           },
           "certification_requirements": {
             "oneOf": [
@@ -47,6 +47,7 @@
         },
         "required": [
           "member_id",
+          "application_date",
           "certification_requirements"
         ],
         "examples": {
@@ -54,6 +55,7 @@
             "value": {
               "member_id": "123",
               "case_number": "C-111",
+              "application_date": "2025-09-26",
               "certification_requirements": {
                 "certification_date": "2025-09-26",
                 "certification_period_start": "2025-04-01",
@@ -107,6 +109,7 @@
             "value": {
               "member_id": "123",
               "case_number": "C-111",
+              "application_date": "2025-09-26",
               "certification_requirements": {
                 "certification_date": "2025-09-26",
                 "certification_period_start": "2025-04-01",
@@ -137,6 +140,7 @@
             "value": {
               "member_id": "123",
               "case_number": "C-111",
+              "application_date": "2025-09-26",
               "certification_requirements": {
                 "certification_date": "2025-09-26",
                 "certification_type": "new_application"

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -22,8 +22,8 @@ components:
         application_date:
           type: string
           format: date
-          description: The date of the application. The reportable months are counted back from
-            it.
+          description: The date of the application. The reportable months are counted
+            back from it.
         certification_requirements:
           oneOf:
           - "$ref": "#/components/schemas/CertificationRequirements"
@@ -798,73 +798,73 @@ components:
       required:
       - status
   responses:
-    bc7c38dbb4e2916d88f9b88eb44fa22d:
+    073240fcaa7624455eb9d53e12cb7a2d:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    9afdb3726a33dc35e26974a0cb274780:
+    44d3eb312a5fcc96a19f8b9ca4c71f9b:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    d15cbbb6d16291b24ee49dacef39672c:
+    aa1b1dff0cd5116de9a9582b14411a80:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    02fdf556205c7d87ca688358eddb1cc2:
+    dac415a1887259a7baf787e211888ab1:
       description: Created Certification.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    3bbbb103b123faca7637fa1bc8b682b1:
+    2b6591a7cc74f87548192ab39e4f46e7:
       description: Existing Certification returned for a duplicate request.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    502356f1b87aa203ffd31b5ed0cc8f77:
+    f23d163d4807eae6361f0c50b6f8e9e1:
       description: Accepted
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/d41d8cd98f00b204e9800998ecf8427e"
-    b8b8f820b57a6a75922e1398f6a6be9c:
+    f7813d0821aba29c6d8ffc616f5b3adb:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    978d6177e0d2ccfbd093ca1d896bf5a4:
+    6d2fe47dd2ebe9f861f122dc8bd792af:
       description: User error.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    13d18b977535cf849df9fadf399b7424:
+    34c6d9da514313c29d57bd230cae9db5:
       description: A Certification
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/CertificationResponseBody"
-    6da94a0dfecc83dff4623a39383d6229:
+    3c12514ec8c7213bd1c5dfd7d699d9e4:
       description: Not found.
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ErrorResponseBody"
-    c91c560fde58727adc71cfc80c8ab293:
+    9e28b5c59b375f7c3acef43fa9b7fde2:
       description: Response
       content:
         application/json:
           schema:
             "$ref": "#/components/schemas/ece4f2c15f241af4536e1132d15a279a"
-    f573b9a1be171e8a7818fba6d6ca7aed:
+    6af3fd92654af0ab31a6afe9e920a35e:
       description: Response
       content:
         application/json:
@@ -896,7 +896,7 @@ components:
         type: string
       style: simple
   requestBodies:
-    775e6784240822e9287ef6cd1b591b2a:
+    5224b3f19b15cd6450bbc08d07d7a681:
       description: The Certification data.
       content:
         application/json:
@@ -989,11 +989,11 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/bc7c38dbb4e2916d88f9b88eb44fa22d"
+          "$ref": "#/components/responses/073240fcaa7624455eb9d53e12cb7a2d"
         '202':
-          "$ref": "#/components/responses/9afdb3726a33dc35e26974a0cb274780"
+          "$ref": "#/components/responses/44d3eb312a5fcc96a19f8b9ca4c71f9b"
         '404':
-          "$ref": "#/components/responses/d15cbbb6d16291b24ee49dacef39672c"
+          "$ref": "#/components/responses/aa1b1dff0cd5116de9a9582b14411a80"
       security:
       - hmac: []
       deprecated: false
@@ -1007,18 +1007,18 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/4f7cce241e43c9b4680b65e2612ab599"
       requestBody:
-        "$ref": "#/components/requestBodies/775e6784240822e9287ef6cd1b591b2a"
+        "$ref": "#/components/requestBodies/5224b3f19b15cd6450bbc08d07d7a681"
       responses:
         '201':
-          "$ref": "#/components/responses/02fdf556205c7d87ca688358eddb1cc2"
+          "$ref": "#/components/responses/dac415a1887259a7baf787e211888ab1"
         '200':
-          "$ref": "#/components/responses/3bbbb103b123faca7637fa1bc8b682b1"
+          "$ref": "#/components/responses/2b6591a7cc74f87548192ab39e4f46e7"
         '202':
-          "$ref": "#/components/responses/502356f1b87aa203ffd31b5ed0cc8f77"
+          "$ref": "#/components/responses/f23d163d4807eae6361f0c50b6f8e9e1"
         '400':
-          "$ref": "#/components/responses/b8b8f820b57a6a75922e1398f6a6be9c"
+          "$ref": "#/components/responses/f7813d0821aba29c6d8ffc616f5b3adb"
         '422':
-          "$ref": "#/components/responses/978d6177e0d2ccfbd093ca1d896bf5a4"
+          "$ref": "#/components/responses/6d2fe47dd2ebe9f861f122dc8bd792af"
       security:
       - hmac: []
       deprecated: false
@@ -1033,9 +1033,9 @@ paths:
       - "$ref": "#/components/parameters/49e46dd8af57e26752938ebb0d0ec979"
       responses:
         '200':
-          "$ref": "#/components/responses/13d18b977535cf849df9fadf399b7424"
+          "$ref": "#/components/responses/34c6d9da514313c29d57bd230cae9db5"
         '404':
-          "$ref": "#/components/responses/6da94a0dfecc83dff4623a39383d6229"
+          "$ref": "#/components/responses/3c12514ec8c7213bd1c5dfd7d699d9e4"
       security:
       - hmac: []
       deprecated: false
@@ -1070,9 +1070,9 @@ paths:
       operationId: GET_api_health
       responses:
         '200':
-          "$ref": "#/components/responses/c91c560fde58727adc71cfc80c8ab293"
+          "$ref": "#/components/responses/9e28b5c59b375f7c3acef43fa9b7fde2"
         '503':
-          "$ref": "#/components/responses/f573b9a1be171e8a7818fba6d6ca7aed"
+          "$ref": "#/components/responses/6af3fd92654af0ab31a6afe9e920a35e"
       security:
       - hmac: []
       deprecated: false

--- a/reporting-app/openapi.generated.yml
+++ b/reporting-app/openapi.generated.yml
@@ -20,11 +20,10 @@ components:
           - 'null'
           description: An identifier for the case associated with the certification
         application_date:
-          type:
-          - string
-          - 'null'
+          type: string
           format: date
-          description: The date of the application
+          description: The date of the application. The reportable months are counted back from
+            it.
         certification_requirements:
           oneOf:
           - "$ref": "#/components/schemas/CertificationRequirements"
@@ -40,12 +39,14 @@ components:
           - type: 'null'
       required:
       - member_id
+      - application_date
       - certification_requirements
       examples:
         fully_specified_certification_requirements:
           value:
             member_id: '123'
             case_number: C-111
+            application_date: '2025-09-26'
             certification_requirements:
               certification_date: '2025-09-26'
               certification_period_start: '2025-04-01'
@@ -87,6 +88,7 @@ components:
           value:
             member_id: '123'
             case_number: C-111
+            application_date: '2025-09-26'
             certification_requirements:
               certification_date: '2025-09-26'
               certification_period_start: '2025-04-01'
@@ -111,6 +113,7 @@ components:
           value:
             member_id: '123'
             case_number: C-111
+            application_date: '2025-09-26'
             certification_requirements:
               certification_date: '2025-09-26'
               certification_type: new_application

--- a/reporting-app/spec/factories/certifications/certification_requirements_factory.rb
+++ b/reporting-app/spec/factories/certifications/certification_requirements_factory.rb
@@ -4,7 +4,9 @@ FactoryBot.define do
   factory :certification_certification_requirements, class: Certifications::Requirements do
     certification_date { Faker::Date.forward(days: 30) }
     number_of_months_to_certify { Faker::Number.within(range: 1..3) }
-    # Mirrors Certifications::RequirementParams#months_that_can_be_certified.
+    # TODO: repoint to application_date. Production anchors there, and certifications_factory
+    # defaults it to Date.current while this defaults up to 30 days ahead, so a factory-built
+    # certification's months do not match what production would derive for it.
     months_that_can_be_certified do
       Faker::Number.between(
         from: number_of_months_to_certify,

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -4,10 +4,12 @@ require "rails_helper"
 
 RSpec.describe Certifications::RequirementParams do
   describe "#months_that_can_be_certified" do
-    subject(:months) { params.months_that_can_be_certified }
+    subject(:months) { params.months_that_can_be_certified(application_date) }
 
-    let(:certification_date) { Date.new(2026, 8, 20) }
-    let(:cert_date_start) { certification_date.beginning_of_month }
+    let(:application_date) { Date.new(2026, 8, 20) }
+    let(:application_month) { application_date.beginning_of_month }
+    # Different month from the anchor, so these examples prove the months follow the argument.
+    let(:certification_date) { Date.new(2026, 2, 3) }
     let(:params) do
       build(
         :certification_certification_requirement_params,
@@ -21,41 +23,63 @@ RSpec.describe Certifications::RequirementParams do
     context "with a multi-month lookback" do
       let(:lookback_period) { 3 }
 
-      it "returns the lookback_period months ending the month before the certification month" do
+      it "returns the lookback_period months ending the month before the application month" do
         expect(months).to eq [ Date.new(2026, 7, 1), Date.new(2026, 6, 1), Date.new(2026, 5, 1) ]
       end
 
-      it "excludes the certification month" do
-        expect(months).not_to include cert_date_start
+      it "ends the month before the application month" do
+        expect(months.max).to eq application_month << 1
       end
     end
 
     context "with a single-month lookback" do
       let(:lookback_period) { 1 }
 
-      it "returns only the month before the certification month" do
-        expect(months).to eq [ cert_date_start << 1 ]
+      it "returns only the month before the application month" do
+        expect(months).to eq [ application_month << 1 ]
       end
     end
 
     context "when the window crosses a year boundary" do
       let(:lookback_period) { 2 }
 
-      let(:certification_date) { Date.new(2026, 1, 15) }
+      let(:application_date) { Date.new(2026, 1, 15) }
 
       it "walks back into the previous year" do
         expect(months).to eq [ Date.new(2025, 12, 1), Date.new(2025, 11, 1) ]
       end
     end
+
+    context "when the application date and the certification date disagree" do
+      let(:lookback_period) { 2 }
+
+      it "counts from the application date" do
+        expect(months).to eq [ Date.new(2026, 7, 1), Date.new(2026, 6, 1) ]
+      end
+
+      it "returns the same months whatever the certification date carries" do
+        moved = build(
+          :certification_certification_requirement_params,
+          certification_date: Date.new(2020, 12, 25),
+          lookback_period: lookback_period,
+          number_of_months_to_certify: 1,
+          due_period_days: 30
+        )
+
+        expect(moved.months_that_can_be_certified(application_date)).to eq months
+      end
+    end
   end
 
   describe "#to_requirements" do
-    subject(:requirements) { params.to_requirements }
+    subject(:requirements) { params.to_requirements(application_date:) }
 
     let(:lookback_period) { 6 }
-    let(:certification_date) { Date.new(2026, 8, 20) }
-    let(:expected_start) { certification_date.beginning_of_month << lookback_period }
-    let(:expected_end) { certification_date.beginning_of_month << 1 }
+    let(:application_date) { Date.new(2026, 8, 20) }
+    # Different month from the anchor, so the carried months cannot have come from this field.
+    let(:certification_date) { Date.new(2026, 2, 3) }
+    let(:expected_start) { application_date.beginning_of_month << lookback_period }
+    let(:expected_end) { application_date.beginning_of_month << 1 }
 
     let(:params) do
       build(
@@ -72,7 +96,7 @@ RSpec.describe Certifications::RequirementParams do
       expect(requirements.months_that_can_be_certified.max).to eq expected_end
     end
 
-    it "produces a continuous lookback period ending the month before the certification month" do
+    it "produces a continuous lookback period ending the month before the application month" do
       lookback = requirements.continuous_lookback_period
 
       expect(lookback.start).to eq expected_start
@@ -81,11 +105,12 @@ RSpec.describe Certifications::RequirementParams do
   end
 
   describe "#to_requirements certification period bounds" do
-    subject(:requirements) { params.to_requirements }
+    subject(:requirements) { params.to_requirements(application_date:) }
 
     # Coverage runs Jan to Jun and the renewal is requested in May, so the period
     # supplied is the currently active one, not the upcoming one.
-    let(:certification_date) { Date.new(2026, 5, 20) }
+    let(:application_date) { Date.new(2026, 5, 20) }
+    let(:certification_date) { Date.new(2026, 2, 3) }
     let(:params) do
       build(
         :certification_certification_requirement_params, :with_direct_params,
@@ -123,12 +148,13 @@ RSpec.describe Certifications::RequirementParams do
     # as its type dispatch. Validating here is what production actually does.
     subject(:requirements) do
       params.valid?
-      params.to_requirements
+      params.to_requirements(application_date:)
     end
 
-    # Sits well away from today, so anchoring on the certification date is
-    # distinguishable from anchoring on the day the request is processed.
-    let(:certification_date) { Date.new(2026, 11, 20) }
+    # Both sit well away from today, so a due date anchored on either is distinguishable from one
+    # anchored on the processing date.
+    let(:application_date) { Date.new(2026, 11, 20) }
+    let(:certification_date) { Date.new(2026, 2, 3) }
 
     around { |example| freeze_time { example.run } }
 

--- a/reporting-app/spec/models/certifications/requirement_params_spec.rb
+++ b/reporting-app/spec/models/certifications/requirement_params_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Certifications::RequirementParams do
   describe "#months_that_can_be_certified" do
-    subject(:months) { params.months_that_can_be_certified(application_date) }
+    subject(:months) { params.months_that_can_be_certified(application_date:) }
 
     let(:application_date) { Date.new(2026, 8, 20) }
     let(:application_month) { application_date.beginning_of_month }
@@ -66,7 +66,7 @@ RSpec.describe Certifications::RequirementParams do
           due_period_days: 30
         )
 
-        expect(moved.months_that_can_be_certified(application_date)).to eq months
+        expect(moved.months_that_can_be_certified(application_date:)).to eq months
       end
     end
   end

--- a/reporting-app/spec/models/certifications/requirements_spec.rb
+++ b/reporting-app/spec/models/certifications/requirements_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Certifications::Requirements do
   end
 
   describe "supplied period bounds" do
+    # Different month from the "2026-05-20" the examples send, so a wrong anchor would show.
+    let(:application_date) { Date.new(2026, 8, 20) }
     let(:bounds) do
       {
         "certification_period_start" => "2026-01-01",
@@ -60,7 +62,9 @@ RSpec.describe Certifications::Requirements do
       expect(input.certification_period_start).to eq Date.new(2026, 1, 1)
     end
 
-    it "survives a parameter-shaped request" do
+    # Load-bearing: this hash carries no application date, and UnionObject#new dispatches on
+    # valid?, so presence-validating application_date on RequirementParams would break it.
+    it "survives a parameter-shaped request, which carries no application date" do
       input = Api::Certifications::RequirementsOrParamsInput.new(
         bounds.merge(
           "certification_date" => "2026-05-20",
@@ -71,7 +75,25 @@ RSpec.describe Certifications::Requirements do
       )
 
       expect(input).to be_a(Certifications::RequirementParams)
-      expect(input.to_requirements.certification_period_start).to eq Date.new(2026, 1, 1)
+      expect(input.to_requirements(application_date:).certification_period_start).to eq Date.new(2026, 1, 1)
+    end
+
+    # A nested application date is dropped by new_filtered; the anchor comes from the top level.
+    # Guards against promoting it to an attribute, which would put it into the union dispatch.
+    it "ignores an application date nested inside the requirements hash" do
+      input = Api::Certifications::RequirementsOrParamsInput.new(
+        bounds.merge(
+          "certification_date" => "2026-05-20",
+          "application_date" => "2020-01-01",
+          "lookback_period" => 6,
+          "number_of_months_to_certify" => 3,
+          "due_period_days" => 30
+        )
+      )
+
+      expect(input).to be_a(Certifications::RequirementParams)
+      expect(input.to_requirements(application_date:).months_that_can_be_certified.max)
+        .to eq(application_date.beginning_of_month << 1)
     end
 
     it "survives batch upload input" do
@@ -79,7 +101,8 @@ RSpec.describe Certifications::Requirements do
         bounds.merge(
           "certification_date" => "2026-05-20",
           "certification_type" => "recertification"
-        )
+        ),
+        application_date: application_date
       )
 
       expect(requirements.certification_period_start).to eq Date.new(2026, 1, 1)

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -995,8 +995,6 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
-      # These two used to assert an undated request bypassed duplicate detection. It is rejected
-      # now; find_duplicate's blank guard is covered in spec/models/certification_spec.rb.
       it "rejects a request carrying no application_date" do
         params = valid_json_request_attributes.except(:application_date).merge(
           member_id: "no-app-date",
@@ -1027,6 +1025,25 @@ RSpec.describe "/api/certifications", type: :request do
           post api_certifications_url,
                params: undated_attributes,
                headers: auth_headers(undated_attributes),
+               as: :json
+        }.not_to change(Certification, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "application_date"))
+        expect(response).to match_openapi_doc(OPENAPI_DOC)
+      end
+
+      it "rejects a request whose application_date is not a date" do
+        params = valid_json_request_attributes.merge(
+          application_date: 12_345,
+          member_id: "bad-app-date",
+          case_number: "C-BAD"
+        )
+
+        expect {
+          post api_certifications_url,
+               params: params,
+               headers: auth_headers(params),
                as: :json
         }.not_to change(Certification, :count)
 

--- a/reporting-app/spec/requests/api/certifications_spec.rb
+++ b/reporting-app/spec/requests/api/certifications_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe "/api/certifications", type: :request do
   include Warden::Test::Helpers
 
   let(:member_user) { create(:user) }
+  let(:application_date) { Date.new(2025, 10, 16) }
   let(:valid_json_request_attributes) {
     {
       member_id: "foobar",
-      application_date: "2025-10-16",
+      application_date: application_date.to_s,
       member_data: {
         account_email: member_user.email,
         name: {
@@ -198,7 +199,30 @@ RSpec.describe "/api/certifications", type: :request do
 
         requirement_params.validate
         cert = Certification.find(response.parsed_body[:id])
-        expect(cert.certification_requirements).to eq(requirement_params.to_requirements)
+        expect(cert.certification_requirements).to eq(requirement_params.to_requirements(application_date:))
+      end
+    end
+
+    context "when the application date and the nested certification date differ" do
+      it "counts the reportable months from the application date" do
+        requirement_params = build(
+          :certification_certification_requirement_params, :with_direct_params,
+          certification_date: Date.new(2024, 3, 9)
+        )
+        params = valid_json_request_attributes.merge({
+          certification_requirements: requirement_params.as_json
+        })
+
+        post api_certifications_url,
+             params: params,
+             headers: auth_headers(params),
+             as: :json
+
+        expect(response).to have_http_status(:created)
+
+        cert = Certification.find(response.parsed_body[:id])
+        expect(cert.certification_requirements.months_that_can_be_certified.max)
+          .to eq(application_date.beginning_of_month << 1)
       end
     end
 
@@ -872,7 +896,6 @@ RSpec.describe "/api/certifications", type: :request do
     end
 
     context "when a duplicate request is submitted" do
-      let(:application_date) { Date.new(2025, 10, 16) }
       let(:duplicate_attributes) {
         valid_json_request_attributes.merge(
           member_id: "dup-member",
@@ -972,30 +995,27 @@ RSpec.describe "/api/certifications", type: :request do
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
-      it "creates a new certification when no application_date is provided" do
+      # These two used to assert an undated request bypassed duplicate detection. It is rejected
+      # now; find_duplicate's blank guard is covered in spec/models/certification_spec.rb.
+      it "rejects a request carrying no application_date" do
         params = valid_json_request_attributes.except(:application_date).merge(
           member_id: "no-app-date",
           case_number: "C-NAD"
         )
-
-        post api_certifications_url,
-             params: params,
-             headers: auth_headers(params),
-             as: :json
-        expect(response).to have_http_status(:created)
 
         expect {
           post api_certifications_url,
                params: params,
                headers: auth_headers(params),
                as: :json
-        }.to change(Certification, :count).by(1)
+        }.not_to change(Certification, :count)
 
-        expect(response).to have_http_status(:created)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "application_date"))
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
 
-      it "creates a new certification when a dated request is replayed without application_date" do
+      it "rejects a dated request replayed without its application_date" do
         post api_certifications_url,
              params: duplicate_attributes,
              headers: auth_headers(duplicate_attributes),
@@ -1008,9 +1028,10 @@ RSpec.describe "/api/certifications", type: :request do
                params: undated_attributes,
                headers: auth_headers(undated_attributes),
                as: :json
-        }.to change(Certification, :count).by(1)
+        }.not_to change(Certification, :count)
 
-        expect(response).to have_http_status(:created)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body["errors"]).to include(a_hash_including("field" => "application_date"))
         expect(response).to match_openapi_doc(OPENAPI_DOC)
       end
     end

--- a/reporting-app/spec/services/certifications/creation_service_spec.rb
+++ b/reporting-app/spec/services/certifications/creation_service_spec.rb
@@ -5,14 +5,18 @@ require "rails_helper"
 RSpec.describe Certifications::CreationService, type: :service do
   let(:member_id) { "member-123" }
   let(:case_number) { "case-456" }
-  let(:certification_date) { Date.new(2025, 12, 25) }
-  let(:latest_certifiable_month) { certification_date << 1 }
+  let(:application_date) { Date.new(2025, 12, 25) }
+  # Equal by default, as both creation paths send one value, so every example below is unchanged.
+  let(:certification_date) { application_date }
+  # Fixtures must be placed relative to the anchor to fall inside the lookback.
+  let(:latest_certifiable_month) { application_date << 1 }
   let(:household_data) { {} }
 
   let(:base_params) do
     {
       member_id: member_id,
       case_number: case_number,
+      application_date: application_date,
       member_data: member_data.as_json,
       household_data: household_data.as_json,
       certification_requirements: build(:certification_certification_requirement_params,
@@ -636,6 +640,50 @@ RSpec.describe Certifications::CreationService, type: :service do
         expect(ExternalActivity.with_income.count).to eq(1)
         expect(CertificationOrigin.count).to eq(1)
         expect(Rails.logger).to have_received(:warn).with(/skipped duplicate submission/)
+      end
+    end
+  end
+
+  describe "the reportable months anchor" do
+    # Reads the months off the request without calling the service, so no member data is needed.
+    let(:member_data) { {} }
+    # Pinned: :with_direct_params randomises it and two examples compare separate requests.
+    let(:lookback_period) { 4 }
+
+    def months_for(certification_date:)
+      request = Api::Certifications::CreateRequest.new(
+        **base_params.merge(
+          certification_requirements: build(
+            :certification_certification_requirement_params, :with_direct_params,
+            certification_date: certification_date,
+            lookback_period: lookback_period
+          ).as_json
+        )
+      )
+
+      request.to_certification.certification_requirements.months_that_can_be_certified
+    end
+
+    it "counts the months back from the application date" do
+      expect(months_for(certification_date: application_date).max)
+        .to eq(application_date.beginning_of_month << 1)
+    end
+
+    context "when the request carries a certification date from a different month" do
+      let(:disagreeing_date) { Date.new(2024, 3, 9) }
+
+      it "still counts from the application date" do
+        expect(months_for(certification_date: disagreeing_date).max)
+          .to eq(application_date.beginning_of_month << 1)
+      end
+
+      it "records the months it would record with the two dates in agreement" do
+        expect(months_for(certification_date: disagreeing_date))
+          .to eq(months_for(certification_date: application_date))
+      end
+
+      it "records as many months as the lookback period asks for" do
+        expect(months_for(certification_date: disagreeing_date).length).to eq(lookback_period)
       end
     end
   end


### PR DESCRIPTION
## Ticket

Resolves PBI-71083

## Changes

- `Certifications::RequirementParams#months_that_can_be_certified` takes the
anchor as an argument and counts back from the application date rather than
`certification_date`. `#to_requirements` gains a required `application_date:`
keyword to pass it through. The arithmetic is unchanged.
- `Api::Certifications::CreateRequest` validates `application_date` present and
threads it into `to_requirements`.
- `CertificationService#certification_requirements_from_input` gains a required
`application_date:` keyword. `UnifiedRecordProcessor` passes the value it
already writes to the column, cast explicitly because the CSV holds dates as
strings.
- `Demo::Certifications::CreateForm` passes the anchor it already holds.
- `Certification.find_duplicate` keeps its blank guard, with a TODO on the
`application_date` clause this makes unreachable from the API.
- `oas.json` and `openapi.generated.yml` mark `application_date` required and
non-nullable, and all three request examples carry it.

## Context for reviewers

The anchor is a method argument rather than an attribute on `RequirementParams`,
which is load-bearing. That class is a union member and `UnionObject#new` returns
the first member that is `valid?`, so any presence validation on it is also type
dispatch. The application date is not in the nested requirements hash, so
validating it there would match neither member and reject every request.
`CreateRequest` validates it instead.

Deriving a recertification's months from its certification period stays out of
scope, deferred until the certification period contract is defined. Every type still
counts backwards,
so this is behaviour-preserving. The derivation carries a TODO.

Two API specs flipped from 201 to 422. They asserted that an undated request
bypassed duplicate detection, which the API can no longer express;
`find_duplicate` keeps its coverage at the model level.

## Testing

`make lint` clean (586 files, no offenses) and `make test` green (3589 examples,
0 failures; line 96.86%, branch 84.22%).

Coverage is the months following the application date when the two dates differ,
asserted at unit, service and request level; a request with no application date
rejected naming the field; and a nested `application_date` in the requirements
hash ignored rather than becoming the anchor. The service-level example compares
two real requests rather than a literal, so it cannot drift as the factories
change.

Running it caught what reading did not: the batch path passed the raw CSV string,
since moving the value out of an attribute moved it out of the date cast it had
been getting for free.

No migration, so E2E is a real signal here rather than the usual migration-PR
noise.

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->