### PR TITLE
PBI-70969: aggregate hours and income when necessary

### DIFF
--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -252,8 +252,16 @@ class CertificationCase < Strata::Case
   # drop the case). Income silent recalculation is aligned via +record_income_compliance+.
   # @param outcome [Symbol] :compliant or :not_compliant
   # @param hours_data [Hash] aggregated hours data
-  def record_hours_compliance(outcome, hours_data)
-    reason_key = outcome == :compliant ? :hours_reported_compliant : :hours_reported_insufficient
+  def record_hours_compliance(outcome, hours_data, with_income_conversion: false)
+    reason_key = if outcome == :compliant
+                   if with_income_conversion
+                     :combined_hours_reported_compliant
+                   else
+                     :hours_reported_compliant
+                   end
+    else
+                   :hours_reported_insufficient
+    end
     record_automated_ce_compliance(
       outcome,
       Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -310,9 +310,9 @@ class CertificationCase < Strata::Case
     )
   end
 
-  # External CE check: one automated determination with both tracks in +determination_data+.
-  # Member is compliant if either +hours_ok+ or +income_ok+; not compliant only when both are false.
-  # Events/notifications are published by CommunityEngagementCheckService (via Strata).
+  # External CE check: every track assessed in one automated determination's +determination_data+.
+  # Member is compliant if any of +hours_ok+, +income_ok+ or +combined_hours_ok+; not compliant only
+  # when all are false. Events/notifications are published by CommunityEngagementCheckService (via Strata).
   #
   # @param actor [Strata::VirtualActor] recording the assessment
   # @param certification [Certification] aggregate root for +record_determination!+
@@ -320,14 +320,23 @@ class CertificationCase < Strata::Case
   # @param income_data [Hash] from IncomeComplianceDeterminationService.aggregate_income_for_certification
   # @param hours_ok [Boolean]
   # @param income_ok [Boolean]
-  def record_external_ce_combined_assessment(actor:, certification:, hours_data:, income_data:, hours_ok:, income_ok:)
-    outcome = (hours_ok || income_ok) ? :compliant : :not_compliant
-    reasons = external_ce_combined_reason_codes(outcome: outcome, hours_ok: hours_ok, income_ok: income_ok)
+  # @param combined_hours_data [Hash, nil] hours aggregated with earned income imputed as hours
+  #   (+with_income_conversion+); nil unless the fallback was consulted
+  # @param combined_hours_ok [Boolean, nil] nil unless the fallback was consulted; goes with
+  #   +combined_hours_data+
+  def record_external_ce_combined_assessment(actor:, certification:, hours_data:, income_data:, hours_ok:, income_ok:,
+                                             combined_hours_data: nil, combined_hours_ok: nil)
+    outcome = (hours_ok || income_ok || combined_hours_ok) ? :compliant : :not_compliant
+    reasons = external_ce_combined_reason_codes(
+      outcome: outcome, hours_ok: hours_ok, income_ok: income_ok, combined_hours_ok: combined_hours_ok
+    )
     determination_data = Determinations::ExternalCECombinedDeterminationData.build(
       hours_data: hours_data,
       income_data: income_data,
       hours_ok: hours_ok,
-      income_ok: income_ok
+      income_ok: income_ok,
+      combined_hours_data: combined_hours_data,
+      combined_hours_ok: combined_hours_ok
     ).to_h
 
     record_automated_ce_compliance(
@@ -384,11 +393,13 @@ class CertificationCase < Strata::Case
     end
   end
 
-  def external_ce_combined_reason_codes(outcome:, hours_ok:, income_ok:)
+  def external_ce_combined_reason_codes(outcome:, hours_ok:, income_ok:, combined_hours_ok: nil)
     if outcome == :compliant
       [].tap do |codes|
         codes << Determination::REASON_CODE_MAPPING[:hours_reported_compliant] if hours_ok
         codes << Determination::REASON_CODE_MAPPING[:income_reported_compliant] if income_ok
+        # Never alongside the two above: the combined track is only reached once both have failed.
+        codes << Determination::REASON_CODE_MAPPING[:combined_hours_reported_compliant] if combined_hours_ok
       end
     else
       [

--- a/reporting-app/app/models/certification_case.rb
+++ b/reporting-app/app/models/certification_case.rb
@@ -252,16 +252,8 @@ class CertificationCase < Strata::Case
   # drop the case). Income silent recalculation is aligned via +record_income_compliance+.
   # @param outcome [Symbol] :compliant or :not_compliant
   # @param hours_data [Hash] aggregated hours data
-  def record_hours_compliance(outcome, hours_data, with_income_conversion: false)
-    reason_key = if outcome == :compliant
-                   if with_income_conversion
-                     :combined_hours_reported_compliant
-                   else
-                     :hours_reported_compliant
-                   end
-    else
-                   :hours_reported_insufficient
-    end
+  def record_hours_compliance(outcome, hours_data)
+    reason_key = outcome == :compliant ? :hours_reported_compliant : :hours_reported_insufficient
     record_automated_ce_compliance(
       outcome,
       Determinations::HoursBasedDeterminationData.from_aggregate(hours_data).to_h,
@@ -321,9 +313,7 @@ class CertificationCase < Strata::Case
   # @param hours_ok [Boolean]
   # @param income_ok [Boolean]
   # @param combined_hours_data [Hash, nil] hours aggregated with earned income imputed as hours
-  #   (+with_income_conversion+); nil unless the fallback was consulted
-  # @param combined_hours_ok [Boolean, nil] nil unless the fallback was consulted; goes with
-  #   +combined_hours_data+
+  # @param combined_hours_ok [Boolean, nil] both are nil unless the fallback was consulted
   def record_external_ce_combined_assessment(actor:, certification:, hours_data:, income_data:, hours_ok:, income_ok:,
                                              combined_hours_data: nil, combined_hours_ok: nil)
     outcome = (hours_ok || income_ok || combined_hours_ok) ? :compliant : :not_compliant

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -112,7 +112,8 @@ class Determination < Strata::Determination
   # CALCULATION_TYPE_DATA_SOURCE_CE when a data source is what attested it.
   CE_MET_REASON_CODES = {
     hours_reported_compliant: "hours_reported_compliant",
-    income_reported_compliant: "income_reported_compliant"
+    income_reported_compliant: "income_reported_compliant",
+    combined_hours_reported_compliant: "combined_hours_reported_compliant"
   }.freeze
 
   # Neither community-engagement track reached its threshold. Recorded as +:not_compliant+.

--- a/reporting-app/app/models/determination.rb
+++ b/reporting-app/app/models/determination.rb
@@ -62,6 +62,8 @@ class Determination < Strata::Determination
   SATISFIED_BY_BOTH = "both"
   SATISFIED_BY_HOURS = "hours"
   SATISFIED_BY_INCOME = "income"
+  # Neither track passed on its own, but reported hours plus hours imputed from earned income did.
+  SATISFIED_BY_COMBINED_HOURS = "combined_hours"
   SATISFIED_BY_NEITHER = "neither"
   CALCULATION_METHOD_AUTOMATED_INCOME_INTAKE = "automated_income_intake"
 

--- a/reporting-app/app/models/determinations/external_ce_combined_determination_data.rb
+++ b/reporting-app/app/models/determinations/external_ce_combined_determination_data.rb
@@ -10,38 +10,57 @@ module Determinations
   #
   # Nested {HoursBasedDeterminationData} and {IncomeBasedDeterminationData} are validated during
   # {.build} (eager), not only when {#to_h} serializes, so invalid inner aggregates raise before persist.
+  #
+  # The combined-hours track is the last resort {CommunityEngagementCheckService} reaches for when
+  # neither of the other two passes, so its aggregate is absent from most payloads and its nested
+  # +combined_hours+ hash is omitted when it is. It is carried beside the reported-hours aggregate
+  # rather than replacing it, so a reviewer can tell imputed hours from reported ones.
   class ExternalCECombinedDeterminationData < ValueObject
     attribute :hours_data
     attribute :income_data
+    attribute :combined_hours_data
     attribute :hours_ok, :boolean
     attribute :income_ok, :boolean
+    attribute :combined_hours_ok, :boolean
     attribute :calculated_at, :string
 
     validates :calculated_at, presence: true
     validates :hours_ok, inclusion: { in: [ true, false ] }
     validates :income_ok, inclusion: { in: [ true, false ] }
+    validates :combined_hours_ok, inclusion: { in: [ true, false ] }, allow_nil: true
     validate :hours_data_is_hash
     validate :income_data_is_hash
+    validate :combined_hours_data_is_hash_when_present
+    validate :combined_hours_track_is_all_or_nothing
 
     # @param hours_data [Hash] aggregate from {HoursComplianceDeterminationService.aggregate_hours_for_certification}
     # @param income_data [Hash] aggregate from {IncomeComplianceDeterminationService.aggregate_income_for_certification}
+    # @param combined_hours_data [Hash, nil] the same hours aggregate recomputed with earned income
+    #   imputed as hours; nil unless the fallback was consulted
+    # @param combined_hours_ok [Boolean, nil] nil unless the fallback was consulted; the two go
+    #   together, and either alone is a validation error
     # @return [self]
     # @raise [ActiveModel::ValidationError] outer or nested aggregate payload is invalid
-    def self.build(hours_data:, income_data:, hours_ok:, income_ok:)
-      hours_payload = hours_data.is_a?(Hash) ? hours_data.to_h.with_indifferent_access : hours_data
-      income_payload = income_data.is_a?(Hash) ? income_data.to_h.with_indifferent_access : income_data
-
+    def self.build(hours_data:, income_data:, hours_ok:, income_ok:,
+                   combined_hours_data: nil, combined_hours_ok: nil)
       new(
-        hours_data: hours_payload,
-        income_data: income_payload,
+        hours_data: indifferent(hours_data),
+        income_data: indifferent(income_data),
+        combined_hours_data: combined_hours_data.nil? ? nil : indifferent(combined_hours_data),
         hours_ok: hours_ok,
         income_ok: income_ok,
+        combined_hours_ok: combined_hours_ok,
         calculated_at: Time.current.iso8601
       ).tap do |vo|
         vo.validate!
         vo.send(:validate_nested_aggregate_payloads!)
       end
     end
+
+    def self.indifferent(payload)
+      payload.is_a?(Hash) ? payload.to_h.with_indifferent_access : payload
+    end
+    private_class_method :indifferent
 
     # @return [Hash{String => Object}] JSONB-safe keys and values for +Determination#determination_data+
     # @raise [ArgumentError] if nested VOs were not populated via {.build} (e.g. +#to_h+ on an instance constructed with +new+). Invalid aggregates instead raise {ActiveModel::ValidationError} during {.build}.
@@ -52,7 +71,9 @@ module Determinations
         "hours" => nested_hours_hash,
         "income" => nested_income_hash,
         "calculated_at" => calculated_at
-      }
+      }.tap do |h|
+        h["combined_hours"] = nested_combined_hours_vo.to_h if combined_hours_data.present?
+      end
     end
 
     private
@@ -60,8 +81,15 @@ module Determinations
     def validate_nested_aggregate_payloads!
       @nested_hours_vo = HoursBasedDeterminationData.from_aggregate(hours_data, compliant: hours_ok)
       @nested_income_vo = IncomeBasedDeterminationData.from_aggregate(income_data, compliant: income_ok)
+      return if combined_hours_data.blank?
+
+      @nested_combined_hours_vo = HoursBasedDeterminationData.from_aggregate(
+        combined_hours_data, compliant: combined_hours_ok
+      )
     end
 
+    # Ordered by what actually carried the member: the combined track is only consulted after the
+    # other two have failed, so it can never compete with them here.
     def satisfied_by
       if hours_ok && income_ok
         Determination::SATISFIED_BY_BOTH
@@ -69,6 +97,8 @@ module Determinations
         Determination::SATISFIED_BY_HOURS
       elsif income_ok
         Determination::SATISFIED_BY_INCOME
+      elsif combined_hours_ok
+        Determination::SATISFIED_BY_COMBINED_HOURS
       else
         Determination::SATISFIED_BY_NEITHER
       end
@@ -94,12 +124,33 @@ module Determinations
       @nested_income_vo
     end
 
+    def nested_combined_hours_vo
+      raise ArgumentError, "call #{self.class.name}.build(...) before #to_h" if @nested_combined_hours_vo.nil?
+
+      @nested_combined_hours_vo
+    end
+
     def hours_data_is_hash
       errors.add(:hours_data, :invalid) unless hours_data.is_a?(Hash)
     end
 
     def income_data_is_hash
       errors.add(:income_data, :invalid) unless income_data.is_a?(Hash)
+    end
+
+    def combined_hours_data_is_hash_when_present
+      return if combined_hours_data.nil? || combined_hours_data.is_a?(Hash)
+
+      errors.add(:combined_hours_data, :invalid)
+    end
+
+    # The fallback was either consulted or it was not: a verdict with no aggregate behind it would
+    # put a compliant determination on an empty payload, and an aggregate with no verdict would
+    # serialize figures nothing weighed.
+    def combined_hours_track_is_all_or_nothing
+      return if combined_hours_data.nil? == combined_hours_ok.nil?
+
+      errors.add(:combined_hours_ok, :invalid)
     end
   end
 end

--- a/reporting-app/app/models/determinations/external_ce_combined_determination_data.rb
+++ b/reporting-app/app/models/determinations/external_ce_combined_determination_data.rb
@@ -37,8 +37,8 @@ module Determinations
     # @param income_data [Hash] aggregate from {IncomeComplianceDeterminationService.aggregate_income_for_certification}
     # @param combined_hours_data [Hash, nil] the same hours aggregate recomputed with earned income
     #   imputed as hours; nil unless the fallback was consulted
-    # @param combined_hours_ok [Boolean, nil] nil unless the fallback was consulted; the two go
-    #   together, and either alone is a validation error
+    # @param combined_hours_ok [Boolean, nil] goes with +combined_hours_data+; either alone is a
+    #   validation error
     # @return [self]
     # @raise [ActiveModel::ValidationError] outer or nested aggregate payload is invalid
     def self.build(hours_data:, income_data:, hours_ok:, income_ok:,
@@ -88,8 +88,7 @@ module Determinations
       )
     end
 
-    # Ordered by what actually carried the member: the combined track is only consulted after the
-    # other two have failed, so it can never compete with them here.
+    # The combined track is only consulted once the other two have failed, so it never competes.
     def satisfied_by
       if hours_ok && income_ok
         Determination::SATISFIED_BY_BOTH
@@ -144,9 +143,9 @@ module Determinations
       errors.add(:combined_hours_data, :invalid)
     end
 
-    # The fallback was either consulted or it was not: a verdict with no aggregate behind it would
-    # put a compliant determination on an empty payload, and an aggregate with no verdict would
-    # serialize figures nothing weighed.
+    # The fallback was either consulted or it was not: a verdict with no aggregate would put a
+    # compliant determination on an empty payload, an aggregate with no verdict would serialize
+    # figures nothing weighed.
     def combined_hours_track_is_all_or_nothing
       return if combined_hours_data.nil? == combined_hours_ok.nil?
 

--- a/reporting-app/app/models/external_activity.rb
+++ b/reporting-app/app/models/external_activity.rb
@@ -25,14 +25,14 @@ class ExternalActivity < ApplicationRecord
   CATEGORY_EMPLOYMENT = "employment"
   ALLOWED_CATEGORIES = (ActivityCategories::ALL + [ CATEGORY_HOUSEHOLD ]).freeze
 
-  # Categories whose income was earned by working, so the hours behind it can be imputed when the
-  # hours track alone falls short (see +#converted_hours+). Unearned income has no work behind it.
-  # +with_convertible_income+ and +#converted_hours+ must agree on this list: a row the scope
-  # selects but the method declines lands in the hours aggregate as a zero-valued category.
+  # The categories policy allows converting income to hours for (see +#converted_hours+).
+  # +with_convertible_income+ and +#converted_hours+ both read this list, so a row one of them
+  # selects can never be one the other declines.
   CONVERTIBLE_INCOME_CATEGORIES = [ CATEGORY_EMPLOYMENT, CATEGORY_HOUSEHOLD ].freeze
 
-  # Hours per dollar: the hourly wage implied by the two CE thresholds ($580/month against
-  # 80 hours/month is $7.25/hour), inverted so income multiplies into hours.
+  # Hours per dollar: the hourly wage implied by the two CE thresholds (in the default
+  # configuration, $580/month against 80 hours/month is $7.25/hour), inverted so income
+  # multiplies into hours.
   INCOME_TO_HOURS = (BigDecimal(HoursComplianceDeterminationService::TARGET_HOURS) /
     Rails.application.config.ce_compliance[:income_threshold_monthly]).freeze
 
@@ -94,9 +94,8 @@ class ExternalActivity < ApplicationRecord
     gross_income.present?
   end
 
-  # Hours the row stands for once earned income is imputed as hours. Reported hours win: a row
-  # carrying both values would otherwise count the same job twice.
-  # @return [Numeric] 0 for income the hours track cannot impute work from
+  # Reported hours win: a row carrying both values would otherwise count the same job twice.
+  # @return [Numeric] 0 for income no conversion applies to
   def converted_hours
     return hours if hours?
     return 0 unless income? && CONVERTIBLE_INCOME_CATEGORIES.include?(category)

--- a/reporting-app/app/models/external_activity.rb
+++ b/reporting-app/app/models/external_activity.rb
@@ -23,6 +23,7 @@ class ExternalActivity < ApplicationRecord
   # since a member never reports another household member's income as their own activity.
   CATEGORY_HOUSEHOLD = "household"
   ALLOWED_CATEGORIES = (ActivityCategories::ALL + [ CATEGORY_HOUSEHOLD ]).freeze
+  INCOME_TO_HOURS = BigDecimal((HoursComplianceDeterminationService::TARGET_HOURS / CECompliance.fetch_income_threshold.to_f).to_s).freeze
 
   SOURCE_TYPES = {
     api: "api",
@@ -68,6 +69,7 @@ class ExternalActivity < ApplicationRecord
   # A row reporting both values belongs to both scopes: it contributes to both compliance tracks.
   scope :with_hours, -> { where.not(hours: nil) }
   scope :with_income, -> { where.not(gross_income: nil) }
+  scope :with_convertible_income, -> { where(hours: nil, category: [ :employment, :household ]) }
 
   def month
     period_start.beginning_of_month
@@ -79,6 +81,12 @@ class ExternalActivity < ApplicationRecord
 
   def income?
     gross_income.present?
+  end
+
+  def converted_hours
+    return hours if hours?
+    return gross_income * INCOME_TO_HOURS if income? && category == "employment"
+    0
   end
 
   private

--- a/reporting-app/app/models/external_activity.rb
+++ b/reporting-app/app/models/external_activity.rb
@@ -22,8 +22,19 @@ class ExternalActivity < ApplicationRecord
   # Shared with member-reported Activity via ActivityCategories; household is external-only,
   # since a member never reports another household member's income as their own activity.
   CATEGORY_HOUSEHOLD = "household"
+  CATEGORY_EMPLOYMENT = "employment"
   ALLOWED_CATEGORIES = (ActivityCategories::ALL + [ CATEGORY_HOUSEHOLD ]).freeze
-  INCOME_TO_HOURS = BigDecimal((HoursComplianceDeterminationService::TARGET_HOURS / CECompliance.fetch_income_threshold.to_f).to_s).freeze
+
+  # Categories whose income was earned by working, so the hours behind it can be imputed when the
+  # hours track alone falls short (see +#converted_hours+). Unearned income has no work behind it.
+  # +with_convertible_income+ and +#converted_hours+ must agree on this list: a row the scope
+  # selects but the method declines lands in the hours aggregate as a zero-valued category.
+  CONVERTIBLE_INCOME_CATEGORIES = [ CATEGORY_EMPLOYMENT, CATEGORY_HOUSEHOLD ].freeze
+
+  # Hours per dollar: the hourly wage implied by the two CE thresholds ($580/month against
+  # 80 hours/month is $7.25/hour), inverted so income multiplies into hours.
+  INCOME_TO_HOURS = (BigDecimal(HoursComplianceDeterminationService::TARGET_HOURS) /
+    Rails.application.config.ce_compliance[:income_threshold_monthly]).freeze
 
   SOURCE_TYPES = {
     api: "api",
@@ -69,7 +80,7 @@ class ExternalActivity < ApplicationRecord
   # A row reporting both values belongs to both scopes: it contributes to both compliance tracks.
   scope :with_hours, -> { where.not(hours: nil) }
   scope :with_income, -> { where.not(gross_income: nil) }
-  scope :with_convertible_income, -> { where(hours: nil, category: [ :employment, :household ]) }
+  scope :with_convertible_income, -> { where(hours: nil, category: CONVERTIBLE_INCOME_CATEGORIES) }
 
   def month
     period_start.beginning_of_month
@@ -83,10 +94,14 @@ class ExternalActivity < ApplicationRecord
     gross_income.present?
   end
 
+  # Hours the row stands for once earned income is imputed as hours. Reported hours win: a row
+  # carrying both values would otherwise count the same job twice.
+  # @return [Numeric] 0 for income the hours track cannot impute work from
   def converted_hours
     return hours if hours?
-    return gross_income * INCOME_TO_HOURS if income? && category == "employment"
-    0
+    return 0 unless income? && CONVERTIBLE_INCOME_CATEGORIES.include?(category)
+
+    gross_income * INCOME_TO_HOURS
   end
 
   private

--- a/reporting-app/app/services/community_engagement_check_service.rb
+++ b/reporting-app/app/services/community_engagement_check_service.rb
@@ -14,12 +14,16 @@
 class CommunityEngagementCheckService
   include Strata::VirtualActor
 
-  # The in-hand assessment: both aggregates and their per-track verdicts. DataSourceCheckService
+  # The in-hand assessment: each aggregate and its per-track verdict. DataSourceCheckService
   # recomputes this when no data source produced an outcome, so the derivation lives here once
   # instead of in both steps, where the two could drift apart.
-  Assessment = Struct.new(:hours_data, :income_data, :hours_ok, :income_ok, keyword_init: true) do
+  #
+  # +combined_hours_data+ and +combined_hours_ok+ are both nil unless the fallback was consulted
+  # (see +assess+), so an unweighed track is never mistaken for one that fell short.
+  Assessment = Struct.new(:hours_data, :income_data, :combined_hours_data,
+                          :hours_ok, :income_ok, :combined_hours_ok, keyword_init: true) do
     def met?
-      hours_ok || income_ok
+      hours_ok || income_ok || combined_hours_ok
     end
   end
 
@@ -40,7 +44,9 @@ class CommunityEngagementCheckService
         hours_data: assessment.hours_data,
         income_data: assessment.income_data,
         hours_ok: assessment.hours_ok,
-        income_ok: assessment.income_ok
+        income_ok: assessment.income_ok,
+        combined_hours_data: assessment.combined_hours_data,
+        combined_hours_ok: assessment.combined_hours_ok
       )
 
       Strata::EventManager.publish("DeterminedCommunityEngagementMet", payload_base)
@@ -51,15 +57,30 @@ class CommunityEngagementCheckService
     def assess(certification)
       hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(certification)
       income_data = IncomeComplianceDeterminationService.aggregate_income_for_certification(certification)
+      # A qualifying education enrollment meets the hours requirement outright, so it passes the
+      # hours track instead of standing up a track of its own the determination payload has no shape for.
+      hours_ok = HoursComplianceDeterminationService.compliant_for_monthly_hours?(hours_data[:hours_by_month]) ||
+        HoursComplianceDeterminationService.education_enrollment_compliant?(certification)
+      income_ok = IncomeComplianceDeterminationService.compliant_for_monthly_income?(income_data[:income_by_month])
+
+      # A member already carried by one of the two tracks leaves the fallback unconsulted, and its
+      # two fields unset, rather than recorded as a track that was weighed and fell short.
+      return Assessment.new(hours_data:, income_data:, hours_ok:, income_ok:) if hours_ok || income_ok
+
+      # The last resort: earned income stands for the hours behind it, so a member short on both
+      # tracks can still clear the hours threshold on reported and imputed hours together. It
+      # imputes hours nobody reported, so it is work worth doing only where it changes the answer.
+      # The aggregate is carried beside +hours_data+ rather than replacing it, so the determination
+      # keeps reported hours distinguishable from imputed ones.
+      combined_hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(
+        certification, with_income_conversion: true
+      )
 
       Assessment.new(
-        hours_data: hours_data,
-        income_data: income_data,
-        # A qualifying education enrollment meets the hours requirement outright, so it passes the
-        # hours track instead of standing up a third one the determination payload has no shape for.
-        hours_ok: HoursComplianceDeterminationService.compliant_for_monthly_hours?(hours_data[:hours_by_month]) ||
-          HoursComplianceDeterminationService.education_enrollment_compliant?(certification),
-        income_ok: IncomeComplianceDeterminationService.compliant_for_monthly_income?(income_data[:income_by_month])
+        hours_data:, income_data:, hours_ok:, income_ok:,
+        combined_hours_data:,
+        combined_hours_ok: HoursComplianceDeterminationService
+          .compliant_for_monthly_hours?(combined_hours_data[:hours_by_month])
       )
     end
   end

--- a/reporting-app/app/services/community_engagement_check_service.rb
+++ b/reporting-app/app/services/community_engagement_check_service.rb
@@ -63,15 +63,11 @@ class CommunityEngagementCheckService
         HoursComplianceDeterminationService.education_enrollment_compliant?(certification)
       income_ok = IncomeComplianceDeterminationService.compliant_for_monthly_income?(income_data[:income_by_month])
 
-      # A member already carried by one of the two tracks leaves the fallback unconsulted, and its
-      # two fields unset, rather than recorded as a track that was weighed and fell short.
       return Assessment.new(hours_data:, income_data:, hours_ok:, income_ok:) if hours_ok || income_ok
 
       # The last resort: earned income stands for the hours behind it, so a member short on both
       # tracks can still clear the hours threshold on reported and imputed hours together. It
       # imputes hours nobody reported, so it is work worth doing only where it changes the answer.
-      # The aggregate is carried beside +hours_data+ rather than replacing it, so the determination
-      # keeps reported hours distinguishable from imputed ones.
       combined_hours_data = HoursComplianceDeterminationService.aggregate_hours_for_certification(
         certification, with_income_conversion: true
       )

--- a/reporting-app/app/services/concerns/activity_aggregator.rb
+++ b/reporting-app/app/services/concerns/activity_aggregator.rb
@@ -21,6 +21,13 @@ module ActivityAggregator
     ExternalActivity.for_member(certification.member_id).within_period(lookback_period).with_income
   end
 
+  def fetch_external_convertible_income_activities(certification)
+    return ExternalActivity.none unless certification&.member_id
+
+    lookback_period = certification.certification_requirements.continuous_lookback_period
+    ExternalActivity.for_member(certification.member_id).within_period(lookback_period).with_convertible_income
+  end
+
   def fetch_member_activities(form)
     return Activity.none unless form
 
@@ -65,13 +72,14 @@ module ActivityAggregator
 
   # A relation is accepted as well as an array. Expects rows carrying +hours+ — pass a
   # +with_hours+-scoped relation, or income-only rows would land in +by_category+ as zeroes.
-  def summarize_hours(activities)
+  def summarize_hours(activities, with_income_conversion: false)
     rows = activities.to_a
 
+    hours_method = with_income_conversion ? :converted_hours : :hours
     {
-      total: decimal_sum(rows, :hours).to_f,
-      by_category: rows.group_by(&:category).transform_values { |group| decimal_sum(group, :hours).to_f },
-      by_month: rows.group_by(&:month).transform_values { |group| decimal_sum(group, :hours) },
+      total: decimal_sum(rows, hours_method).to_f,
+      by_category: rows.group_by(&:category).transform_values { |group| decimal_sum(group, hours_method).to_f },
+      by_month: rows.group_by(&:month).transform_values { |group| decimal_sum(group, hours_method) },
       ids: rows.map(&:id)
     }
   end

--- a/reporting-app/app/services/data_source_check_service.rb
+++ b/reporting-app/app/services/data_source_check_service.rb
@@ -80,7 +80,9 @@ class DataSourceCheckService
         hours_data: assessment.hours_data,
         income_data: assessment.income_data,
         hours_ok: assessment.hours_ok,
-        income_ok: assessment.income_ok
+        income_ok: assessment.income_ok,
+        combined_hours_data: assessment.combined_hours_data,
+        combined_hours_ok: assessment.combined_hours_ok
       )
 
       # The Insufficient/ActionRequired split moved here with the negative determination, so both

--- a/reporting-app/app/services/external_activity_service.rb
+++ b/reporting-app/app/services/external_activity_service.rb
@@ -157,7 +157,7 @@ class ExternalActivityService
 
       if hours.present?
         hours_data = HoursComplianceDeterminationService
-          .aggregate_hours_for_certification(certification, application_form:)
+          .aggregate_hours_for_certification(certification, application_form:, with_income_conversion: false)
         hours_compliant = HoursComplianceDeterminationService
           .compliant_for_monthly_hours?(hours_data[:hours_by_month])
 
@@ -171,7 +171,16 @@ class ExternalActivityService
       income_compliant = IncomeComplianceDeterminationService
         .compliant_for_monthly_income?(income_data[:income_by_month])
 
-      kase.record_income_compliance(income_compliant ? :compliant : :not_compliant, income_data)
+      if income_compliant || hours.blank?
+        return kase.record_income_compliance(income_compliant ? :compliant : :not_compliant, income_data)
+      end
+
+      combined_hours_data = HoursComplianceDeterminationService
+        .aggregate_hours_for_certification(certification, application_form:, with_income_conversion: true)
+      combined_hours_compliant = HoursComplianceDeterminationService
+        .compliant_for_monthly_hours?(combined_hours_data[:hours_by_month])
+
+      kase.record_hours_compliance(combined_hours_compliant ? :compliant : :not_compliant, combined_hours_data, with_income_conversion: true)
     end
   end
 end

--- a/reporting-app/app/services/external_activity_service.rb
+++ b/reporting-app/app/services/external_activity_service.rb
@@ -5,8 +5,8 @@
 # report hours, gross income, or both, and is split into one entry per calendar month it touches.
 #
 # After a successful save, optional compliance recalculation (+recalculate_compliance+, default
-# +true+) records exactly one determination for the member's open case — hours first, falling
-# through to income only when hours fall short.
+# +true+) records exactly one determination for the member's open case — hours first, then income
+# when hours fall short, then the two combined as a last resort.
 #
 # That path is dormant: the only caller, +Certifications::CreationService+, passes
 # +recalculate_compliance: false+ because the case does not exist yet at intake. Wiring up a
@@ -148,7 +148,7 @@ class ExternalActivityService
     #
     # The determination services' +.calculate+ methods aggregate *and* record, so calling both
     # would write two rows. The pieces they build on are public, so the branch is decided here and
-    # only the winning track is recorded.
+    # only the deciding track is recorded.
     #
     # Judged on monthly hours alone, matching +HoursComplianceDeterminationService#calculate+:
     # the education-enrollment track is deliberately not consulted here.
@@ -175,12 +175,23 @@ class ExternalActivityService
         return kase.record_income_compliance(income_compliant ? :compliant : :not_compliant, income_data)
       end
 
+      # Last resort: reported hours plus hours imputed from earned income. Recorded as the combined
+      # assessment, the shape +CommunityEngagementCheckService+ writes for this same policy, so all
+      # three tracks land in one payload rather than a second hours determination.
       combined_hours_data = HoursComplianceDeterminationService
         .aggregate_hours_for_certification(certification, application_form:, with_income_conversion: true)
-      combined_hours_compliant = HoursComplianceDeterminationService
-        .compliant_for_monthly_hours?(combined_hours_data[:hours_by_month])
 
-      kase.record_hours_compliance(combined_hours_compliant ? :compliant : :not_compliant, combined_hours_data, with_income_conversion: true)
+      kase.record_external_ce_combined_assessment(
+        actor: self,
+        certification: certification,
+        hours_data: hours_data,
+        income_data: income_data,
+        hours_ok: false,
+        income_ok: false,
+        combined_hours_data: combined_hours_data,
+        combined_hours_ok: HoursComplianceDeterminationService
+          .compliant_for_monthly_hours?(combined_hours_data[:hours_by_month])
+      )
     end
   end
 end

--- a/reporting-app/app/services/hours_compliance_determination_service.rb
+++ b/reporting-app/app/services/hours_compliance_determination_service.rb
@@ -6,23 +6,29 @@ class HoursComplianceDeterminationService
   class << self
     include ActivityAggregator
 
-    # Called by CalculateComplianceJob for async recalculation of existing certifications
-    # Records determination without triggering workflow events/notifications.
+    # Silent recalculation of an existing certification: records a determination without triggering
+    # workflow events/notifications. No caller yet.
     # When compliant, +record_hours_compliance+ closes the case (+CertificationCase#record_automated_ce_compliance+);
     # +IncomeComplianceDeterminationService#calculate+ follows the same close-on-compliant rule for parity.
+    #
+    # Reported hours only — neither education enrollment nor the combined-hours last resort is
+    # consulted. Both belong to +CommunityEngagementCheckService+, which has a payload shape that
+    # keeps imputed hours apart from reported ones, and is the judge to reach for if this is ever
+    # wired up to a job.
+    #
     # @param certification_id [String]
     # @return [void]
-    def calculate(certification_id, with_income_conversion: false)
+    def calculate(certification_id)
       certification = Certification.find(certification_id)
       kase = certification_case_for_certification(certification)
       raise ActiveRecord::RecordNotFound, "Couldn't find CertificationCase for Certification #{certification_id}" unless kase
 
       # TODO: the logic behind which forms are updated tbd
       application_form = ActivityReportApplicationForm.where(certification_case_id: kase.id).first
-      hours_data = aggregate_hours_for_certification(certification, application_form:, with_income_conversion:)
+      hours_data = aggregate_hours_for_certification(certification, application_form:)
       outcome = determine_outcome(hours_data[:hours_by_month])
 
-      kase.record_hours_compliance(outcome, hours_data, with_income_conversion:)
+      kase.record_hours_compliance(outcome, hours_data)
     end
 
     # PUBLIC: Aggregate hours from both ExternalActivity and approved Activity records

--- a/reporting-app/app/services/hours_compliance_determination_service.rb
+++ b/reporting-app/app/services/hours_compliance_determination_service.rb
@@ -12,17 +12,17 @@ class HoursComplianceDeterminationService
     # +IncomeComplianceDeterminationService#calculate+ follows the same close-on-compliant rule for parity.
     # @param certification_id [String]
     # @return [void]
-    def calculate(certification_id)
+    def calculate(certification_id, with_income_conversion: false)
       certification = Certification.find(certification_id)
       kase = certification_case_for_certification(certification)
       raise ActiveRecord::RecordNotFound, "Couldn't find CertificationCase for Certification #{certification_id}" unless kase
 
       # TODO: the logic behind which forms are updated tbd
       application_form = ActivityReportApplicationForm.where(certification_case_id: kase.id).first
-      hours_data = aggregate_hours_for_certification(certification, application_form:)
+      hours_data = aggregate_hours_for_certification(certification, application_form:, with_income_conversion:)
       outcome = determine_outcome(hours_data[:hours_by_month])
 
-      kase.record_hours_compliance(outcome, hours_data)
+      kase.record_hours_compliance(outcome, hours_data, with_income_conversion:)
     end
 
     # PUBLIC: Aggregate hours from both ExternalActivity and approved Activity records
@@ -40,10 +40,16 @@ class HoursComplianceDeterminationService
       certification,
       application_form: nil,
       external_hourly_activities: nil,
-      member_hour_activity_rows: nil
+      member_hour_activity_rows: nil,
+      with_income_conversion: false
     )
-      external_sources = external_hourly_activities.nil? ? fetch_external_hourly_activities(certification) : external_hourly_activities
-      external_hours = summarize_hours(external_sources)
+      external_hours = if with_income_conversion
+                        sources = fetch_external_hourly_activities(certification) + fetch_external_convertible_income_activities(certification)
+                        summarize_hours(sources, with_income_conversion:)
+      else
+                        external_sources = external_hourly_activities.nil? ? fetch_external_hourly_activities(certification) : external_hourly_activities
+                        summarize_hours(external_sources)
+      end
 
       member_hours = if member_hour_activity_rows.nil?
         member_hours_from_activities(certification, application_form:)

--- a/reporting-app/config/locales/services/en.yml
+++ b/reporting-app/config/locales/services/en.yml
@@ -30,5 +30,6 @@ en:
         income_reported_compliant: "Income reported compliant"
         income_reported_insufficient: "Insufficient community engagement income"
         hours_reported_compliant: "Hours reported compliant"
-        hours_insufficient: "Insufficient community engagement hours"
+        combined_hours_reported_compliant: "Combined hours compliant"
+        hours_reported_insufficient: "Insufficient community engagement hours"
         exemption_request_compliant: "Exemption request compliant"

--- a/reporting-app/spec/factories/external_activities_factory.rb
+++ b/reporting-app/spec/factories/external_activities_factory.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       category { 'education' }
     end
 
+    trait :unearned do
+      category { 'unearned' }
+    end
+
     trait :from_batch do
       source_type { ExternalActivity::SOURCE_TYPES[:batch] }
       source_id { SecureRandom.uuid }

--- a/reporting-app/spec/models/certification_case_spec.rb
+++ b/reporting-app/spec/models/certification_case_spec.rb
@@ -583,6 +583,52 @@ RSpec.describe CertificationCase, type: :model do
       }
     end
 
+    let(:combined_hours_data) do
+      {
+        total_hours: 95,
+        hours_by_month: { Date.current.beginning_of_month => 95 },
+        hours_by_category: {},
+        hours_by_source: { external: 95.0, activity: 0.0 },
+        external_hourly_activity_ids: [],
+        activity_ids: []
+      }
+    end
+
+    it "stores compliant with the combined-hours reason when only that track passes" do
+      certification_case.record_external_ce_combined_assessment(
+        actor: MockSubmitter,
+        certification: certification,
+        hours_data: hours_data,
+        income_data: income_data,
+        hours_ok: false,
+        income_ok: false,
+        combined_hours_data: combined_hours_data,
+        combined_hours_ok: true
+      )
+
+      determination = latest_determination_for(certification_case.certification_id)
+      expect(determination.outcome).to eq("compliant")
+      expect(determination.reasons).to contain_exactly("combined_hours_reported_compliant")
+      expect(determination.determination_data["satisfied_by"]).to eq(Determination::SATISFIED_BY_COMBINED_HOURS)
+      expect(determination.determination_data["combined_hours"]["total_hours"]).to eq(95.0)
+    end
+
+    # Compliant closes the case here as it does on the other two tracks.
+    it "closes the case when the combined track passes" do
+      certification_case.record_external_ce_combined_assessment(
+        actor: MockSubmitter,
+        certification: certification,
+        hours_data: hours_data,
+        income_data: income_data,
+        hours_ok: false,
+        income_ok: false,
+        combined_hours_data: combined_hours_data,
+        combined_hours_ok: true
+      )
+
+      expect(certification_case.reload).to be_closed
+    end
+
     it "stores not_compliant with both insufficient reasons when both tracks fail" do
       certification_case.record_external_ce_combined_assessment(
         actor: MockSubmitter,

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Determination, type: :model do
           income_reported_compliant
           income_reported_insufficient
           hours_reported_compliant
+          combined_hours_reported_compliant
           hours_reported_insufficient
           exemption_request_compliant
           veteran_disability_excluded

--- a/reporting-app/spec/models/determination_spec.rb
+++ b/reporting-app/spec/models/determination_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Determination, type: :model do
         expect(determination).to be_valid
       end
 
-      it 'accepts hours_insufficient' do
+      it 'accepts hours_reported_insufficient' do
         determination = build(:determination, reasons: [ 'hours_reported_insufficient' ])
         expect(determination).to be_valid
       end
@@ -339,6 +339,18 @@ RSpec.describe Determination, type: :model do
     it 'keeps one exception reason code per ExceptionDeterminationService check' do
       expect(described_class::EXCEPTION_OUTCOME_KEYS.count)
         .to eq(ExceptionDeterminationService::EXCEPTION_CHECKS.count)
+    end
+
+    # MemberStatusService#human_readable_reason_codes falls back to the bare code, so a missing
+    # entry shows a member "combined_hours_reported_compliant" rather than failing anywhere.
+    it 'has a translation for every community-engagement reason code' do
+      codes = described_class::CE_MET_REASON_CODES.values + described_class::CE_INSUFFICIENT_REASON_CODES.values
+
+      codes.each do |code|
+        key = "services.member_status_service.reason_codes.#{code}"
+        expect(I18n.exists?(key.to_sym, :en)).to be(true),
+          "Missing locale :en key #{key.inspect} for Determination reason code #{code.inspect}"
+      end
     end
   end
 

--- a/reporting-app/spec/models/determinations/external_ce_combined_determination_data_spec.rb
+++ b/reporting-app/spec/models/determinations/external_ce_combined_determination_data_spec.rb
@@ -5,6 +5,26 @@ require "rails_helper"
 RSpec.describe Determinations::ExternalCECombinedDeterminationData do
   let(:expected_calculated_at) { Time.zone.parse("2026-04-30 15:00:00").iso8601 }
 
+  let(:empty_hours_data) do
+    {
+      total_hours: 0,
+      hours_by_category: {},
+      hours_by_source: { external: 0.0, activity: 0.0 },
+      external_hourly_activity_ids: [],
+      activity_ids: []
+    }
+  end
+  let(:empty_income_data) do
+    {
+      total_income: BigDecimal("0"),
+      income_by_source: { external: BigDecimal("0"), activity: BigDecimal("0") },
+      period_start: nil,
+      period_end: nil,
+      external_income_activity_ids: [],
+      activity_ids: []
+    }
+  end
+
   around do |example|
     travel_to(Time.zone.parse(expected_calculated_at)) { example.run }
   end
@@ -132,6 +152,70 @@ RSpec.describe Determinations::ExternalCECombinedDeterminationData do
     expect(payload["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
     expect(payload["hours"]["compliant"]).to be false
     expect(payload["income"]["compliant"]).to be false
+  end
+
+  # No fallback aggregate was computed, so there is no third track to serialize.
+  it "omits the combined_hours payload when no combined aggregate is given" do
+    payload = described_class.build(
+      hours_data: empty_hours_data,
+      income_data: empty_income_data,
+      hours_ok: false,
+      income_ok: false
+    ).to_h
+
+    expect(payload).not_to have_key("combined_hours")
+  end
+
+  it "uses satisfied_by combined_hours when only the combined track passes" do
+    combined_hours_data = {
+      total_hours: 95,
+      hours_by_category: { "employment" => 55.0, "community_service" => 40.0 },
+      hours_by_source: { external: 95.0, activity: 0.0 },
+      external_hourly_activity_ids: [ "cccccccc-cccc-4ccc-8ccc-cccccccccccc" ],
+      activity_ids: []
+    }
+
+    payload = described_class.build(
+      hours_data: empty_hours_data,
+      income_data: empty_income_data,
+      hours_ok: false,
+      income_ok: false,
+      combined_hours_data: combined_hours_data,
+      combined_hours_ok: true
+    ).to_h
+
+    expect(payload["satisfied_by"]).to eq(Determination::SATISFIED_BY_COMBINED_HOURS)
+    expect(payload["hours"]["compliant"]).to be false
+    expect(payload["income"]["compliant"]).to be false
+    expect(payload["combined_hours"]).to eq(
+      Determinations::HoursBasedDeterminationData.from_aggregate(combined_hours_data, compliant: true).to_h
+    )
+  end
+
+  # A verdict with nothing behind it would put a compliant determination on an empty payload.
+  it "fails at build time when the combined track passes with no aggregate" do
+    expect {
+      described_class.build(
+        hours_data: empty_hours_data,
+        income_data: empty_income_data,
+        hours_ok: false,
+        income_ok: false,
+        combined_hours_ok: true
+      )
+    }.to raise_error(ActiveModel::ValidationError)
+  end
+
+  # The reverse: figures no verdict was drawn from have no business in the payload.
+  it "fails at build time when a combined aggregate arrives with no verdict" do
+    expect {
+      described_class.build(
+        hours_data: empty_hours_data,
+        income_data: empty_income_data,
+        hours_ok: false,
+        income_ok: false,
+        combined_hours_data: empty_hours_data
+      )
+    }.to raise_error(ActiveModel::ValidationError)
   end
 
   it "fails at build time when nested hours aggregate is invalid" do

--- a/reporting-app/spec/models/external_activity_spec.rb
+++ b/reporting-app/spec/models/external_activity_spec.rb
@@ -399,8 +399,8 @@ RSpec.describe ExternalActivity, type: :model do
     end
   end
 
-  # $72.50 is one hour short of a day at the wage implied by the two thresholds ($7.25), so each
-  # conversion below lands on a round 10 hours.
+  # $72.50 is ten hours at the $7.25/hour implied by the two thresholds, so each conversion below
+  # lands on a round number.
   describe "#converted_hours" do
     it "returns hours if hours only" do
       activity = build(:external_activity, :with_hours)

--- a/reporting-app/spec/models/external_activity_spec.rb
+++ b/reporting-app/spec/models/external_activity_spec.rb
@@ -325,6 +325,23 @@ RSpec.describe ExternalActivity, type: :model do
     end
   end
 
+  describe ".with_convertible_income" do
+    let!(:income_only) { create(:external_activity, :with_income, :employment) }
+    let!(:household) { create(:external_activity, :household) }
+
+    before do
+      create(:external_activity, :with_hours)
+      create(:external_activity, :with_hours_and_income)
+      create(:external_activity, :with_income, :unearned)
+      household
+      income_only
+    end
+
+    it "has household and income_only hours only" do
+      expect(described_class.with_convertible_income).to contain_exactly(income_only, household)
+    end
+  end
+
   describe '#month' do
     it 'returns the first day of the period start month' do
       activity = build(:external_activity, :with_hours,
@@ -376,6 +393,28 @@ RSpec.describe ExternalActivity, type: :model do
         expect(I18n.exists?(key.to_sym, :en)).to be(true),
           "Missing locale :en key #{key.inspect} for ExternalActivity source_type #{source_type.inspect}"
       end
+    end
+  end
+
+  describe "#converted_hours" do
+    it "returns hours if hours only" do
+      activity = build(:external_activity, :with_hours)
+      expect(activity.converted_hours).to eq activity.hours
+    end
+
+    it "returns hours if hours and imcome" do
+      activity = build(:external_activity, :with_hours, category: :employment)
+      expect(activity.converted_hours).to eq activity.hours
+    end
+
+    it "returns income divided by minimum wage if income only and category employment" do
+      activity = build(:external_activity, :with_income, category: :employment, gross_income: 72.5)
+      expect(activity.converted_hours).to be_within(0.001).of(10)
+    end
+
+    it "returns 0 if income only and category not employment" do
+      activity = build(:external_activity, :with_income, category: :unearned, gross_income: 75)
+      expect(activity.converted_hours).to eq 0
     end
   end
 end

--- a/reporting-app/spec/models/external_activity_spec.rb
+++ b/reporting-app/spec/models/external_activity_spec.rb
@@ -326,19 +326,22 @@ RSpec.describe ExternalActivity, type: :model do
   end
 
   describe ".with_convertible_income" do
-    let!(:income_only) { create(:external_activity, :with_income, :employment) }
-    let!(:household) { create(:external_activity, :household) }
+    let!(:employment_income) { create(:external_activity, :with_income, :employment) }
+    let!(:household_income) { create(:external_activity, :household) }
 
     before do
       create(:external_activity, :with_hours)
       create(:external_activity, :with_hours_and_income)
       create(:external_activity, :with_income, :unearned)
-      household
-      income_only
     end
 
-    it "has household and income_only hours only" do
-      expect(described_class.with_convertible_income).to contain_exactly(income_only, household)
+    it "returns the income-only rows whose category has work behind it" do
+      expect(described_class.with_convertible_income)
+        .to contain_exactly(employment_income, household_income)
+    end
+
+    it "matches the categories #converted_hours actually converts" do
+      expect(described_class.with_convertible_income.map(&:converted_hours)).to all(be_positive)
     end
   end
 
@@ -396,23 +399,31 @@ RSpec.describe ExternalActivity, type: :model do
     end
   end
 
+  # $72.50 is one hour short of a day at the wage implied by the two thresholds ($7.25), so each
+  # conversion below lands on a round 10 hours.
   describe "#converted_hours" do
     it "returns hours if hours only" do
       activity = build(:external_activity, :with_hours)
       expect(activity.converted_hours).to eq activity.hours
     end
 
-    it "returns hours if hours and imcome" do
-      activity = build(:external_activity, :with_hours, category: :employment)
+    # Converting the income of a row that already reports hours would count the same job twice.
+    it "returns hours if hours and income" do
+      activity = build(:external_activity, :with_hours_and_income, category: :employment)
       expect(activity.converted_hours).to eq activity.hours
     end
 
-    it "returns income divided by minimum wage if income only and category employment" do
+    it "converts employment income at the implied hourly wage" do
       activity = build(:external_activity, :with_income, category: :employment, gross_income: 72.5)
       expect(activity.converted_hours).to be_within(0.001).of(10)
     end
 
-    it "returns 0 if income only and category not employment" do
+    it "converts household income at the implied hourly wage" do
+      activity = build(:external_activity, :household, gross_income: 72.5)
+      expect(activity.converted_hours).to be_within(0.001).of(10)
+    end
+
+    it "returns 0 for income with no work behind it" do
       activity = build(:external_activity, :with_income, category: :unearned, gross_income: 75)
       expect(activity.converted_hours).to eq 0
     end

--- a/reporting-app/spec/services/community_engagement_check_service_spec.rb
+++ b/reporting-app/spec/services/community_engagement_check_service_spec.rb
@@ -42,13 +42,17 @@ RSpec.describe CommunityEngagementCheckService do
       ]))
   end
 
-  def create_income_for(certification, gross_income:, **attrs)
+  # Category matters to the combined-hours fallback, which imputes hours from employment and
+  # household income only. The default is deliberately a category it cannot convert, so a test
+  # that means to exercise the fallback opts in by naming one.
+  def create_income_for(certification, gross_income:, category: "unearned", **attrs)
     lookback = certification.certification_requirements.continuous_lookback_period
     period_start = lookback.start.to_date
     period_end = lookback.start.to_date.end_of_month
 
     create(:external_activity, :with_income, member_id: certification.member_id,
-           period_start: period_start, period_end: period_end, gross_income: gross_income, **attrs)
+           period_start: period_start, period_end: period_end, gross_income: gross_income,
+           category: category, **attrs)
   end
 
   # .assess is the derivation .determine used to inline. It is public so a second step can reuse it
@@ -96,7 +100,71 @@ RSpec.describe CommunityEngagementCheckService do
       expect(assessment.income_data[:total_income]).to be_positive
       expect(assessment.hours_ok).to be(false)
       expect(assessment.income_ok).to be(false)
+      expect(assessment.combined_hours_ok).to be(false)
       expect(assessment.met?).to be(false)
+    end
+
+    # The fallback: earnings the member reported as income stand for the hours behind them, so a
+    # member short on both tracks can still clear the hours threshold on the two combined.
+    # $400 converts to ~55 hours, which carries 40 reported hours over the 80-hour target.
+    it "reports met? on combined hours when neither track passes on its own" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: 400, category: "employment")
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.hours_ok).to be(false)
+      expect(assessment.income_ok).to be(false)
+      expect(assessment.combined_hours_ok).to be(true)
+      expect(assessment.met?).to be(true)
+    end
+
+    it "counts household income toward combined hours" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: 400, category: "household")
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.combined_hours_ok).to be(true)
+      expect(assessment.met?).to be(true)
+    end
+
+    # The reported-hours aggregate is what the determination and the member dashboard report, so
+    # the imputed hours are carried alongside it rather than folded into it.
+    it "keeps the combined aggregate separate from the reported-hours aggregate" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: 400, category: "employment")
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.hours_data[:total_hours]).to eq(under_hours)
+      expect(assessment.combined_hours_data[:total_hours]).to be > under_hours
+    end
+
+    it "reports met? false when even the combined hours fall short" do
+      create_external_hourly_activity_for(certification, hours: under_hours)
+      create_income_for(certification, gross_income: 100, category: "employment")
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.combined_hours_data[:total_hours]).to be_positive
+      expect(assessment.combined_hours_ok).to be(false)
+      expect(assessment.met?).to be(false)
+    end
+
+    # A last resort: imputing hours nobody reported is work the assessment does only when it
+    # changes the answer. Both fields stay unset, so an unconsulted track is distinguishable from
+    # one that was weighed and fell short.
+    it "does not compute combined hours when a track already passes" do
+      create_external_hourly_activity_for(certification, hours: over_hours)
+      create_income_for(certification, gross_income: 400, category: "employment")
+
+      assessment = described_class.assess(certification)
+
+      expect(assessment.combined_hours_data).to be_nil
+      expect(assessment.combined_hours_ok).to be_nil
+      expect(HoursComplianceDeterminationService).not_to have_received(:aggregate_hours_for_certification)
+        .with(certification, with_income_conversion: true)
     end
 
     # Passes on the hours track, which is why hours_ok is true against a zero total.
@@ -151,6 +219,14 @@ RSpec.describe CommunityEngagementCheckService do
         expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_HOURS)
         expect(data["hours"]["compliant"]).to be true
         expect(data["income"]["compliant"]).to be false
+      end
+
+      # No imputed hours were needed, so the payload carries no combined track to explain.
+      it "omits the combined hours payload" do
+        described_class.determine(certification_case)
+
+        expect(latest_determination_for(certification.id).determination_data)
+          .not_to have_key("combined_hours")
       end
 
       it "publishes DeterminedCommunityEngagementMet" do
@@ -256,8 +332,54 @@ RSpec.describe CommunityEngagementCheckService do
       end
     end
 
+    context "when only the combined hours pass" do
+      before do
+        create_external_hourly_activity_for(certification, hours: 40)
+        create_income_for(certification, gross_income: 400, category: "employment")
+      end
+
+      it "records the combined determination satisfied by combined hours" do
+        described_class.determine(certification_case)
+
+        determination = latest_determination_for(certification.id)
+        expect(determination.outcome).to eq("compliant")
+        expect(determination.reasons).to eq([ "combined_hours_reported_compliant" ])
+        data = determination.determination_data
+        expect(data["calculation_type"]).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+        expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_COMBINED_HOURS)
+        expect(data["hours"]["compliant"]).to be false
+        expect(data["income"]["compliant"]).to be false
+        expect(data["combined_hours"]["compliant"]).to be true
+      end
+
+      # Which part of the total was imputed rather than reported has to stay legible to a reviewer.
+      it "records the reported and combined hours totals side by side" do
+        described_class.determine(certification_case)
+
+        data = latest_determination_for(certification.id).determination_data
+        expect(data["hours"]["total_hours"]).to eq(40.0)
+        expect(data["combined_hours"]["total_hours"]).to be_within(0.001).of(95.172)
+      end
+
+      it "publishes DeterminedCommunityEngagementMet" do
+        described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementMet",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+
+      it 'logs approved event' do
+        expect do
+          described_class.determine(certification_case)
+        end.to change { Strata::AuditLine.where(subject: certification, actor_type: described_class.name, action: 'case.activity_report.approved').count }.by(1)
+      end
+    end
+
     # Not-met defers to the trailing step (OSCER-805), which owns the negative determination and
     # the Insufficient/ActionRequired split, so this service records nothing here.
+    # The income here is unearned, so the combined-hours fallback has nothing to impute from.
     context "when neither hours nor income meet targets with some external hours" do
       before do
         create_external_hourly_activity_for(certification, hours: 40)
@@ -316,6 +438,25 @@ RSpec.describe CommunityEngagementCheckService do
       # to the trailing step, so both not-met flavors leave here as the same event.
       it "publishes DeterminedCommunityEngagementNotMet" do
         described_class.determine(certification_case)
+
+        expect(Strata::EventManager).to have_received(:publish).with(
+          "DeterminedCommunityEngagementNotMet",
+          hash_including(case_id: certification_case.id)
+        )
+      end
+    end
+
+    # The fallback ran on convertible income and still fell short, which is not-met like any other.
+    context "when the combined hours also fall short" do
+      before do
+        create_external_hourly_activity_for(certification, hours: 40)
+        create_income_for(certification, gross_income: 100, category: "employment")
+      end
+
+      it "records no determination, deferring the negative to the data-source step" do
+        expect do
+          described_class.determine(certification_case)
+        end.not_to change { Determination.unscope(:order).where(subject_id: certification.id).count }
 
         expect(Strata::EventManager).to have_received(:publish).with(
           "DeterminedCommunityEngagementNotMet",

--- a/reporting-app/spec/services/community_engagement_check_service_spec.rb
+++ b/reporting-app/spec/services/community_engagement_check_service_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe CommunityEngagementCheckService do
       ]))
   end
 
-  # Category matters to the combined-hours fallback, which imputes hours from employment and
-  # household income only. The default is deliberately a category it cannot convert, so a test
+  # The default is deliberately a category the combined-hours fallback cannot convert, so a test
   # that means to exercise the fallback opts in by naming one.
   def create_income_for(certification, gross_income:, category: "unearned", **attrs)
     lookback = certification.certification_requirements.continuous_lookback_period
@@ -56,7 +55,7 @@ RSpec.describe CommunityEngagementCheckService do
   end
 
   # .assess is the derivation .determine used to inline. It is public so a second step can reuse it
-  # rather than re-deriving the same four values and risking a different verdict.
+  # rather than re-deriving the same aggregates and verdicts and risking a different one.
   describe ".assess" do
     let(:over_hours) { HoursComplianceDeterminationService::TARGET_HOURS + 5 }
     let(:under_hours) { HoursComplianceDeterminationService::TARGET_HOURS / 2 }
@@ -75,7 +74,7 @@ RSpec.describe CommunityEngagementCheckService do
       expect(assessment.met?).to be(true)
     end
 
-    # met? is hours_ok || income_ok; without this the income side is never exercised.
+    # met? ORs the tracks; without this the income side is never exercised.
     it "reports met? when only the income track passes" do
       create_external_hourly_activity_for(certification, hours: under_hours)
       create_income_for(certification, gross_income: over_income)
@@ -104,8 +103,6 @@ RSpec.describe CommunityEngagementCheckService do
       expect(assessment.met?).to be(false)
     end
 
-    # The fallback: earnings the member reported as income stand for the hours behind them, so a
-    # member short on both tracks can still clear the hours threshold on the two combined.
     # $400 converts to ~55 hours, which carries 40 reported hours over the 80-hour target.
     it "reports met? on combined hours when neither track passes on its own" do
       create_external_hourly_activity_for(certification, hours: under_hours)
@@ -129,8 +126,6 @@ RSpec.describe CommunityEngagementCheckService do
       expect(assessment.met?).to be(true)
     end
 
-    # The reported-hours aggregate is what the determination and the member dashboard report, so
-    # the imputed hours are carried alongside it rather than folded into it.
     it "keeps the combined aggregate separate from the reported-hours aggregate" do
       create_external_hourly_activity_for(certification, hours: under_hours)
       create_income_for(certification, gross_income: 400, category: "employment")
@@ -152,9 +147,8 @@ RSpec.describe CommunityEngagementCheckService do
       expect(assessment.met?).to be(false)
     end
 
-    # A last resort: imputing hours nobody reported is work the assessment does only when it
-    # changes the answer. Both fields stay unset, so an unconsulted track is distinguishable from
-    # one that was weighed and fell short.
+    # Both fields stay unset, so an unconsulted track stays distinguishable from one that was
+    # weighed and fell short.
     it "does not compute combined hours when a track already passes" do
       create_external_hourly_activity_for(certification, hours: over_hours)
       create_income_for(certification, gross_income: 400, category: "employment")

--- a/reporting-app/spec/services/data_source_check_service_spec.rb
+++ b/reporting-app/spec/services/data_source_check_service_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe DataSourceCheckService do
       hours: hours)
   end
 
+  def create_external_income_activity_for(certification, gross_income:, category: "employment")
+    lookback = certification.certification_requirements.continuous_lookback_period
+    create(:external_activity, :with_income,
+      member_id: certification.member_id,
+      period_start: lookback.start.to_date,
+      period_end: lookback.start.to_date.end_of_month,
+      category: category,
+      gross_income: gross_income)
+  end
+
   def latest_determination
     latest_determination_for(certification.id)
   end
@@ -325,6 +335,19 @@ RSpec.describe DataSourceCheckService do
         described_class.determine(certification_case)
 
         expect(certification_case.reload).to be_open
+      end
+
+      # The negative records what was weighed, and the combined-hours fallback is part of that
+      # once the member has income the hours track can impute from.
+      it "carries the combined-hours track it considered into the negative payload" do
+        create_external_income_activity_for(certification, gross_income: 100)
+
+        described_class.determine(certification_case)
+
+        data = latest_determination.determination_data
+        expect(data["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
+        expect(data["combined_hours"]["compliant"]).to be false
+        expect(data["combined_hours"]["total_hours"]).to be > data["hours"]["total_hours"]
       end
     end
 

--- a/reporting-app/spec/services/external_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_activity_service_spec.rb
@@ -774,26 +774,33 @@ RSpec.describe ExternalActivityService do
         expect(latest_determination_for(certification.id).outcome).to eq("compliant")
       end
 
-
+      # Recorded in the combined shape, not as another hours determination.
       it "falls through to combined hours for a combined row whose hours fall short" do
         stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: true)
 
         described_class.create_entry(**params, hours: 100, gross_income: 600)
 
         expect(determinations.count).to eq(1)
-        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
-        expect(latest_determination_for(certification.id).reasons).to include("combined_hours_reported_compliant")
-        expect(latest_determination_for(certification.id).outcome).to eq("compliant")
+        determination = latest_determination_for(certification.id)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+        expect(determination.reasons).to eq([ "combined_hours_reported_compliant" ])
+        expect(determination.outcome).to eq("compliant")
+        expect(determination.determination_data["satisfied_by"]).to eq(Determination::SATISFIED_BY_COMBINED_HOURS)
+        expect(determination.determination_data["combined_hours"]["compliant"]).to be true
       end
 
-      it "records a not-compliant hours determination when neither track qualifies" do
+      it "records the combined not-compliant determination when no track qualifies" do
         stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: false)
 
         described_class.create_entry(**params, hours: 100, gross_income: 600)
 
         expect(determinations.count).to eq(1)
-        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
-        expect(latest_determination_for(certification.id).outcome).to eq("not_compliant")
+        determination = latest_determination_for(certification.id)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_EXTERNAL_CE_COMBINED)
+        expect(determination.outcome).to eq("not_compliant")
+        expect(determination.determination_data["satisfied_by"]).to eq(Determination::SATISFIED_BY_NEITHER)
+        # The income the member did report stays in the denial payload beside the hours.
+        expect(determination.determination_data["income"]).to be_present
       end
 
       it "skips recalculation when recalculate_compliance is false" do

--- a/reporting-app/spec/services/external_activity_service_spec.rb
+++ b/reporting-app/spec/services/external_activity_service_spec.rb
@@ -696,9 +696,20 @@ RSpec.describe ExternalActivityService do
       allow(NotificationService).to receive(:send_email_notification)
     end
 
-    def stub_thresholds(hours_ok:, income_ok:)
-      allow(HoursComplianceDeterminationService).to receive(:compliant_for_monthly_hours?).and_return(hours_ok)
+    def stub_thresholds(hours_ok:, income_ok:, combined_hours_ok:)
+      hours_by_month = hours_ok ? { foo: HoursComplianceDeterminationService::TARGET_HOURS } : {}
+      hours_agg = { total_hours: 0, hours_by_month: }
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification)
+                                                      .with(anything, application_form: nil, with_income_conversion: false)
+                                                      .and_return(hours_agg)
+
       allow(IncomeComplianceDeterminationService).to receive(:compliant_for_monthly_income?).and_return(income_ok)
+
+      combined_hours_by_month = combined_hours_ok ? { foo: HoursComplianceDeterminationService::TARGET_HOURS } : {}
+      combined_hours_agg = { total_hours: 0, hours_by_month: combined_hours_by_month }
+      allow(HoursComplianceDeterminationService).to receive(:aggregate_hours_for_certification)
+                                                      .with(anything, application_form: nil, with_income_conversion: true)
+                                                      .and_return(combined_hours_agg)
     end
 
     def determinations
@@ -713,7 +724,7 @@ RSpec.describe ExternalActivityService do
       let!(:kase) { create(:certification_case, certification: certification) }
 
       it "records an hours determination for an hours-only row" do
-        stub_thresholds(hours_ok: true, income_ok: false)
+        stub_thresholds(hours_ok: true, income_ok: false, combined_hours_ok: false)
 
         expect { described_class.create_entry(**params, hours: 100) }
           .to change(determinations, :count).by(1)
@@ -724,7 +735,7 @@ RSpec.describe ExternalActivityService do
       end
 
       it "records a not-compliant hours determination when hours fall short" do
-        stub_thresholds(hours_ok: false, income_ok: false)
+        stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: false)
 
         described_class.create_entry(**params, hours: 100)
 
@@ -734,7 +745,7 @@ RSpec.describe ExternalActivityService do
       end
 
       it "records an income determination for an income-only row" do
-        stub_thresholds(hours_ok: false, income_ok: true)
+        stub_thresholds(hours_ok: false, income_ok: true, combined_hours_ok: false)
 
         described_class.create_entry(**params, gross_income: 600)
 
@@ -745,7 +756,7 @@ RSpec.describe ExternalActivityService do
 
       # Hours take precedence, so income is not consulted at all.
       it "records only the hours determination for a combined row whose hours qualify" do
-        stub_thresholds(hours_ok: true, income_ok: true)
+        stub_thresholds(hours_ok: true, income_ok: true, combined_hours_ok: false)
 
         described_class.create_entry(**params, hours: 100, gross_income: 600)
 
@@ -754,7 +765,7 @@ RSpec.describe ExternalActivityService do
       end
 
       it "falls through to income for a combined row whose hours fall short" do
-        stub_thresholds(hours_ok: false, income_ok: true)
+        stub_thresholds(hours_ok: false, income_ok: true, combined_hours_ok: false)
 
         described_class.create_entry(**params, hours: 100, gross_income: 600)
 
@@ -763,25 +774,37 @@ RSpec.describe ExternalActivityService do
         expect(latest_determination_for(certification.id).outcome).to eq("compliant")
       end
 
-      it "records a not-compliant income determination when neither track qualifies" do
-        stub_thresholds(hours_ok: false, income_ok: false)
+
+      it "falls through to combined hours for a combined row whose hours fall short" do
+        stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: true)
 
         described_class.create_entry(**params, hours: 100, gross_income: 600)
 
         expect(determinations.count).to eq(1)
-        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_INCOME_BASED)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
+        expect(latest_determination_for(certification.id).reasons).to include("combined_hours_reported_compliant")
+        expect(latest_determination_for(certification.id).outcome).to eq("compliant")
+      end
+
+      it "records a not-compliant hours determination when neither track qualifies" do
+        stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: false)
+
+        described_class.create_entry(**params, hours: 100, gross_income: 600)
+
+        expect(determinations.count).to eq(1)
+        expect(calculation_type).to eq(Determination::CALCULATION_TYPE_HOURS_BASED)
         expect(latest_determination_for(certification.id).outcome).to eq("not_compliant")
       end
 
       it "skips recalculation when recalculate_compliance is false" do
-        stub_thresholds(hours_ok: true, income_ok: true)
+        stub_thresholds(hours_ok: true, income_ok: true, combined_hours_ok: false)
 
         expect { described_class.create_entry(**params, hours: 100, recalculate_compliance: false) }
           .not_to change(determinations, :count)
       end
 
       it "recalculates once for the whole submission, not once per entry" do
-        stub_thresholds(hours_ok: false, income_ok: false)
+        stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: false)
         multi_month = params.merge(period_start: period_start, period_end: (period_start + 2.months).end_of_month)
 
         expect { described_class.create_entries(**multi_month, hours: 300) }
@@ -789,7 +812,7 @@ RSpec.describe ExternalActivityService do
       end
 
       it "recalculates only for a submission that created entries" do
-        stub_thresholds(hours_ok: false, income_ok: false)
+        stub_thresholds(hours_ok: false, income_ok: false, combined_hours_ok: false)
         described_class.create_entries(**params, hours: 100, name: "Acme Corp")
 
         expect { described_class.create_entries(**params, hours: 100, name: "Acme Corp") }
@@ -799,7 +822,7 @@ RSpec.describe ExternalActivityService do
 
     context "when the member has no open certification case" do
       it "creates the row without recording a determination" do
-        stub_thresholds(hours_ok: true, income_ok: true)
+        stub_thresholds(hours_ok: true, income_ok: true, combined_hours_ok: false)
 
         expect { described_class.create_entry(**params, hours: 100) }
           .not_to change(Determination, :count)
@@ -810,7 +833,7 @@ RSpec.describe ExternalActivityService do
       before { create(:certification_case, certification: certification) }
 
       it "logs a warning rather than failing the save" do
-        stub_thresholds(hours_ok: true, income_ok: true)
+        stub_thresholds(hours_ok: true, income_ok: true, combined_hours_ok: false)
         allow(Certification).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
         allow(Rails.logger).to receive(:warn)
 

--- a/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
@@ -113,6 +113,43 @@ RSpec.describe HoursComplianceDeterminationService do
         expect(determination.reasons).to include("hours_reported_insufficient")
       end
     end
+
+    context "with income conversion" do
+      let(:income_category) { "employment" }
+
+      before do
+        create_external_hourly_activity_for(certification, category: "education", hours: 75)
+        create_external_hourly_activity_for(certification, category: income_category, hours: nil, gross_income: 72.5)
+      end
+
+      it "is not compliant when false" do
+        described_class.calculate(certification.id, with_income_conversion: false)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.reasons).to include("hours_reported_insufficient")
+        expect(determination.outcome).to eq("not_compliant")
+      end
+
+      it "is compliant when true" do
+        described_class.calculate(certification.id, with_income_conversion: true)
+
+        determination = Determination.where(subject_id: certification.id).last
+        expect(determination.reasons).to include("combined_hours_reported_compliant")
+        expect(determination.outcome).to eq("compliant")
+      end
+
+      context "when income category not employment" do
+        let(:income_category) { "unearned" }
+
+        it "is not compliant" do
+          described_class.calculate(certification.id, with_income_conversion: true)
+
+          determination = Determination.where(subject_id: certification.id).last
+          expect(determination.reasons).to include("hours_reported_insufficient")
+          expect(determination.outcome).to eq("not_compliant")
+        end
+      end
+    end
   end
 
   describe "hours aggregation" do
@@ -188,6 +225,26 @@ RSpec.describe HoursComplianceDeterminationService do
         # 50 hours < 80 target = not compliant
         expect(determination.outcome).to eq("not_compliant")
         expect(determination.determination_data["total_hours"]).to eq(50.0)
+      end
+    end
+
+    context "with income conversion" do
+      let (:gross_income) { 72.5 }
+
+      before do
+        create_external_hourly_activity_for(certification, category: "education", hours: 75)
+        create_external_hourly_activity_for(certification, category: "employment", hours: nil, gross_income:)
+      end
+
+
+      it "does not include conversion when false" do
+        data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: false)
+        expect(data[:total_hours]).to eq 75
+      end
+
+      it "includes converted income when true" do
+        data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: true)
+        expect(data[:total_hours]).to be_within(0.001).of(85)
       end
     end
   end

--- a/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
@@ -114,40 +114,20 @@ RSpec.describe HoursComplianceDeterminationService do
       end
     end
 
-    context "with income conversion" do
-      let(:income_category) { "employment" }
-
+    # The combined-hours last resort belongs to CommunityEngagementCheckService, not here.
+    context "when the member also reported income the hours track could impute from" do
       before do
         create_external_hourly_activity_for(certification, category: "education", hours: 75)
-        create_external_hourly_activity_for(certification, category: income_category, hours: nil, gross_income: 72.5)
+        create_external_hourly_activity_for(certification, category: "employment", hours: nil, gross_income: 72.5)
       end
 
-      it "is not compliant when false" do
-        described_class.calculate(certification.id, with_income_conversion: false)
+      it "judges reported hours alone" do
+        described_class.calculate(certification.id)
 
         determination = Determination.where(subject_id: certification.id).last
         expect(determination.reasons).to include("hours_reported_insufficient")
         expect(determination.outcome).to eq("not_compliant")
-      end
-
-      it "is compliant when true" do
-        described_class.calculate(certification.id, with_income_conversion: true)
-
-        determination = Determination.where(subject_id: certification.id).last
-        expect(determination.reasons).to include("combined_hours_reported_compliant")
-        expect(determination.outcome).to eq("compliant")
-      end
-
-      context "when income category not employment" do
-        let(:income_category) { "unearned" }
-
-        it "is not compliant" do
-          described_class.calculate(certification.id, with_income_conversion: true)
-
-          determination = Determination.where(subject_id: certification.id).last
-          expect(determination.reasons).to include("hours_reported_insufficient")
-          expect(determination.outcome).to eq("not_compliant")
-        end
+        expect(determination.determination_data["total_hours"]).to eq(75.0)
       end
     end
   end

--- a/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
+++ b/reporting-app/spec/services/hours_compliance_determination_service_spec.rb
@@ -228,23 +228,43 @@ RSpec.describe HoursComplianceDeterminationService do
       end
     end
 
+    # $72.50 converts to 10 hours at the wage implied by the two thresholds.
     context "with income conversion" do
-      let (:gross_income) { 72.5 }
+      let(:gross_income) { 72.5 }
 
       before do
         create_external_hourly_activity_for(certification, category: "education", hours: 75)
         create_external_hourly_activity_for(certification, category: "employment", hours: nil, gross_income:)
       end
 
-
       it "does not include conversion when false" do
         data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: false)
         expect(data[:total_hours]).to eq 75
       end
 
-      it "includes converted income when true" do
+      it "includes converted employment income when true" do
         data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: true)
+
         expect(data[:total_hours]).to be_within(0.001).of(85)
+        expect(data[:hours_by_category]["employment"]).to be_within(0.001).of(10)
+      end
+
+      it "includes converted household income when true" do
+        create_external_hourly_activity_for(certification, category: "household", hours: nil, gross_income:)
+
+        data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: true)
+
+        expect(data[:total_hours]).to be_within(0.001).of(95)
+        expect(data[:hours_by_category]["household"]).to be_within(0.001).of(10)
+      end
+
+      it "leaves income the hours track cannot impute work from out of the aggregate" do
+        create_external_hourly_activity_for(certification, category: "unearned", hours: nil, gross_income: 1_000)
+
+        data = described_class.aggregate_hours_for_certification(certification, with_income_conversion: true)
+
+        expect(data[:total_hours]).to be_within(0.001).of(85)
+        expect(data[:hours_by_category]).not_to have_key("unearned")
       end
     end
   end


### PR DESCRIPTION
## Ticket

Finishes PBI-70969

## Changes

A third community-engagement track: when neither reported hours nor income clears its threshold on
its own, reported hours plus hours imputed from earned income are checked against the hours target.

- `ExternalActivity` — `#converted_hours` values a row in hours, imputing them from income if hours not present.
- `CommunityEngagementCheckService::Assessment` — gains `combined_hours_data` / `combined_hours_ok`
  as a distinct track.
- `Determinations::ExternalCECombinedDeterminationData` — carries the combined aggregate beside the
  reported-hours one, omitting the nested `combined_hours` hash when the fallback was not consulted.
- `Determination` — new `combined_hours_reported_compliant` reason code and
  `SATISFIED_BY_COMBINED_HOURS`.
- `CertificationCase#record_external_ce_combined_assessment` and `DataSourceCheckService` pass the
  new track through.
- `ActivityAggregator#summarize_hours` and
  `HoursComplianceDeterminationService.aggregate_hours_for_certification` take
  `with_income_conversion:`, which switches the aggregate to `#converted_hours` and folds in
  convertible income-only rows.
- Fixes a pre-existing locale key mismatch: the `hours_insufficient` translation is renamed
  `hours_reported_insufficient`, which is the reason code the code actually emits.
- `HoursComplianceDeterminationService#calculate` comment updated to match reality.

## Context for reviewers

**The combined track is deliberately not folded into the hours track.** Imputed hours have to stay
distinguishable from reported ones in the determination payload, so it is a third set of keys rather
than a larger `hours` number.

Conversion based on existing configuration values for hours and income targets, rather than adding a 'minimum wage' configuration value.

**`combined_hours_data` / `combined_hours_ok` are nil, not false, when the fallback was not
consulted.** `false` would conflate "weighed and fell short" with "never ran".

The new reason code widens the verification data-source vocabulary — API `outcome.reason` can now
emit `combined_hours_reported_compliant`. It is a free-form string in the OpenAPI spec, so no schema
change.

**Known gaps, out of scope for this PR:**

- Only external activities are converted. Income a member reports on their own application never
  enters the combined aggregate — `member_hours_from_activities` summarizes hourly member
  activities alone.
- The combined figures are not surfaced in the member UI.
- The combined figures are not surfaced in the staff UI either, though the reason code on a
  successful determination does show there.
- Removing or making `HoursComplianceDeterminationService#calculate` work properly.

## Testing

`make lint` — 576 files inspected, no offenses. Full suite:

```
3613 examples, 0 failures

Line coverage: 5767 / 5953 (96.87%)
Branch coverage: 1437 / 1704 (84.33%)
```

New coverage: `#converted_hours` and `with_convertible_income` (including a spec asserting the scope
and the method agree on categories), the all-or-nothing validation on the determination data, the
early return in `#assess`, the combined pass and combined denial paths through
`CommunityEngagementCheckService`, `DataSourceCheckService` and `ExternalActivityService`, and
`with_income_conversion:` on the hours aggregate.

Manual testing results. "Combined in determination" is whether the determination_data includes combined hourly data.

| Member hours | Member income | Member combined | Household income | Combined in determination | Outcome |
|---|---|---|---|---|---|
| sufficient | insufficient | n/a | absent | no | compliant |
| insufficient | sufficient | n/a | absent | no | compliant |
| insufficient | insufficient | sufficient | absent | yes | compliant |
| insufficient | insufficient | sufficient, but unearned category | absent | yes | not compliant |
| insufficient | insufficient | insufficient | absent | yes | not compliant |
| insufficient | insufficient | insufficient | sufficient | no | compliant |
| insufficient | insufficient | insufficient | insufficient, combined insufficient | yes | not compliant |
| insufficient | insufficient | insufficient | insufficient, combined sufficient | yes | compliant |

<!-- reporting-app - begin PR environment info -->
## Preview environment for reporting-app
♻️ Environment destroyed ♻️
<!-- reporting-app - end PR environment info -->